### PR TITLE
feat(DB-001): npm scripts + Prisma 환경 가이드 + 명세 현실 동기화

### DIFF
--- a/onday-app/docs/prisma-env-setup.md
+++ b/onday-app/docs/prisma-env-setup.md
@@ -1,0 +1,203 @@
+# Prisma 환경 설정 가이드 (Prisma 7 + adapter)
+
+> **이 문서의 위치**: `onday-app/docs/prisma-env-setup.md`
+> **역할**: 현 onday-app 의 Prisma 7 환경 설정 + DB 전환 정책의 **기준 문서**
+> **자매 문서**: 실제 SQLite → Postgres 이주 절차·RLS SQL 은 [`migration-to-postgres.md`](./migration-to-postgres.md) 참조
+
+---
+
+## 0. ★ 현실 불일치 경고 (먼저 읽기)
+
+`migration-to-postgres.md` 는 4/29 시점 가정(`provider = env("DATABASE_PROVIDER")`)으로 작성됨.
+현 `prisma/schema.prisma` 는 다음 패턴 (Prisma 7 + adapter) 이다:
+
+- **schema.prisma**: `provider = "sqlite"` **하드코딩**
+- **prisma.config.ts**: runtime `url = process.env["DATABASE_URL"]` override
+- **lib/db.ts**: PrismaClient 가 아님 — **`src/lib/db.ts` = Vercel demo 용 in-memory store**
+
+env-based provider (`provider = env("DATABASE_PROVIDER")`) 전환은 **INFRA-002 시점**.
+현재 환경 설정의 기준 문서는 본 문서(`prisma-env-setup.md`)다.
+
+---
+
+## 1. ★ in-memory store 예고 (DB-001 핵심 메모)
+
+현 `src/lib/db.ts` 는 **PrismaClient 가 아니라 in-memory Map store** 다.
+이유: Vercel serverless filesystem 이 read-only + ephemeral 이므로 SQLite 가 prod 에서 동작 불가.
+
+```typescript
+// src/lib/db.ts (현 상태 발췌)
+// In-memory store for the Vercel demo deploy.
+// Pin stores to globalThis so Next.js dev mode HMR doesn't wipe them between
+// requests (and so warm Vercel lambda instances reuse the same Maps).
+export const prisma = {
+  diagnosis: { create, findUnique },
+  shareLink: { create, findUnique, update },
+  savedSearch: { upsert, findUnique },
+};
+```
+
+모든 API 라우트 (`src/app/api/diagnosis/*`, `src/app/api/share/*`, `src/app/api/save/*`) 가
+`import { prisma } from '@/lib/db'` 로 이 fake API 를 사용한다.
+
+**실 PrismaClient 싱글톤으로의 swap 은 INFRA-002 (Supabase Postgres 프로비저닝) 시점에 수행한다.**
+DB-001 단계에서는 in-memory 를 **그대로 보존**하고, Prisma 인프라(schema/migrations/config) 만 준비된 상태로 둔다.
+
+---
+
+## 2. 현재 Prisma 7 환경 구조
+
+### 2-1. 파일 구성
+
+| 파일 | 역할 |
+| --- | --- |
+| `prisma/schema.prisma` | datasource (`provider = "sqlite"`) + generator (`provider = "prisma-client"`) + 4모델 (User/Diagnosis/ShareLink/SavedSearch) |
+| `prisma.config.ts` | Prisma 7 신 파일. schema/migrations path + `datasource.url = process.env["DATABASE_URL"]` runtime override |
+| `prisma/migrations/20260429125124_init/` | 4/29 작성 init migration (4모델 CREATE TABLE) |
+| `prisma/seed.ts` | `PrismaBetterSqlite3` adapter 사용. DB-001 단계에서 seed runner 미설정 (tsx 부재) |
+| `src/generated/prisma/` | `npx prisma generate` 산출물. `.gitignore` 됨 |
+| `src/lib/db.ts` | **in-memory store** (위 §1 참조) |
+
+### 2-2. Prisma 7 신패턴 — generator
+
+```prisma
+generator client {
+  provider = "prisma-client"      // ← v5 의 "prisma-client-js" 가 아님
+  output   = "../src/generated/prisma"
+}
+```
+
+- v5 의 `provider = "prisma-client-js"` → v7 에서 `"prisma-client"` 로 변경
+- `output` 명시 필수. 결과는 `src/generated/prisma/` 에 생성됨
+- import 경로: `import { PrismaClient } from "@/generated/prisma/client"` (path alias `@/* → ./src/*` 정합)
+- ⚠️ v7 generated 디렉토리에는 `index.ts` 가 없음. `/client` 서브 경로 필수
+
+### 2-3. Prisma 7 신패턴 — prisma.config.ts
+
+```typescript
+// prisma.config.ts
+import "dotenv/config";
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: { path: "prisma/migrations" },
+  datasource: { url: process.env["DATABASE_URL"] },
+});
+```
+
+- v5 까지는 schema.prisma 의 `url = env("DATABASE_URL")` 직접 인용
+- v7 부터는 `prisma.config.ts` 에서 datasource override 가능 (schema 의 url 줄 생략 가능)
+
+### 2-4. Prisma 7 신패턴 — better-sqlite3 driver adapter
+
+```typescript
+// prisma/seed.ts (현 상태)
+import { PrismaClient } from "../src/generated/prisma/client";
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+
+const adapter = new PrismaBetterSqlite3({ url: "file:prisma/dev.db" });
+const prisma = new PrismaClient({ adapter });
+```
+
+- v7 의 driver adapter 패턴. SQLite 의 경우 `@prisma/adapter-better-sqlite3` 필요
+- 단 INFRA-002 시점에 Postgres 로 전환하면 adapter 불필요 (네이티브 PostgreSQL driver 사용)
+
+---
+
+## 3. 로컬 개발 환경 (SQLite)
+
+### 3-1. .env 설정
+
+```env
+DATABASE_PROVIDER=sqlite
+DATABASE_URL=file:./dev.db
+```
+
+### 3-2. CLI 명령 (DB-001 npm scripts)
+
+| 명령 | 용도 |
+| --- | --- |
+| `npm run db:validate` | schema 문법 검증 (`npx prisma validate`) |
+| `npm run db:generate` | Prisma Client 생성 (`src/generated/prisma/` 갱신) |
+| `npm run db:migrate:dev` | 새 migration 생성·적용 (dev) |
+| `npm run db:push` | schema → DB 직접 적용 (migration 미생성) |
+| `npm run db:studio` | Prisma Studio (DB GUI) |
+| `npm run db:seed` | ⚠️ tsx 부재로 `prisma.seed` 미설정 — 후속 ISSUE 에서 결정 |
+| `npm run db:migrate:deploy` | prod migration 적용 (CI/Vercel) |
+
+### 3-3. 로컬 동작 흐름
+
+1. `npm install` → `postinstall` hook 으로 자동 `npx prisma generate`
+2. `npm run db:validate` → schema 문법 OK
+3. (스키마 변경 시) `npm run db:migrate:dev --name <description>`
+4. **현 시점에는 API 라우트가 in-memory store 사용 → 로컬 SQLite 파일(dev.db) 은 실제 read/write 되지 않음**
+
+---
+
+## 4. 프로덕션 전환 (Supabase Postgres) — INFRA-002 시점
+
+> 상세 절차·Supabase 프로젝트 생성·RLS SQL 은 [`migration-to-postgres.md`](./migration-to-postgres.md) 참조.
+> 단 그 문서의 §3-3 schema 조정 부분(`provider = env(...)`) 은 현실과 불일치 — INFRA-002 에서 schema 갱신 시 정합화.
+
+### 4-1. INFRA-002 시점에 할 일 (요약)
+
+1. Supabase 프로젝트 생성 + connection string 획득 (`migration-to-postgres.md §3-1`)
+2. `prisma/schema.prisma` 의 datasource provider 갱신 — `"sqlite"` → `env("DATABASE_PROVIDER")`
+3. `src/lib/db.ts` 의 in-memory store 폐기 → 실 PrismaClient 싱글톤으로 swap
+4. 환경변수 `DATABASE_PROVIDER=postgresql`, `DATABASE_URL=postgresql://...`
+5. `npm run db:migrate:deploy` (또는 `migration-to-postgres.md §3-4` 의 `reset` + `migrate dev`)
+6. RLS 정책 수동 적용 (`migration-to-postgres.md §3-5`)
+7. Vercel env 등록 (`migration-to-postgres.md §3-6`)
+
+### 4-2. 실 PrismaClient 싱글톤 (INFRA-002 시점 작성 예정)
+
+```typescript
+// src/lib/db.ts (INFRA-002 시점 swap 후 예시)
+import { PrismaClient } from "@/generated/prisma/client";
+
+declare global {
+  var prismaGlobal: PrismaClient | undefined;
+}
+
+export const prisma = global.prismaGlobal ?? new PrismaClient({
+  log: process.env.NODE_ENV === "development" ? ["query", "error"] : ["error"],
+});
+
+if (process.env.NODE_ENV !== "production") {
+  global.prismaGlobal = prisma;
+}
+```
+
+---
+
+## 5. SQLite ↔ Postgres 차이 주의점
+
+상세 비교 + 워크어라운드는 [`migration-to-postgres.md §2`](./migration-to-postgres.md) 참조. 핵심만:
+
+| 항목 | SQLite (현재 schema) | Postgres (INFRA-002 후) |
+| --- | --- | --- |
+| `@db.JsonB` | `TEXT` 로 매핑 (현 schema 는 `String` 직접 사용, JSON.parse 처리) | 네이티브 JSONB |
+| `@db.Uuid` | `TEXT` 로 매핑 (현 schema 는 `@default(uuid())` 사용) | 네이티브 UUID |
+| RLS | 미지원 — Mock 단일 사용자 전제로 회피 | `prisma/migrations/manual/` 에 수동 SQL |
+| ENUM | 미지원 → `String` + `@map` 사용 | 네이티브 ENUM 가능 |
+| 동시 쓰기 | 단일 사용자 한정 | pgbouncer + connection pool (Supabase 무료 티어 제한 주의) |
+| Vercel serverless | ❌ filesystem read-only — 사용 불가 | ✅ Supabase pooler 경유 가능 |
+
+---
+
+## 6. 본 문서 vs migration-to-postgres.md 역할 분담
+
+| 문서 | 역할 | 갱신 주체 |
+| --- | --- | --- |
+| **`prisma-env-setup.md`** (본 문서) | 현 Prisma 7 환경 구조 + in-memory note + 신패턴 가이드 | DB-001 (현재) → INFRA-002 시점 §1 in-memory 메모 갱신 |
+| **`migration-to-postgres.md`** | 실제 Postgres 이주 절차 + RLS SQL | 4/29 작성 보존, INFRA-002 시점에 schema 가정 갱신 |
+
+---
+
+## 7. References
+
+- 명세: [`tasks/DB-001.md`](../../tasks/DB-001.md) — 본 ISSUE
+- 명세: [`tasks/INFRA-002.md`](../../tasks/INFRA-002.md) — 실 PrismaClient swap 시점
+- SRS: [`docs/05_SRS_v1.6.md`](../../docs/05_SRS_v1.6.md) §6.2.0 ERD, CON-11
+- Prisma 7 docs: <https://www.prisma.io/docs>

--- a/onday-app/package.json
+++ b/onday-app/package.json
@@ -6,7 +6,15 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "db:migrate:dev": "npx prisma migrate dev",
+    "db:migrate:deploy": "npx prisma migrate deploy",
+    "db:generate": "npx prisma generate",
+    "db:studio": "npx prisma studio",
+    "db:validate": "npx prisma validate",
+    "db:seed": "npx prisma db seed",
+    "db:push": "npx prisma db push",
+    "postinstall": "npx prisma generate"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/tasks/DB-001.md
+++ b/tasks/DB-001.md
@@ -1,19 +1,19 @@
 ---
 name: Feature Task
-title: "[Feature] DB-001: Prisma ORM 초기화 + SQLite/Supabase Postgres 환경변수 기반 전환 구조 + 싱글톤 클라이언트"
+title: "[Feature] DB-001: Prisma 7 ORM 초기화 + DATABASE_URL 전환 구조 (기존 onday-app/ 베이스, 실 PrismaClient 싱글톤 swap 은 INFRA-002 위임)"
 labels: ['feature', 'priority:H', 'epic:Data Foundation', 'wave:1']
 assignees: []
 ---
 
 ## 1. 🎯 Summary
 
-- **기능명:** [DB-001] Prisma ORM 초기화 + SQLite/Supabase Postgres 환경변수 기반 전환 구조 + 싱글톤 클라이언트
+- **기능명:** [DB-001] Prisma 7 ORM 초기화 (better-sqlite3 driver adapter) + DATABASE_URL 환경변수 전환 구조 + 인메모리 어댑터 (실 PrismaClient 싱글톤 swap 은 INFRA-002 위임)
 - **목적 (Why):**
   - **비즈니스:** 모든 DB 스키마(DB-002~DB-007)와 데이터 접근 로직(CMD-DIAG, CMD-SHARE, CMD-SAVE 등)의 기반이 되는 ORM 초기화 구조를 확립한다. 로컬 SQLite로 빠른 개발·테스트를 지원하고, 프로덕션 Supabase PostgreSQL로 무중단 전환이 가능한 환경 분기 구조를 제공한다.
   - **사용자 가치:** 개발 환경과 프로덕션 환경 간 DB 전환이 환경변수 변경만으로 가능하여, 배포 파이프라인의 안정성과 개발 생산성을 동시에 확보한다.
 - **범위 (What):**
-  - ✅ 만드는 것: `prisma/schema.prisma` datasource 설정, `lib/db.ts` PrismaClient 싱글톤, `.env` / `.env.example` 환경변수 템플릿, 초기 마이그레이션, Prisma CLI 명령어 npm scripts
-  - ❌ 만들지 않는 것: 개별 모델 정의(DB-002~007 범위), AES-256 암호화 로직, NextAuth.js Adapter, 결제 관련 스키마
+  - ✅ 만드는 것: `package.json` Prisma npm scripts 8종 (`db:*` + `postinstall`), `onday-app/docs/prisma-env-setup.md` (Prisma 7 환경 가이드 + in-memory 예고), 명세 현실 동기화 (`tasks/DB-001.md`)
+  - ❌ 만들지 않는 것: **개별 모델 정의(DB-002~006: User/Diagnosis/ShareLink/SavedSearch — 4모델은 4/29 onday-app/prisma/schema.prisma 에 이미 정의됨, 본 ISSUE 미수정. 후속 DB-002/003/004/006 ISSUE 도 현실 추인 패턴 예정)**, 실 PrismaClient 싱글톤 swap (INFRA-002 위임), in-memory store 폐기 (INFRA-002 위임), spec 작성 (TEST-* 위임 — vitest config 부재 + in-memory fake 검증 무의미), `schema.prisma` / `prisma.config.ts` / `prisma/seed.ts` / `prisma/migrations/` 수정 (사용자 가드 = 4/29 산출물 불변), AES-256 암호화 로직, NextAuth.js Adapter, 결제 관련 스키마
 - **복잡도:** L
 - **Wave:** 1 (Data Foundation 트랙)
 
@@ -33,101 +33,116 @@ assignees: []
 
 | 선행 Task ID | 제공 산출물 | 본 태스크에서의 사용처 |
 |---|---|---|
-| None (최하위 기반) | — | DB-001은 의존하는 선행 태스크가 없다 |
+| INFRA-001 (PR #74 머지 완료) | onday-app/ 베이스 + `prisma@^7.8.0`/`@prisma/client@^7.8.0`/`@prisma/adapter-better-sqlite3@^7.8.0` 설치 + `vercel.json` (buildCommand 의 `npx prisma generate && next build`) + `tasks/INFRA-001.md` 갱신본 (Prisma 7 + src/* 정합) | DB-001 의 모든 변경 (package.json scripts 8종 추가, `onday-app/docs/prisma-env-setup.md` 신규) 이 INFRA-001 산출물 위에 보강 |
+| ⚠️ Issue #5 본문은 "선행: INFRA-001" 명시, 명세 v1.0 의 "None" 표기는 historical (현실 추인으로 갱신) | — | — |
 
-### 배치 1~4 ISSUE 정합성 검증 대상
+### 배치 1~4 ISSUE 정합성 검증 대상 (현실 추인 갱신)
 
-| 기존 ISSUE | 검증 항목 | 검증 결과 |
+| 기존 ISSUE | 검증 항목 | 현실 (onday-app 4/29 + INFRA-001 갱신본) |
 |---|---|---|
-| DB-003.md | `prisma/schema.prisma`에서 `@db.JsonB`, `@db.Date` 어노테이션 사용 — Postgres 전용 | ⚠️ SQLite 환경에서 `@db.JsonB`는 `TEXT`로 매핑됨. Prisma가 자동 처리하므로 코드 변경 불필요하나, 로컬 테스트 시 JSONB 쿼리 기능(인덱싱 등) 미지원 인지 필요 |
-| DB-006.md | `@db.Uuid` 어노테이션 사용 — Postgres 전용 | ⚠️ SQLite에서 `@db.Uuid`는 `TEXT`로 매핑됨. 기능 동작에 영향 없음 |
-| DB-007.md | `prisma/migrations/manual/001_user_auth_fk.sql`에서 `auth.users` FK 참조 + RLS 정책 | ⚠️ SQLite 환경에서 `auth.users` 테이블 없음 + RLS 미지원. 로컬에서는 FK/RLS 건너뛰고 프로덕션에서만 수동 SQL 적용 전략 필요 |
-| DB-003.md | `Diagnosis.id @id @default(cuid())` — cuid 자동 생성 | ✅ SQLite/Postgres 모두 호환 |
-| DB-006.md | `userId @id @map("user_id") @db.Uuid` — PK UUID | ⚠️ SQLite에서 UUID 타입 없음, TEXT로 매핑. 기능 동작에 영향 없음 |
-| 배치 1~4 전체 | `import { prisma } from '@/lib/db'` 경로 사용 | ✅ 본 ISSUE에서 `lib/db.ts` 정의 — 일치 |
+| DB-002~006 모델 정의 | 명세상 후행 ISSUE 산출물 | ⚠️ **이미 4/29 `prisma/schema.prisma` 에 4모델 (User/Diagnosis/ShareLink/SavedSearch) 정의됨**. 본 ISSUE 미수정 (사용자 가드). 후속 DB-002/003/004/006 ISSUE 도 "현실 추인 + 명세 갱신" 패턴 예정 |
+| DB-003.md | `@db.JsonB`, `@db.Date` 어노테이션 사용 — Postgres 전용 | ⚠️ 현 schema 는 `filters String @default("{}")` 등 String JSON 매핑 (SQLite). INFRA-002 시점에 Postgres 어노테이션 추가 가능 |
+| DB-006.md | `@db.Uuid` 어노테이션 사용 — Postgres 전용 | ⚠️ 현 schema 는 `@default(uuid())` (TEXT 매핑). INFRA-002 시점에 `@db.Uuid` 추가 가능 |
+| DB-007.md | `prisma/migrations/manual/001_user_auth_fk.sql` — `auth.users` FK + RLS | ⚠️ 현 schema 의 User 모델은 단순 (authProvider=kakao\|naver). Supabase Auth 연동은 DB-007 + INFRA-002 시점 |
+| 배치 1~4 전체 | `import { prisma } from '@/lib/db'` 경로 사용 | ⚠️ **현 `src/lib/db.ts` 는 PrismaClient 가 아니라 in-memory Map store** (Vercel demo 용). import 경로는 일치 ✅ 하나 실 Prisma API (transactions, $queryRaw, relations 등) 미지원. 실 PrismaClient swap = **INFRA-002 위임** |
+| tsconfig path alias | `@/* → ./src/*` (INFRA-001 갱신본 정합) | ✅ `@/lib/db` → `src/lib/db.ts` 매핑 OK |
 
 ---
 
 ## 3. 🛠️ Task Breakdown (실행 체크리스트)
 
-- [ ] **3.1** Prisma CLI 설치 확인 및 초기화
-  - 명령어: `npm install prisma@^5.20.0 --save-dev && npm install @prisma/client@^5.20.0`
-  - `npx prisma init --datasource-provider sqlite` 실행
-  - 생성 파일: `prisma/schema.prisma`, `.env`
+- [x] **3.1** Prisma CLI 설치 확인 — 기존 onday-app/ 베이스 (4/29 부트스트랩 + INFRA-001 정합)
+  > 명세 v1.0 의 `prisma@^5.20.0` 가정은 historical. 현실은 Prisma 7 + better-sqlite3 driver adapter.
+  > 본 ISSUE 에서 추가 설치 없음. 검증: `npx prisma validate` exit 0 (Phase A.7 확인).
+  - 현 설치 상태 (INFRA-001 갱신본 정합):
+    - `prisma@^7.8.0` (devDependencies)
+    - `@prisma/client@^7.8.0` (devDependencies)
+    - `@prisma/adapter-better-sqlite3@^7.8.0` (dependencies)
+    - `better-sqlite3@^12.9.0` (dependencies)
 
-- [ ] **3.2** `prisma/schema.prisma`에 datasource 설정 (환경변수 기반 DB 전환)
+- [x] **3.2** `prisma/schema.prisma` datasource — 기존 onday-app 패턴 (Prisma 7 + adapter), 본 ISSUE 미수정
+  > 사용자 가드 (4/29 산출물 불변). 명세 v1.0 의 동적 `provider = env("DATABASE_PROVIDER")` 패턴은 **INFRA-002 시점**에 적용.
   ```prisma
-  // prisma/schema.prisma
+  // 현 prisma/schema.prisma (4/29 작성, 본 ISSUE 미수정)
   generator client {
-    provider = "prisma-client-js"
+    provider = "prisma-client"             // ← Prisma 7 신패턴 (v5의 "prisma-client-js" 아님)
+    output   = "../src/generated/prisma"
   }
 
   datasource db {
-    provider = env("DATABASE_PROVIDER")   // "sqlite" | "postgresql"
-    url      = env("DATABASE_URL")
+    provider = "sqlite"                    // ← 하드코딩 (env 화는 INFRA-002 위임)
   }
   ```
-  - **로컬 개발:** `DATABASE_PROVIDER=sqlite`, `DATABASE_URL=file:./dev.db`
-  - **프로덕션:** `DATABASE_PROVIDER=postgresql`, `DATABASE_URL=postgresql://postgres:[password]@db.[ref].supabase.co:5432/postgres`
-
-- [ ] **3.3** `.env` 파일에 로컬 개발용 기본값 설정
-  ```env
-  # Database — 로컬 개발 (SQLite)
-  DATABASE_PROVIDER=sqlite
-  DATABASE_URL=file:./dev.db
-  ```
-
-- [ ] **3.4** `.env.example` 파일 생성 — 환경변수 템플릿
-  ```env
-  # === Database ===
-  # 로컬 개발: sqlite / file:./dev.db
-  # 프로덕션: postgresql / postgresql://postgres:[password]@db.[ref].supabase.co:5432/postgres
-  DATABASE_PROVIDER=sqlite
-  DATABASE_URL=file:./dev.db
-
-  # === Supabase Auth ===
-  NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-  NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-  SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-
-  # === External API ===
-  KAKAO_REST_API_KEY=your-kakao-api-key
-
-  # === Monitoring ===
-  SENTRY_DSN=your-sentry-dsn
-  ```
-
-- [ ] **3.5** `lib/db.ts`에 PrismaClient 싱글톤 패턴 구현
   ```typescript
-  // lib/db.ts
-  import { PrismaClient } from '@prisma/client';
-
-  declare global {
-    // eslint-disable-next-line no-var
-    var prismaGlobal: PrismaClient | undefined;
-  }
-
-  export const prisma = global.prismaGlobal ?? new PrismaClient({
-    log: process.env.NODE_ENV === 'development' ? ['query', 'error'] : ['error'],
+  // prisma.config.ts (Prisma 7 신 파일, 4/29 작성, 본 ISSUE 미수정)
+  // runtime url override — datasource url 줄 schema 에서 생략
+  export default defineConfig({
+    schema: "prisma/schema.prisma",
+    migrations: { path: "prisma/migrations" },
+    datasource: { url: process.env["DATABASE_URL"] },
   });
+  ```
+  - **로컬 개발:** `DATABASE_URL=file:./dev.db` (.env 정합)
+  - **프로덕션 (INFRA-002 시점):** `DATABASE_URL=postgresql://postgres:[password]@db.[ref].supabase.co:5432/postgres` + schema.prisma 의 provider 를 `env("DATABASE_PROVIDER")` 로 갱신
+  - **AC-4 (env-based provider 전환) = INFRA-002 위임:** §4/§9 참조
+  - 상세 가이드: [`onday-app/docs/prisma-env-setup.md`](../onday-app/docs/prisma-env-setup.md) §2-2 / §2-3
 
-  if (process.env.NODE_ENV !== 'production') {
-    global.prismaGlobal = prisma;
-  }
+- [x] **3.3** `.env` 로컬 개발용 기본값 — 기존 onday-app/.env (4/29) 이미 존재, 본 ISSUE 미수정
+  ```env
+  # Database — 현 onday-app/.env (4/29, 본 ISSUE 미수정)
+  DATABASE_PROVIDER=sqlite
+  DATABASE_URL=file:./dev.db
+  ```
+  > .env 는 `.gitignore` 대상이라 git 추적 안 됨. 본 ISSUE 에서 .env 파일 수정 없음.
+
+- [x] **3.4** `.env.example` 환경변수 템플릿 — INFRA-001 갱신본 정합 (8종), 본 ISSUE 미수정
+  > INFRA-001 에서 이미 SENTRY_AUTH_TOKEN 등 보강 완료. 현 `.env.example` 8종:
+  > Supabase(3) + Kakao(2) + AI(2) + App(2) + Sentry(2) + DB(2). 본 ISSUE 미수정.
+  > 자세한 내용은 INFRA-001 갱신본 §3.6 참조.
+
+- [x] **3.5** ★ **`src/lib/db.ts` 처리 — 현 in-memory store 보존, 실 PrismaClient 싱글톤 swap 은 INFRA-002 위임**
+  > **핵심 메모 (DB-001 의 본질).** 현 `src/lib/db.ts` 는 PrismaClient 가 아니라 **Vercel demo 용 in-memory Map store** 다.
+  > **이유:** Vercel serverless filesystem 이 read-only + ephemeral → SQLite 가 prod 에서 동작 불가 → in-memory 우회.
+  > 모든 API 라우트 (`src/app/api/diagnosis/*`, `src/app/api/share/*`, `src/app/api/save/*`) 가 `import { prisma } from '@/lib/db'` 로 이 fake API 사용.
+  > **실 PrismaClient 싱글톤 swap 은 INFRA-002 (Supabase Postgres 프로비저닝) 시점에 수행.**
+  > DB-001 단계에서는 in-memory 보존 + Prisma 인프라 (schema/migrations/config/scripts/docs) 만 준비.
+  > 사용자 가드: src/lib/db.ts 절대 불변.
+
+  ```typescript
+  // 현 src/lib/db.ts (in-memory, 본 ISSUE 미수정)
+  // In-memory store for the Vercel demo deploy.
+  // Pin stores to globalThis so Next.js dev mode HMR doesn't wipe them.
+  export const prisma = {
+    diagnosis:    { create, findUnique },
+    shareLink:    { create, findUnique, update },
+    savedSearch:  { upsert, findUnique },
+  };
   ```
 
-- [ ] **3.6** `.gitignore`에 Prisma 관련 파일 추가
-  ```gitignore
-  # Prisma
-  prisma/dev.db
-  prisma/dev.db-journal
-  prisma/shadow.db
+  ```typescript
+  // INFRA-002 시점 swap 후 예시 (참고용, 본 ISSUE 미작성)
+  import { PrismaClient } from "@/generated/prisma/client";
+  declare global { var prismaGlobal: PrismaClient | undefined; }
+  export const prisma = global.prismaGlobal ?? new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["query", "error"] : ["error"],
+  });
+  if (process.env.NODE_ENV !== "production") global.prismaGlobal = prisma;
   ```
 
-- [ ] **3.7** `package.json`에 Prisma CLI npm scripts 추가
+  > 상세 가이드: [`onday-app/docs/prisma-env-setup.md`](../onday-app/docs/prisma-env-setup.md) §1 (in-memory note) + §4-2 (실 싱글톤 예시).
+
+- [x] **3.6** `.gitignore` Prisma 관련 — INFRA-001 갱신본 정합, 본 ISSUE 미수정
+  > INFRA-001 에서 이미 보강: `prisma/dev.db`, `prisma/dev.db-journal`, `*.db` glob, `/src/generated/prisma`. `prisma/shadow.db` 는 `*.db` glob 으로 포괄.
+
+- [x] **3.7** `package.json` Prisma CLI npm scripts 8종 추가 (Phase B 산출물)
+  > 기존 4개 (`dev`, `build`, `start`, `lint`) 보존 + 추가 8종 = 합 12 scripts.
   ```json
   {
     "scripts": {
+      "dev": "next dev",
+      "build": "next build",
+      "start": "next start",
+      "lint": "eslint",
       "db:migrate:dev": "npx prisma migrate dev",
       "db:migrate:deploy": "npx prisma migrate deploy",
       "db:generate": "npx prisma generate",
@@ -139,131 +154,108 @@ assignees: []
     }
   }
   ```
+  > `postinstall` 은 매 `npm install` 시점에 자동 generate 실행. INFRA-001 의 `vercel.json` buildCommand (`npx prisma generate && next build`) 와 중복이지만 무해 (dev 친화 + Vercel 빌드 명시).
+  > 검증: Phase B 에서 `npm run db:validate` exit 0 + `npx tsc --noEmit` exit 0 (기준선 유지).
 
-- [ ] **3.8** 초기 마이그레이션 실행 및 검증
-  - 명령어: `npx prisma migrate dev --name init`
-  - 생성 파일: `prisma/migrations/{timestamp}_init/migration.sql`
-  - 검증: `npx prisma validate` 통과 확인
+- [x] **3.8** 초기 마이그레이션 — 기존 4/29 산출물 보존, 본 ISSUE 미생성
+  > `prisma/migrations/20260429125124_init/migration.sql` (4/29 작성) 이미 존재.
+  > 포함 4테이블: `users`, `diagnoses`, `share_links`, `saved_searches` (DB-002~006 영역까지 포함됨 — 위 §2 정합성 표 참조).
+  > 본 ISSUE 에서 신규 migration 생성 없음 (사용자 가드). 검증만: `npx prisma validate` exit 0 (Phase A.7) + `npx prisma generate` exit 0 (Phase A.8).
 
-- [ ] **3.9** `prisma/seed.ts` 기본 구조 작성
+- [x] **3.9** `prisma/seed.ts` — 기존 onday-app 산출물 보존 (Prisma 7 + better-sqlite3 adapter 패턴)
+  > 사용자 가드: `prisma/seed.ts` 절대 불변. 현 패턴:
   ```typescript
-  // prisma/seed.ts
-  import { PrismaClient } from '@prisma/client';
+  // 현 prisma/seed.ts (4/29 작성, 본 ISSUE 미수정)
+  import { PrismaClient } from "../src/generated/prisma/client";
+  import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 
-  const prisma = new PrismaClient();
+  const adapter = new PrismaBetterSqlite3({ url: "file:prisma/dev.db" });
+  const prisma = new PrismaClient({ adapter });
 
   async function main() {
-    console.log('🌱 Seeding database...');
-    // 후속 DB-002~007에서 시드 데이터 추가 예정
-    console.log('✅ Seed completed');
-  }
-
-  main()
-    .catch((e) => {
-      console.error('❌ Seed failed:', e);
-      process.exit(1);
-    })
-    .finally(async () => {
-      await prisma.$disconnect();
-    });
-  ```
-  - `package.json`에 시드 설정 추가:
-  ```json
-  {
-    "prisma": {
-      "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
-    }
+    const user = await prisma.user.upsert({ /* test@onday.kr */ });
   }
   ```
+  - **seed runner 결정 보류 (Q4):** `tsx` 가 onday-app/node_modules 부재. 사용자 지시 "설치 말고 보고" 발동.
+    - `package.json` 의 `"prisma": { "seed": "..." }` 항목 **비움** — Phase B 에서 `db:seed` npm script 만 추가.
+    - `npm run db:seed` 실행 시 `prisma.seed` 미설정으로 Prisma 가 에러 출력. 정상 (의도적).
+    - **실제 seed 실행 결정은 INFRA-002 이후** (in-memory → 실 Prisma 전환 시점) 에 함께 결정.
+    - 옵션 (후속 결정 시): (i) tsx 설치 + `tsx prisma/seed.ts`, (ii) Prisma 7 자체 TS runner 확인, (iii) seed.ts → .js 사전 컴파일
 
-- [ ] **3.10** `__tests__/db/prisma-init.spec.ts`에 초기화 검증 테스트 작성
-  ```typescript
-  import { prisma } from '@/lib/db';
+- [ ] **3.10** `__tests__/db/prisma-init.spec.ts` — **TEST-* 위임 (본 ISSUE 미작성)**
+  > **이유:**
+  > 1. `vitest.config.ts` 가 부재 (INFRA-001 §9-5 보류 사항). vitest 패키지만 설치, config 없음 → spec 작성해도 실행 불가.
+  > 2. 현 `src/lib/db.ts` 가 in-memory fake 라서 "PrismaClient 인스턴스 검증" 자체가 fake 검증으로 meaningless. `$queryRaw` 등 실 Prisma API 미지원.
+  > 3. TEST-* 시점에 `vitest.config.ts` + 모든 ISSUE 의 spec 일괄 작성이 자연스러움.
+  > 4. 본 ISSUE 의 Prisma 초기화 검증은 CLI (`npx prisma validate`, `npx prisma generate`, `npx tsc --noEmit`) 로 충족 (§8 Test Plan).
+  > 5. INFRA-001 §9-5 follow-up 위임 흐름과 일관.
+  > **단, INFRA-001 의 `__tests__/db/.gitkeep` 빈 디렉토리는 보존** — TEST-* 시점에 spec 추가될 위치.
 
-  describe('Prisma ORM 초기화 검증', () => {
-    afterAll(async () => { await prisma.$disconnect(); });
+- [x] **3.11** `onday-app/docs/prisma-env-setup.md` 신규 — Prisma 7 환경 가이드 + in-memory 예고 (Phase C 산출물)
+  > Phase C 산출물 (~180줄). `onday-app/docs/` 에 작성 (design 루트 `docs/` 와 무관 — 격리).
+  > 핵심 섹션:
+  > - §0 ★ 현실 불일치 경고 (먼저 읽기): `migration-to-postgres.md` (4/29) 가정 vs 현실
+  > - §1 ★ in-memory store 예고 (DB-001 핵심 메모): INFRA-002 swap 예고
+  > - §2 Prisma 7 신패턴 3종 (generator / prisma.config.ts / better-sqlite3 adapter)
+  > - §3 로컬 개발 환경 (SQLite + npm scripts 7종)
+  > - §4 프로덕션 전환 (INFRA-002 시점 할 일 요약 + 실 싱글톤 예시)
+  > - §5 SQLite ↔ Postgres 차이 비교표
+  > - §6 본 문서 vs `migration-to-postgres.md` 역할 분담
 
-    it('PrismaClient 인스턴스가 정상 생성된다', () => {
-      expect(prisma).toBeDefined();
-      expect(prisma).toBeInstanceOf(Object);
-    });
+  ### 두 docs 역할 분담
 
-    it('DB 연결이 정상적으로 수행된다', async () => {
-      // $queryRaw로 간단한 쿼리 실행
-      const result = await prisma.$queryRaw`SELECT 1 as ok`;
-      expect(result).toBeDefined();
-    });
+  | 문서 | 역할 | 갱신 주체 |
+  | --- | --- | --- |
+  | `onday-app/docs/prisma-env-setup.md` (본 ISSUE 신규) | 현 Prisma 7 환경 구조 + in-memory note + 신패턴 가이드 | DB-001 (현재) → INFRA-002 시점 §1 in-memory 메모 갱신 |
+  | `onday-app/docs/migration-to-postgres.md` (4/29, 보존) | 실제 Postgres 이주 절차 + RLS SQL | 4/29 작성 보존. **현실 불일치 (4/29 가정 = env-based provider) 는 본 ISSUE 가드로 미수정. `prisma-env-setup.md` §0 에 경고 명시.** INFRA-002 시점에 schema 가정 갱신 |
 
-    it('싱글톤 패턴 — 동일 인스턴스 반환', async () => {
-      const { prisma: prisma2 } = await import('@/lib/db');
-      expect(prisma).toBe(prisma2);
-    });
-
-    it('development 환경에서 query 로그가 활성화된다', () => {
-      // PrismaClient 생성 옵션의 log 배열 검증
-      // 환경별 분기 테스트
-    });
-  });
-  ```
-
-- [ ] **3.11** `docs/prisma-env-setup.md`에 환경별 DB 전환 가이드 문서 작성
-  ```markdown
-  # Prisma 환경별 DB 설정 가이드
-
-  ## 로컬 개발 (SQLite)
-  DATABASE_PROVIDER=sqlite
-  DATABASE_URL=file:./dev.db
-  npx prisma migrate dev --name {description}
-
-  ## 프로덕션 (Supabase PostgreSQL)
-  DATABASE_PROVIDER=postgresql
-  DATABASE_URL=postgresql://postgres:[password]@db.[ref].supabase.co:5432/postgres
-  npx prisma migrate deploy
-
-  ## 주의사항
-  - SQLite에서는 @db.JsonB, @db.Uuid 등 Postgres 전용 어노테이션이 TEXT로 매핑됨
-  - RLS 정책은 Postgres에서만 동작 — prisma/migrations/manual/ 디렉토리에 별도 관리
-  ```
-
-- [ ] **3.12** Prisma Client 타입 생성 및 타입 검증
-  - 명령어: `npx prisma generate`
-  - 검증: `npx tsc --noEmit` 통과
+- [x] **3.12** Prisma Client 타입 생성 및 타입 검증 — Phase A/B 검증 완료
+  - 명령어: `npx prisma generate` (또는 `npm run db:generate`)
+  - 검증: `npx tsc --noEmit` exit 0 (Phase A.9 baseline + Phase B 회귀 검증 통과)
+  - 출력: `src/generated/prisma/` (`.gitignore` 됨, 매 빌드/install 마다 재생성)
+  - import 경로: `import { PrismaClient } from "@/generated/prisma/client"` (단 `src/lib/db.ts` 가 in-memory store 라 후속 ISSUE 의 import 는 여전히 `@/lib/db`)
 
 ---
 
 ## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
 
-**AC-1 (정상):** Prisma 초기화 및 SQLite 로컬 DB 연결 성공
-- **Given** `DATABASE_PROVIDER=sqlite`, `DATABASE_URL=file:./dev.db` 환경변수가 설정된 상태
-- **When** `npx prisma migrate dev --name init` 실행
-- **Then** `prisma/migrations/{timestamp}_init/migration.sql` 파일이 생성되고, `prisma/dev.db` SQLite 파일이 생성되며, `npx prisma validate` 통과
+**AC-1 (정상):** Prisma 초기화 및 SQLite 로컬 DB 연결 성공 — **기존 4/29 onday-app 부트스트랩 시 완료**
+- **Given** 4/29 `npx prisma migrate dev --name init` 이미 실행됨 (`prisma/migrations/20260429125124_init/` + `prisma/dev.db` 존재)
+- **When** 본 ISSUE 의 `npm run db:validate` 실행 (Phase B)
+- **Then** `npx prisma validate` exit 0, `"The schema at prisma/schema.prisma is valid 🚀"`
 
-**AC-2 (정상):** PrismaClient 싱글톤 동작 검증
-- **Given** `lib/db.ts`에 싱글톤 패턴이 구현된 상태
-- **When** 서로 다른 모듈에서 `import { prisma } from '@/lib/db'`를 2회 수행
-- **Then** 두 import가 동일한 PrismaClient 인스턴스를 참조하며, `prisma === prisma2`가 `true`
+**AC-2 (정상):** ~~PrismaClient 싱글톤 동작 검증~~ — **in-memory store 의 export 구조로 부분 충족, 실 PrismaClient 싱글톤은 INFRA-002 위임**
+- **Given** `src/lib/db.ts` 가 in-memory store 를 export (PrismaClient 아님)
+- **When** 서로 다른 모듈에서 `import { prisma } from '@/lib/db'`
+- **Then** 동일한 in-memory `prisma` 객체 참조 (`globalThis` 핀으로 dev HMR 시 안정)
+- **⏸ 실 PrismaClient 싱글톤 검증 (`prisma === prisma2` 등) 은 INFRA-002 swap 후 수행**
 
-**AC-3 (예외):** DATABASE_URL 미설정 시 명확한 에러 발생
-- **Given** `.env`에서 `DATABASE_URL`을 제거한 상태
-- **When** `npx prisma validate` 실행
-- **Then** `Error: Environment variable not found: DATABASE_URL` 에러 메시지가 표시되며, 모호한 에러 없이 원인이 명확
+**AC-3 (예외):** ~~DATABASE_URL 미설정 시 명확한 에러~~ — **부분 충족 (validate 만 url 미참조)**
+- **Given** `.env` 에서 `DATABASE_URL` 제거
+- **When** `npm run db:migrate:dev` 또는 `npm run db:push` 실행
+- **Then** `Error: Environment variable not found: DATABASE_URL` 또는 동등 에러 (Prisma 가 prisma.config.ts 의 url override 에서 undefined 감지)
+- **단** `npm run db:validate` 는 url 안 보고 schema 문법만 검증 → DATABASE_URL 미설정에도 통과 (Phase B 검증 시 통과)
+- **검증 시점:** INFRA-002 시점에 migrate/push 명령으로 정밀 검증
 
-**AC-4 (경계):** Postgres URL로 전환 시 스키마 유효성 유지
-- **Given** `DATABASE_PROVIDER=postgresql`, `DATABASE_URL=postgresql://...` 환경변수로 변경한 상태
-- **When** `npx prisma validate` 실행
-- **Then** 스키마 유효성 검증 통과, datasource provider가 postgresql로 인식됨
+**AC-4 (경계):** ~~Postgres URL 로 전환 시 스키마 유효성 유지~~ — **INFRA-002 위임**
+- **Given** 현 `schema.prisma` 의 datasource provider 가 `"sqlite"` 하드코딩 (사용자 가드)
+- **When** INFRA-002 시점에 provider 를 `env("DATABASE_PROVIDER")` 로 갱신 + `DATABASE_PROVIDER=postgresql`
+- **Then** 스키마 유효성 검증 통과 + provider postgresql 인식
+- **⏸ 본 ISSUE 가드 (4/29 산출물 불변) 로 미수행, INFRA-002 영역**
 
-**AC-5 (정합성):** 배치 1~4 ISSUE의 Prisma init 가정과 일치
-- **Given** DB-003, DB-006, DB-007 ISSUE의 Prisma 모델 import 경로가 `@prisma/client`
-- **And** DB-003, DB-006, DB-007이 `import { prisma } from '@/lib/db'`로 싱글톤 사용을 가정
-- **When** 본 ISSUE의 `lib/db.ts` 싱글톤이 `@prisma/client`의 `PrismaClient`를 export
-- **Then** import 경로가 일치하여 별도 follow-up 작업 불필요
-- **And** `prisma/schema.prisma`의 `generator client { provider = "prisma-client-js" }` 설정이 `@prisma/client` 생성을 보장
+**AC-5 (정합성):** 배치 1~4 ISSUE 의 Prisma init 가정과 일치 — **import 경로 일치 ✅, 실 Prisma API 사용 시 INFRA-002 까지 mismatch 가능**
+- **Given** 후속 ISSUE (DB-007, API-*, CMD-*, QRY-*) 가 `import { prisma } from '@/lib/db'` 가정
+- **And** tsconfig path alias `@/* → ./src/*` 정합 (INFRA-001 갱신본)
+- **When** 본 ISSUE 의 `src/lib/db.ts` 가 in-memory fake (diagnosis/shareLink/savedSearch 3종 fake 메서드만 export)
+- **Then** import 경로는 일치 ✅
+- **And** 후속 ISSUE 가 in-memory 미지원 메서드 (`$queryRaw`, transactions, relations include 등) 사용 시 작동 안 함 → **INFRA-002 swap 후 해소** (in-memory → 실 PrismaClient)
+- **fake API 메서드 목록 (참조):** `prisma.diagnosis.{create,findUnique}`, `prisma.shareLink.{create,findUnique,update}`, `prisma.savedSearch.{upsert,findUnique}`. `prisma.user.*` 도 없음 (DB-007 시점 필요).
 
-**AC-6 (경계):** 개발 환경 로그 레벨 분기 동작
-- **Given** `NODE_ENV=development` 환경에서 PrismaClient 생성
-- **When** SQL 쿼리를 실행
-- **Then** 콘솔에 `query` 로그가 출력됨. `NODE_ENV=production` 환경에서는 `error` 로그만 출력
+**AC-6 (경계):** ~~개발 환경 로그 레벨 분기~~ — **in-memory store 라 미적용, INFRA-002 위임**
+- **Given** 현 in-memory store 는 `log` 옵션 없음 (Map operation 만)
+- **When** in-memory store 사용 중 SQL 쿼리 실행 — 발생 안 함 (Map 으로 우회)
+- **Then** N/A
+- **⏸ INFRA-002 swap 후** `log: process.env.NODE_ENV === 'development' ? ['query', 'error'] : ['error']` 분기 적용
 
 ---
 
@@ -271,24 +263,35 @@ assignees: []
 
 | NFR ID | SRS 본문 인용 | 본 태스크에서의 검증 방법 |
 |---|---|---|
-| REQ-NF-012 | "서버 오류율 (5xx 응답) — ≤ 0.5%" (§4.2.2) | PrismaClient 싱글톤 패턴으로 커넥션 풀 관리. Hot-reload 시 커넥션 누수 방지 (`global.prismaGlobal` 캐싱). 연결 실패 시 명확한 에러 로그 + Sentry 전달 가능 구조 |
-| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | PrismaClient 생성 시 `log: ['error']`로 에러 레벨 로그 활성화. Prisma 에러 발생 시 Sentry.captureException으로 전달 가능한 구조 확인 |
-| CON-11 | "데이터베이스는 Prisma ORM + SQLite(로컬 개발) / Supabase PostgreSQL(프로덕션)을 사용한다." (§1.2.3) | `datasource.provider = env("DATABASE_PROVIDER")` + `url = env("DATABASE_URL")` 환경변수 기반 전환 구조. `.env.example`에 양쪽 설정 예시 명시 |
+| REQ-NF-012 | "서버 오류율 (5xx 응답) — ≤ 0.5%" (§4.2.2) | 현 in-memory store 는 `globalThis` 핀으로 dev HMR / Vercel warm lambda 간 데이터 안정. 실 PrismaClient 싱글톤 커넥션 풀 관리는 INFRA-002 swap 후 적용. 에러 발생 시 Sentry 전달은 INFRA-001 silent skip 패턴 정합 (MON-001 시점 활성화) |
+| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | INFRA-001 의 `next.config.ts` withSentryConfig silent skip 패턴 정합. Prisma 에러는 in-memory 사용 중에는 발생 안 함 (Map operation). 실 Prisma swap 후 (INFRA-002) `log: ['error']` + `Sentry.captureException` 구조 |
+| CON-11 | "데이터베이스는 Prisma ORM + SQLite(로컬 개발) / Supabase PostgreSQL(프로덕션)을 사용한다." (§1.2.3) | **부분 충족.** schema.prisma 의 datasource provider = `"sqlite"` 하드코딩 + `prisma.config.ts` 의 url 만 env override. 명세 v1.0 의 `provider = env("DATABASE_PROVIDER")` 동적 전환은 **INFRA-002 위임**. `.env.example` 은 INFRA-001 갱신본 정합 (DATABASE_PROVIDER + DATABASE_URL 포함) |
 
 ---
 
 ## 6. 📦 Deliverables (산출물 명시)
 
-- `prisma/schema.prisma` (datasource 설정 + generator client)
-- `prisma/migrations/{timestamp}_init/migration.sql` (초기 마이그레이션)
-- `prisma/seed.ts` (시드 기본 구조)
-- `lib/db.ts` (PrismaClient 싱글톤)
-- `.env` (로컬 개발용 기본값)
-- `.env.example` (환경변수 템플릿 — DATABASE_URL/PROVIDER + SUPABASE + KAKAO + SENTRY)
-- `docs/prisma-env-setup.md` (환경별 DB 전환 가이드)
-- `__tests__/db/prisma-init.spec.ts` (초기화 검증 테스트)
-- `package.json` 수정 (Prisma npm scripts + seed 설정 + postinstall)
-- `.gitignore` 수정 (Prisma 로컬 DB 파일 제외)
+### DB-001 신규/수정 산출물 (본 ISSUE)
+- `onday-app/package.json` (수정 — Prisma npm scripts 8종 추가, 기존 4종 보존)
+- `onday-app/docs/prisma-env-setup.md` (신규 — Prisma 7 환경 가이드 + in-memory 예고)
+- `tasks/DB-001.md` (본 문서 명세 갱신 — 현실 추인)
+
+### DB-001 에서 보존 (4/29 onday-app 산출물 + INFRA-001 산출물, 본 ISSUE 미수정)
+- `onday-app/prisma/schema.prisma` (4/29, 4모델 정의 + Prisma 7 generator + sqlite 하드코딩)
+- `onday-app/prisma.config.ts` (4/29, Prisma 7 신 파일 + runtime url override)
+- `onday-app/prisma/migrations/20260429125124_init/migration.sql` (4/29)
+- `onday-app/prisma/seed.ts` (4/29, PrismaBetterSqlite3 adapter)
+- `onday-app/src/lib/db.ts` (5/3, in-memory store — ★ 사용자 가드 핵심)
+- `onday-app/docs/migration-to-postgres.md` (4/29, 현실 불일치는 prisma-env-setup.md §0 에 경고만)
+- `onday-app/.env` / `onday-app/.env.example` / `onday-app/.gitignore` (INFRA-001 정합)
+- `onday-app/__tests__/db/.gitkeep` (INFRA-001 빈 디렉토리, TEST-* 시점 spec 추가 위치)
+
+### DB-001 에서 위임 (후속 ISSUE)
+- 실 PrismaClient 싱글톤 (`src/lib/db.ts` swap) → **INFRA-002**
+- datasource provider env 화 (`schema.prisma` 갱신) → **INFRA-002**
+- `__tests__/db/prisma-init.spec.ts` (vitest config + spec) → **TEST-***
+- `prisma.seed` runner 결정 (tsx 부재) → INFRA-002 이후
+- DB-002~006 모델 정의 (이미 4/29 정의됨, 후속 ISSUE 는 현실 추인 패턴)
 
 ---
 
@@ -296,31 +299,29 @@ assignees: []
 
 ### 선행 (이 태스크 시작 전 필요):
 
-- **INFRA-001:** Next.js 프로젝트 초기화 — `package.json`, `tsconfig.json`, 디렉토리 구조가 존재해야 Prisma CLI 설치 및 설정 가능
+- **INFRA-001 (PR #74 머지 완료, `130c998`):** Prisma 7 패키지군 설치 + 디렉토리 보강 + tsconfig path alias `@/* → ./src/*` + vercel.json + 명세 정합 (Next 15+/React 19/Prisma 7)
 
 ### 후행 (이 태스크 완료 후 차례로 가능):
 
-- **DB-002:** USER 테이블 base Prisma 스키마 — DB-001이 제공하는 `prisma/schema.prisma` datasource 설정에 모델 추가
-- **DB-003:** DIAGNOSIS 테이블 — DB-001의 Prisma init 기반
-- **DB-006:** SAVED_SEARCH 테이블 — DB-001의 Prisma init 기반
-- **DB-007:** Supabase Auth 연동 USER 스키마 정렬 — DB-001의 Prisma init + `lib/db.ts` 싱글톤 사용
-- **INFRA-002:** Supabase PostgreSQL 프로비저닝 — DB-001의 환경변수 구조 기반으로 프로덕션 DB 연결
+- **DB-002~006 (현실 추인 패턴):** USER/DIAGNOSIS/SHARE_LINK/SAVED_SEARCH 4모델은 이미 4/29 schema.prisma 에 정의됨. 각 ISSUE 는 명세 갱신 위주 (모델은 INFRA-002 시점 Postgres 어노테이션 추가)
+- **DB-007:** Supabase Auth 연동 USER 스키마 정렬 — INFRA-002 + 본 ISSUE 의 prisma 인프라 기반
+- **INFRA-002:** Supabase PostgreSQL 프로비저닝 + `src/lib/db.ts` in-memory → 실 PrismaClient swap + schema.prisma datasource provider env 화 (본 ISSUE 의 위임 사항 모두 처리)
+- **TEST-*:** vitest config + `__tests__/db/prisma-init.spec.ts` 작성 (본 ISSUE §3.10 위임)
 
 ---
 
 ## 8. 🧪 Test Plan (검증 절차)
 
-- **단위 테스트:** `__tests__/db/prisma-init.spec.ts` — 4개 케이스 (인스턴스 생성, DB 연결, 싱글톤 검증, 로그 레벨 분기)
-- **CLI 검증:**
-  1. `npx prisma validate` — 스키마 문법 검증 통과
-  2. `npx prisma migrate dev --name init` — 초기 마이그레이션 정상 실행
-  3. `npx prisma generate` — Prisma Client 타입 생성 정상
-  4. `npx prisma studio` — DB GUI 정상 실행 (로컬 SQLite 확인)
-- **타입 검증:** `npx tsc --noEmit` — TypeScript 컴파일 에러 0건
-- **환경 전환 검증:**
-  1. `.env`를 SQLite 설정으로 → `npx prisma validate` 통과
-  2. `.env`를 PostgreSQL 설정으로 → `npx prisma validate` 통과
-- **CI 게이트:** `npx prisma validate`, `tsc --noEmit`, Jest 테스트 통과
+- **단위 테스트:** ⏸ TEST-* 위임 (§3.10 참조). 본 ISSUE 미작성.
+- **CLI 검증 (Phase A/B 통과):**
+  1. `npx prisma validate` — exit 0, `"valid 🚀"` (Phase A.7)
+  2. `npx prisma generate` — exit 0, `Generated Prisma Client (7.8.0) to ./src/generated/prisma` (Phase A.8)
+  3. `npm run db:validate` — exit 0 (Phase B.1, npm script 동작 확인)
+  4. ⏸ `npx prisma migrate dev --name init` — 4/29 이미 실행됨, 본 ISSUE 미실행 (사용자 가드)
+  5. ⏸ `npx prisma studio` — local GUI, CI 게이트 외
+- **타입 검증:** `npx tsc --noEmit` — exit 0 (Phase A.9 baseline + Phase B 회귀)
+- **환경 전환 검증:** ⏸ INFRA-002 위임 (AC-4)
+- **CI 게이트 (본 ISSUE):** `npx prisma validate` + `npx prisma generate` + `tsc --noEmit` + INFRA-001 env-less build 회귀 (Phase E)
 
 ---
 
@@ -330,12 +331,36 @@ assignees: []
 
 | 갱신 대상 ISSUE | 갱신 사유 | 우선순위 |
 |---|---|---|
-| DB-007.md | RLS 정책(`auth.uid()`)은 Supabase Postgres에서만 동작 — 로컬 SQLite 환경에서 RLS 우회 전략 필요. `prisma/migrations/manual/` 디렉토리에 별도 관리하는 전략이 DB-007에 이미 명시되어 있으므로 정합성 OK. 단, 로컬 테스트 시 FK 제약(`auth.users` 참조)도 건너뛰어야 하는 점을 DB-007에 추가 명시 권장 | M |
-| DB-003.md | `@db.JsonB`, `@db.Date` 어노테이션이 SQLite에서 TEXT/TEXT로 매핑됨. Prisma가 자동 처리하므로 코드 변경 불필요하나, JSONB 인덱싱 등 Postgres 전용 기능은 로컬에서 테스트 불가한 점을 인지해야 함. DB-003 ISSUE에 이미 Supabase 프로덕션 검증 항목(3.12)이 있으므로 정합성 OK — follow-up 없음 | L |
-| DB-006.md | SQLite JSONB 호환성 — DB-006 Open Questions #2에 이미 명시됨. 정합성 OK — follow-up 없음 | — |
+| DB-002.md / DB-003.md / DB-004.md / DB-006.md | **현실 추인 예고** — 4모델 (User/Diagnosis/ShareLink/SavedSearch) 이 4/29 schema.prisma 에 이미 정의됨. 각 ISSUE 는 "모델 신규 작성" → "현실 추인 + Postgres 어노테이션 추가 (INFRA-002 시점)" 패턴 적용 필요 | H |
+| DB-007.md | Supabase Auth 연동 USER 스키마 정렬 — 현 User 모델은 단순 (authProvider=kakao\|naver). `auth.users` FK + RLS 추가는 INFRA-002 + DB-007 시점. 로컬 SQLite 에서는 FK/RLS 우회 (Mock 단일 사용자) | M |
+| MOCK-001~005 / CMD-DIAG / CMD-SHARE / CMD-SAVE / QRY-DIAG | `import { prisma } from '@/lib/db'` 가 in-memory fake API. `$queryRaw`/transactions/relations 등 실 Prisma API 사용 시 작동 안 함. **INFRA-002 swap 후 검증 필요** | M |
 
 ### 기타 보류 사항
 
-1. **Prisma `provider = env()` 동적 전환의 한계:** Prisma는 `prisma generate` 시점에 provider를 결정하므로, SQLite와 PostgreSQL 간 전환 시 `npx prisma generate`를 재실행해야 한다. CI/CD에서 `postinstall` hook으로 자동 처리되나, 로컬 개발자가 수동으로 전환할 때 주의 필요.
-2. **Supabase 무료 티어 연결 제한:** Supabase 무료 티어는 동시 커넥션 수 제한이 있으므로, PrismaClient의 connection_limit 설정이 필요할 수 있다 — INFRA-002 작업 시 확정.
-3. **Shadow Database:** Prisma `migrate dev`는 shadow database를 사용하는데, Supabase PostgreSQL에서는 shadow DB 생성 권한이 제한될 수 있다 — 프로덕션에서는 `migrate deploy`만 사용하여 우회.
+1. **★ in-memory ↔ 실 PrismaClient 전환 시점 = INFRA-002**
+   - 현 `src/lib/db.ts` = Vercel demo 용 in-memory store (사용자 가드로 본 ISSUE 보존).
+   - INFRA-002 (Supabase Postgres 프로비저닝) 시점에 실 PrismaClient 싱글톤으로 swap.
+   - 동시에 schema.prisma 의 datasource provider 도 `"sqlite"` → `env("DATABASE_PROVIDER")` 갱신.
+   - 모든 API 라우트의 prisma 호출이 자동 동작 (인터페이스 동일, 구현만 swap).
+
+2. **★ AC-4 (env-based provider 전환) = INFRA-002 위임**
+   - 사용자 가드 (4/29 schema.prisma 불변) 로 본 ISSUE 미수행.
+   - `prisma.config.ts` 의 url runtime override 로 일부 만족, schema 의 provider env 화는 INFRA-002.
+
+3. **★ seed runner 결정 = tsx 부재로 보류**
+   - Q4 결정: `prisma.seed` 항목 비움, `db:seed` script 만 추가.
+   - `tsx` 가 onday-app/node_modules 부재 (사용자 지시: 설치 말고 보고).
+   - 실 실행 결정은 INFRA-002 이후 (in-memory → 실 Prisma 전환 시점) 에 함께.
+
+4. **★ DB-002~006 ISSUE 도 현실 추인 패턴 예고**
+   - 4모델이 이미 4/29 정의됨. 각 ISSUE 는 "신규 작성" → "현실 추인 + 명세 갱신 + INFRA-002 시점 Postgres 어노테이션 추가" 패턴.
+   - INFRA-001/DB-001 의 패턴 일관 적용.
+
+5. **`__tests__/db/` spec 작성 = TEST-* 위임**
+   - vitest config 부재 + in-memory fake 검증 무의미.
+   - TEST-* 시점에 config + 모든 spec 일괄 작성.
+   - INFRA-001 §9-5 흐름 일관.
+
+6. **Supabase 무료 티어 연결 제한:** Supabase 무료 티어는 동시 커넥션 수 제한이 있으므로, PrismaClient 의 connection_limit 설정 필요할 수 있다 — INFRA-002 작업 시 확정.
+
+7. **Shadow Database:** Prisma `migrate dev` 는 shadow database 를 사용하는데, Supabase PostgreSQL 에서는 shadow DB 생성 권한이 제한될 수 있다 — 프로덕션에서는 `migrate deploy` 만 사용하여 우회.


### PR DESCRIPTION
## 개요
DB-001 (Prisma 7 ORM 초기화 + DATABASE_URL 전환 구조) 의 onday-app/ 베이스 + 명세 갭 보충 작업.

전제: SSoT = `prototypes/design/` 명세 (06_TASK_LIST/CLAUDE/AGENTS/tasks/DB-001.md). 작업 대상 = 기존 `onday-app/` (보강·수정만, 신규 부트스트랩 없음, 4/29 산출물 절대 불변).

선행 = INFRA-001 (PR #74 머지본 `130c998`).

Refs #5

## ★ 핵심 메모 (Issue 본질)

### §3.5 in-memory store 보존 + INFRA-002 위임
- 현 `src/lib/db.ts` 는 PrismaClient 가 아니라 **Vercel demo 용 in-memory Map store**
- 이유: Vercel serverless filesystem read-only + ephemeral → SQLite prod 동작 불가
- 모든 API 라우트가 `import { prisma } from '@/lib/db'` 로 fake API 사용
- **실 PrismaClient 싱글톤 swap = INFRA-002 (Supabase Postgres 프로비저닝) 시점**
- DB-001 단계는 in-memory 보존 + Prisma 인프라(schema/migrations/config/scripts/docs) 만 준비

### §1 DB-002~006 모델 미수정 (현실 추인)
- 4모델 (User/Diagnosis/ShareLink/SavedSearch) 이 4/29 `prisma/schema.prisma` 에 이미 정의됨
- 본 ISSUE 미수정 (사용자 가드)
- 후속 DB-002/003/004/006 ISSUE 도 현실 추인 패턴 예고

## 산출물

### 신규/수정 (본 ISSUE)
- `onday-app/package.json` — Prisma npm scripts 8종 추가 (db:migrate:dev/deploy, db:generate, db:studio, db:validate, db:seed, db:push, postinstall). 기존 4종(dev/build/start/lint) 보존
- `onday-app/docs/prisma-env-setup.md` — 신규 ~180줄. Prisma 7 환경 가이드 + ★in-memory 예고 + 신패턴 3종 + SQLite↔Postgres 차이 비교표
- `tasks/DB-001.md` — 명세 현실 동기화 (451 line changed, +238/-213)

### 보존 (4/29 산출물 + INFRA-001 산출물)
- `onday-app/prisma/schema.prisma` (4/29, Prisma 7 generator + sqlite 하드코딩 + 4모델)
- `onday-app/prisma.config.ts` (4/29, runtime url override)
- `onday-app/prisma/migrations/20260429125124_init/` (4/29)
- `onday-app/prisma/seed.ts` (4/29, PrismaBetterSqlite3 adapter)
- `onday-app/src/lib/db.ts` (5/3, in-memory store — ★ 핵심)
- `onday-app/docs/migration-to-postgres.md` (4/29, 현실 불일치는 prisma-env-setup.md §0 에 경고만)
- `onday-app/.env` / `.env.example` / `.gitignore` (INFRA-001 정합)
- `onday-app/__tests__/db/.gitkeep` (INFRA-001 빈 디렉토리, TEST-* 시점 spec 추가 위치)

### 위임 (후속 ISSUE)
- 실 PrismaClient 싱글톤 swap → **INFRA-002**
- datasource provider env 화 → **INFRA-002**
- `prisma-init.spec.ts` (vitest config + spec) → **TEST-***
- `prisma.seed` runner 결정 (tsx 부재) → INFRA-002 이후
- DB-002~006 모델 정의 (이미 4/29 정의됨, 현실 추인 패턴)

## AC 검증 결과

| AC | 검증 방법 | 결과 |
| --- | --- | --- |
| AC-1 (init/migration) | 4/29 산출물 + `npm run db:validate` | ✅ exit 0 |
| AC-2 (PrismaClient 싱글톤) | in-memory store export 구조 | ⏸ 부분 충족 (실 싱글톤은 INFRA-002) |
| AC-3 (DATABASE_URL 미설정 에러) | prisma.config.ts url override | ⏸ migrate/push 명령 시 에러 (validate 는 url 미참조). INFRA-002 시점 정밀 검증 |
| AC-4 (Postgres URL 전환) | schema.prisma provider env 화 | ⏸ INFRA-002 위임 (사용자 가드 = schema 불변) |
| AC-5 (import 경로 일치) | `@/lib/db` ↔ `src/lib/db.ts` | ✅ 경로 일치, 실 Prisma API 사용 시 INFRA-002 까지 mismatch |
| AC-6 (로그 레벨 분기) | in-memory store | ⏸ INFRA-002 swap 후 적용 |

### CLI 검증 (Phase E 통과)

| 명령 | 결과 |
| --- | --- |
| `npx prisma validate` | ✅ exit 0, `"valid 🚀"` |
| `npx prisma generate` | ✅ exit 0, `Generated Prisma Client (7.8.0)` |
| `npx tsc --noEmit` | ✅ exit 0 (Phase A.9 기준선 유지) |
| `npm run db:validate` | ✅ exit 0 |
| `npm run db:generate` | ✅ exit 0 |
| env-less `npm run build` | ✅ exit 0, 13 라우트, Middleware **32.5kB 기준선 유지** |

## 커밋 구성 (3개, 코드 ↔ 문서 완전 분리)

1. **59f875e** `feat(DB-001): npm scripts 보강 (Prisma 8종 + postinstall)` — onday-app/package.json
2. **9b6ab8b** `docs(DB-001): Prisma 환경 전환 가이드` — onday-app/docs/prisma-env-setup.md
3. **cb0f769** `docs(DB-001): 명세 현실 동기화` — tasks/DB-001.md

## 격리 검증
- `git diff main --stat -- ':!onday-app' ':!tasks/DB-001.md'` → 빈 출력 (격리 완벽)
- `06_TASK_LIST_v1.3.md` / `CLAUDE.md` / `AGENTS.md` / design 루트 (README-*/.claude/docs) — 변경 0
- `src/lib/db.ts` / `schema.prisma` / `prisma.config.ts` / `prisma/seed.ts` / `prisma/migrations/` — 변경 0 (사용자 가드 핵심)
- `migration-to-postgres.md` / `landing-page-checklist.md` (기존 docs) — 변경 0
- `package-lock.json` — 변동 0 (npm install 미발동)
- INFRA-001 외 untracked (`.agents/skills`, `tasks/ISSUE_REGISTER_LOG.md`) — staging 안 함

## 후속 follow-up

| follow-up | 위임 ISSUE | 메모 |
| --- | --- | --- |
| in-memory → 실 PrismaClient swap | **INFRA-002** | 동시에 schema.prisma datasource provider env 화 |
| AC-4 env-based provider | **INFRA-002** | 사용자 가드 = schema 불변, INFRA-002 영역 |
| `prisma-init.spec.ts` + vitest config | **TEST-*** | INFRA-001 §9-5 일관 흐름 |
| `prisma.seed` runner 결정 | INFRA-002 이후 | tsx 설치 / Prisma 7 신 패턴 / .js 사전 컴파일 중 선택 |
| DB-002~006 모델 명세 | **DB-002/003/004/006** | 현실 추인 패턴 — 4모델 이미 4/29 정의, 명세 갱신 위주 |
| Supabase 무료 티어 connection_limit | INFRA-002 | PrismaClient connection_limit 설정 필요 가능성 |
| Shadow DB (migrate dev) | INFRA-002 | Supabase 권한 제한 시 migrate deploy 만 사용 |

## 명세 링크
- [tasks/DB-001.md (갱신본)](../blob/feature/DB-001/tasks/DB-001.md)
- [onday-app/docs/prisma-env-setup.md (신규)](../blob/feature/DB-001/onday-app/docs/prisma-env-setup.md)
- [onday-app/docs/migration-to-postgres.md (4/29 보존, 자매 문서)](../blob/feature/DB-001/onday-app/docs/migration-to-postgres.md)
- [PR #74 (INFRA-001 머지본)](../pull/74)

🤖 Generated with [Claude Code](https://claude.com/claude-code)