### PR TITLE
feat(DB-003): Diagnosis status TS union + 명세 현실 동기화 (Q1~Q8 mismatch 추적)

### DIFF
--- a/onday-app/src/lib/types/diagnosis.ts
+++ b/onday-app/src/lib/types/diagnosis.ts
@@ -1,0 +1,6 @@
+// schema.prisma 의 status 는 SQLite enum 미지원으로 String 타입 (// processing | completed | expired 주석으로 가능값 명시).
+// 본 파일은 TS union 으로 좁혀 타입 안전성 제공. 실 Prisma enum 강제는 INFRA-002 시점 (Postgres swap).
+// 본 파일은 DIAGNOSIS 도메인 단일 진입점 — 후속 API-002 가 DiagnosisDTO / CandidateAreaDTO / CommuteInfoDTO 등 DTO 를 본 파일에 append 예정.
+// mode 는 user.ts 의 ServiceModeType 재사용 — diagnosis.ts 에서 재정의 금지. API-002 가 DTO 정의 시 `import { ServiceModeType } from './user'` 패턴 사용.
+
+export type DiagnosisStatusType = 'processing' | 'completed' | 'expired';

--- a/tasks/DB-003.md
+++ b/tasks/DB-003.md
@@ -1,19 +1,28 @@
 ---
 name: Feature Task
-title: "[Feature] DB-003: DIAGNOSIS + CandidateArea 테이블 Prisma 스키마 정의 및 마이그레이션"
+title: "[Feature] DB-003: DIAGNOSIS 도메인 base TS union 정의 (기존 onday-app/ 베이스 — CandidateArea 정규화 + JSONB + 복합 인덱스 + 실 Prisma enum 강제 = INFRA-002 후 재평가)"
 labels: ['feature', 'priority:M', 'epic:Data Foundation', 'wave:1']
 assignees: []
 ---
 
 ## 1. 🎯 Summary
 
-- **기능명:** [DB-003] DIAGNOSIS + CandidateArea 테이블 Prisma 스키마 정의 및 마이그레이션
+- **기능명:** [DB-003] DIAGNOSIS 도메인 base TS union 정의 (`src/lib/types/diagnosis.ts`) + 명세 현실 동기화. CandidateArea 정규화 / 실 Prisma enum / mapper / spec / DTO 는 INFRA-002 · TEST-* · API-002 위임.
 - **목적 (Why):**
-  - **비즈니스:** 두 동선 교차 진단 결과(Diagnosis)와 후보 동네(CandidateArea)를 영구 저장하여, 사용자가 진단 결과를 재조회·공유·비교할 수 있게 한다.
-  - **사용자 가치:** 진단 결과가 DB에 저장되어 재방문 시 이전 결과를 즉시 확인하고, 공유 링크를 통해 배우자에게 전달할 수 있다.
+  - **비즈니스:** 두 동선 교차 진단 결과(Diagnosis)와 후보 동네 데이터를 영구 저장하기 위한 DIAGNOSIS 도메인의 TypeScript 타입 안전성을 확보한다. 4/29 산출물의 `String + 주석` 패턴(SQLite enum 미지원)을 TS union 으로 좁혀 `'processing' | 'completed' | 'expired'` 타입 안전성을 제공한다. CandidateArea 정규화 / 실 Prisma enum 강제 / 복합 인덱스 / JSONB / mapper / spec / DTO 는 INFRA-002 (Postgres swap) · TEST-* · API-002 (DTO 정의) 위임으로 도메인 책임 분리를 유지한다.
+  - **사용자 가치:** TypeScript 컴파일 단계에서 `status` 값 오타·잘못된 상태 사용을 차단하여, 사용자의 진단 결과 상태 추적이 일관되도록 보장한다.
 - **범위 (What):**
-  - ✅ 만드는 것: Diagnosis Prisma 모델, CandidateArea Prisma 모델 (별도 테이블), DiagnosisStatus·ServiceMode enum, FK 관계 (User→Diagnosis→CandidateArea, CASCADE), 복합 인덱스, 마이그레이션 파일
-  - ❌ 만들지 않는 것: 진단 로직 구현(CMD-DIAG 범위), 결제 관련 엔터티, SHARE_LINK 테이블(DB-004), 스코어링 엔진(CMD-DIAG-003)
+  - ✅ 만드는 것: `onday-app/src/lib/types/diagnosis.ts` (DiagnosisStatusType union 1개 + 헤더 주석 4종 — Phase B 산출물), 본 명세 현실 동기화 (`tasks/DB-003.md`)
+  - ❌ 만들지 않는 것:
+    - **`prisma/schema.prisma` 의 `model Diagnosis` 신규 작성** — 4/29 부트스트랩 시 이미 정의됨 (사용자 가드). `status` / `mode` 는 SQLite enum 미지원으로 `String + 주석` 패턴. `addressA` / `addressB` 컬럼 존재 (명세 v1.0 누락분 — Q2 현실 추인).
+    - **`model CandidateArea` 별도 테이블** — Q1 결정: 현실 추인 JSON embed 보존 (`Diagnosis.candidates String @default("[]")` JSON array). 정규화 = **INFRA-002 후 + CMD-DIAG-003 스코어링 엔진 도입 시점 재평가**.
+    - **`DiagnosisStatus` / `ServiceMode` Prisma enum 정의** — SQLite native enum 미지원. 본 ISSUE 는 TS union 으로 대체 (`DiagnosisStatusType` Phase B 산출물, `ServiceModeType` 은 DB-002 `user.ts` 재사용). 실 Prisma enum 강제 = **INFRA-002 위임**.
+    - **신규 마이그레이션 (`add_diagnosis_and_candidate_area`)** — 4/29 `_init` migration 의 `diagnoses` / `share_links` 테이블 이미 존재. 사용자 가드.
+    - **`prisma/seed.ts` Diagnosis + CandidateArea 시드 추가** — 4/29 seed.ts 보존, 본 ISSUE 미수정 (DB-001 §3.9 / DB-002 §3.9 가드 일관 + `tsx` 부재 + Q1 결정으로 `candidates: { create: [...] }` nested write mismatch).
+    - **`src/lib/mappers/diagnosis-mapper.ts`** — 현 `src/lib/db.ts` 가 in-memory fake → Prisma Diagnosis 타입 부재 → mapper 매핑 대상 없음. INFRA-002 swap 후 재평가.
+    - **`__tests__/db/diagnosis-schema.spec.ts`** — `vitest.config.ts` 부재 + in-memory fake 검증 무의미. 명세 §3.10 의 8 spec 케이스가 Q1~Q5 결정으로 8 / 8 무의미. **TEST-* 위임 (DB-001/002 §3.10 일관)**.
+    - **`CandidateAreaDTO` / `CommuteInfoDTO` / `DiagnosisDTO` 등 DTO** — Q1 = Q6 핵심 경계 결정: **DB-003 = base type 만, DTO = API-002 영역**. diagnosis.ts 에 DTO 작성 절대 금지. API-002 가 본 파일에 append 예정 (§3.13 참조).
+    - **password / password_hash / salt 컬럼** — OAuth-only, 절대 금지 (양쪽 ISSUE 일관, ShareLink 의 `passwordHash` 는 별도 모델 정상 필드 — 본 AC 범위 외).
 - **복잡도:** M
 - **Wave:** 1 (Data Foundation 트랙)
 
@@ -26,219 +35,284 @@ assignees: []
 - **REQ-FUNC-003** (§4.1.1): "시스템은 두 직장 주소를 기반으로 교집합 후보 동네를 3곳 이상 산출하고, 지도 위에 시각화해야 한다."
 - **REQ-FUNC-004** (§4.1.1): "시스템은 각 후보 동네를 탭했을 때 양쪽 직장까지의 예상 출퇴근 시간(대중교통·자차)을 표시해야 한다."
 - **REQ-FUNC-008** (§4.1.1): "시스템은 두 직장 간 거리로 인해 교집합 후보가 0곳인 경우 ... 조건 완화 제안을 2개 이상 제공해야 한다."
-- **REQ-NF-001** (§4.2.1): "두 동선 교차 계산 응답 시간 — p95 ≤ 8,000ms (클라이언트 API 콜 기준)"
+- **REQ-FUNC-011** (§4.1.2): "시스템은 진단 결과에 대한 배우자 공유 링크와 무료 미리보기를 제공해야 한다." — Q5 결정 (Diagnosis ↔ ShareLink 1:0..1) 의 도메인 근거
+- **REQ-FUNC-021** (§4.1.4): "싱글 모드에서 학군 항목을 숨기고 야간 치안 레이어를 기본 활성화한다." — Q2 결정 (`addressB nullable single 용`) 의 도메인 근거
+- **REQ-NF-001** (§4.2.1): "두 동선 교차 계산 응답 시간 — p95 ≤ 8,000ms (클라이언트 API 콜 기준)" — Q3 결정 (status default `'completed'`) 의 동기 처리 정합 근거
 - **REQ-NF-035** (§4.2.6): "에러 로그 알림 — Sentry 기본 알림 설정 사용"
+- **CON-11** (§1.2.3): "데이터베이스는 Prisma ORM + SQLite(로컬 개발) / Supabase PostgreSQL(프로덕션)을 사용한다." — Q1/Q3/Q4/Q6 결정 (SQLite enum/JSONB 미지원 → INFRA-002 위임) 근거
 
-### ERD §6.2.2 DIAGNOSIS 컬럼
+### `prototypes/design/CLAUDE.md` §3 (1인 MVP 제약) 인용
 
-| 필드명 | 타입 | 제약조건 | 설명 |
-|---|---|---|---|
-| `id` | UUID | PK, NOT NULL | 진단 고유 식별자 |
-| `user_id` | UUID | FK → USER.id, NOT NULL | 진단 수행 사용자 |
-| `deadline` | DATE | NULLABLE | 이사 마감 기한 |
-| `status` | ENUM('processing','completed','expired') | NOT NULL, DEFAULT 'processing' | 진단 상태 |
-| `filters` | JSONB | NOT NULL | 적용된 필터 조건 |
-| `mode` | ENUM('couple','single') | NOT NULL | 진단 모드 |
-| `deadline_mode` | BOOLEAN | NOT NULL, DEFAULT FALSE | 데드라인 모드 여부 |
-| `created_at` | TIMESTAMP | NOT NULL, DEFAULT NOW() | 생성일시 |
+> "**Vercel Serverless Timeout = 10초** (REQ-FUNC-003): 외부 API 반복 호출·교차 연산은 Server Action 이 아닌 Client Component 의 `Promise.all` 으로 처리. Server Action 은 Geocoding·커버리지 검증·**저장만** 담당."
 
-### API-002 CandidateAreaDTO (정합성 대상)
+→ Q3 결정 근거: 진단 계산 = 클라이언트 동기 처리 → 저장 시점 = 결과 완료 시점 → `status @default("completed")` 도메인적으로 정확.
 
-```typescript
-// lib/types/diagnosis.ts (API-002 정의)
-export interface CandidateAreaDTO {
-  id: string;
-  name: string;                   // 행정동 이름
-  coord: { lat: number; lng: number };
-  commuteA: CommuteInfoDTO;       // 직장A까지
-  commuteB: CommuteInfoDTO;       // 직장B까지
-  score: number;                  // 종합 스코어
-  rank: number;
-}
-export interface CommuteInfoDTO {
-  durationMinutes: number;
-  transportType: 'transit' | 'car';
-  transfers: number;
-  walkingMinutes: number;
-}
+### ERD 컬럼 vs 현 schema.prisma (§6.2.2 DIAGNOSIS — 현실 추인)
+
+| 필드명 | SRS 정의 | 현 schema.prisma (4/29 산출물) | Q | 정합성 |
+|---|---|---|---|---|
+| `id` | UUID PK, NOT NULL | `String @id @default(uuid())` | — | ✅ TS string, UUID 자동 생성 (명세 v1.0 `cuid()` 가정 → 현실 추인 `uuid()`, User 와 일관) |
+| `user_id` | UUID FK → USER.id, NOT NULL | `userId String @map("user_id")` | — | ✅ |
+| `address_a` | (명세 v1.0 누락) | `addressA String @map("address_a")` NOT NULL | **Q2** | ⚠️ 현실 추인 — REQ-FUNC-003 입력값 보존. SRS ERD §6.2.2 보완은 별도 ISSUE 위임 (§9.5) |
+| `address_b` | (명세 v1.0 누락) | `addressB String? @map("address_b") // nullable for single mode` | **Q2** | ⚠️ 현실 추인 — REQ-FUNC-021 싱글 모드 호환 |
+| `deadline` | DATE NULLABLE | `DateTime?` (timestamp) | — | ⚠️ Postgres `@db.Date` 미적용 (SQLite TIMESTAMP). INFRA-002 후 |
+| `status` | ENUM('processing','completed','expired') DEFAULT 'processing' | `String @default("completed") // processing \| completed \| expired` | **Q3** | ⚠️ **현실 추인 default `'completed'`** (동기 처리 정합). enum 가능값 3종 주석 보존 → TS union (`DiagnosisStatusType`) 으로 좁힘 |
+| `filters` | JSONB NOT NULL | `String @default("{}") // JSON string (SQLite has no JSONB)` | **Q1** | ⚠️ SQLite JSONB 미지원 → String + JSON.stringify 패턴. INFRA-002 후 |
+| `mode` | ENUM('couple','single') NOT NULL | `String @default("couple") // couple \| single` | **Q6** | ⚠️ DB-002 `ServiceModeType` union 재사용 (diagnosis.ts 에서 재정의 금지) |
+| `deadline_mode` | BOOLEAN DEFAULT FALSE | `Boolean @default(false) @map("deadline_mode")` | — | ✅ |
+| `created_at` | TIMESTAMP DEFAULT NOW() | `DateTime @default(now()) @map("created_at")` | — | ✅ |
+| `candidates` (현실 추가) | (명세는 별도 CandidateArea 모델) | `String @default("[]") // JSON string array of CandidateArea` | **Q1** | ⚠️ **현실 추인 JSON embed** — CandidateArea 별도 테이블 미생성. INFRA-002 + CMD-DIAG-003 후 정규화 재평가 |
+| 관계: User | (FK) | `user User @relation(fields:[userId], references:[id], onDelete: Cascade)` | — | ✅ |
+| 관계: ShareLink | `shareLinks ShareLink[]` (1:N 가정) | `shareLink ShareLink?` (단수) | **Q5** | ⚠️ **현실 추인 1:0..1** — `ShareLink.diagnosisId @unique` 강제. 채널별 분리 시 1:N 재평가 (§9.4) |
+| 복합 인덱스 | `@@index([userId, createdAt(sort: Desc)])` | `@@index([userId])` 단일 | **Q4** | ⚠️ 현실 추인 단일. INFRA-002 후 복합 인덱스 추가 (AC-5 ⏸) |
+| `password` 류 | ❌ | ❌ User 모델 0건 | — | ✅ OAuth-only (DB-002 일관) |
+
+### 4/29 `_init` migration 의 diagnoses / share_links 테이블 검증
+
+```sql
+-- prisma/migrations/20260429125124_init/migration.sql (4/29 산출물, 본 ISSUE 미수정)
+
+CREATE TABLE "diagnoses" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "user_id" TEXT NOT NULL,
+    "address_a" TEXT NOT NULL,                          -- Q2 현실 추인
+    "address_b" TEXT,                                   -- Q2 현실 추인 (nullable)
+    "filters" TEXT NOT NULL DEFAULT '{}',               -- Q1 SQLite JSON string
+    "candidates" TEXT NOT NULL DEFAULT '[]',            -- Q1 JSON array embed
+    "mode" TEXT NOT NULL DEFAULT 'couple',
+    "deadline_mode" BOOLEAN NOT NULL DEFAULT false,
+    "deadline" DATETIME,
+    "status" TEXT NOT NULL DEFAULT 'completed',         -- Q3 동기 처리 정합
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "diagnoses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE INDEX "diagnoses_user_id_idx" ON "diagnoses"("user_id");   -- Q4 단일 인덱스
+
+CREATE TABLE "share_links" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "diagnosis_id" TEXT NOT NULL,
+    "unique_url" TEXT NOT NULL,
+    "password_hash" TEXT,                                -- 별도 모델 정상 필드 (User 모델 아님)
+    "view_count" INTEGER NOT NULL DEFAULT 0,
+    "free_preview_used" BOOLEAN NOT NULL DEFAULT false,
+    "expires_at" DATETIME NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "share_links_diagnosis_id_fkey" FOREIGN KEY ("diagnosis_id") REFERENCES "diagnoses" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX "share_links_diagnosis_id_key" ON "share_links"("diagnosis_id");  -- Q5 1:0..1 강제
+CREATE UNIQUE INDEX "share_links_unique_url_key" ON "share_links"("unique_url");      -- UUID v4 unique
 ```
+
+- ✅ Q1~Q5 결정과 migration 정합 모두 입증
+- ✅ User 모델 password 컬럼 0건 (DB-002 AC-6 일관)
+- ⚠️ CandidateArea 테이블 부재 (Q1 결정) → 명세 §6.2.2 의 `candidate_areas` 테이블 가정은 INFRA-002 + CMD-DIAG-003 후 재평가
+
+### API-002 CandidateAreaDTO — ⏸ Q6 경계 + API-002 위임
+
+명세 v1.0 §2 References 의 `CandidateAreaDTO` / `CommuteInfoDTO` / `DiagnosisDTO` 정의는 **`lib/types/diagnosis.ts` 에 API-002 ISSUE 가 append 예정** (Phase B 산출물의 헤더 주석 (3) 명시). 본 ISSUE 는 `DiagnosisStatusType` union 1개 + 헤더 주석 4종만 작성. **DTO 정의는 API-002 영역, DB-003 책임 외 — Q1 = Q6 핵심 경계.**
 
 ### 선행 태스크 산출물
 
 | 선행 Task ID | 제공 산출물 | import 경로 | 본 태스크에서의 사용처 |
 |---|---|---|---|
-| DB-002 | `model User` (Prisma) | `prisma/schema.prisma` | Diagnosis.userId FK 대상 |
-| API-002 | CandidateAreaDTO, DiagnosisDTO, CommuteInfoDTO | `@/lib/types/diagnosis` | Prisma 모델 ↔ DTO 1:1 매칭 검증 |
+| **DB-002** (PR #76 머지 완료, main `d916a6f`) | `model User` (Prisma) + `src/lib/types/user.ts` (UserDTO + AuthProviderType + **ServiceModeType union 재사용 대상**) | `@/lib/types/user` | Diagnosis.userId FK 대상 + Diagnosis.mode TS 타입은 `ServiceModeType` 재사용 (diagnosis.ts 에서 재정의 금지) |
+| API-002 | (후속 — `DiagnosisDTO`, `CandidateAreaDTO`, `CommuteInfoDTO` 등 DTO) | `@/lib/types/diagnosis` (append) | 본 ISSUE 의 diagnosis.ts 에 DTO append 예정 — 단일 파일 진입점 |
+
+### 후행 ISSUE 정합성 (현실 추인 패턴 예고)
+
+| 후행 ISSUE | 영향 | Q 결정 |
+|---|---|---|
+| DB-004 (SHARE_LINK 스키마) | `diagnosisId @unique` 1:0..1 일관 답습 예정 | Q5 |
+| DB-006 (SAVED_SEARCH 스키마) | User FK + 단일 인덱스 패턴 답습 | Q4 |
+| DB-007 (Supabase Auth 연동) | INFRA-002 + auth.users FK 정렬 | INFRA-002 |
+| API-002 (Diagnosis DTO) | `lib/types/diagnosis.ts` 에 DTO append + `ServiceModeType` import 패턴 | **Q6 경계 협업** |
+| CMD-DIAG-004 (saveDiagnosisResult) | in-memory fake `prisma.diagnosis.create` 미지원 영역 → INFRA-002 후 활성화 | Q1 |
+| QRY-DIAG-001 (GET /api/diagnosis/[id]) | 동일 — in-memory fake `prisma.diagnosis.findUnique` 한계 | Q1 |
+| CMD-DL-001 (데드라인 모드) | `deadlineMode` Boolean 활용 (이미 schema) | — |
+| CMD-SINGLE-001 (싱글 모드) | `mode='single'` + `addressB` nullable 활용 (이미 schema) | Q2 |
+| MOCK-001 (Diagnosis Mock 데이터) | candidates JSON string 패턴 일관 | Q1 |
 
 ---
 
 ## 3. 🛠️ Task Breakdown (실행 체크리스트)
 
-- [ ] **3.1** `prisma/schema.prisma`에 `DiagnosisStatus` enum 정의
-  ```prisma
-  enum DiagnosisStatus {
-    processing
-    completed
-    expired
-  }
-  ```
+- [⏸ INFRA-002 위임] **3.1** `prisma/schema.prisma` 에 `DiagnosisStatus` enum 정의
+  > **현실 추인 (Q3):** SQLite native enum 미지원으로 4/29 schema 가 `status String @default("completed") // processing | completed | expired` 패턴 채택. 본 ISSUE 는 TS union (`DiagnosisStatusType = 'processing' | 'completed' | 'expired'`) 으로 대체 (§3.13 참조).
+  > 실 Prisma enum 강제 = **INFRA-002 위임** (Postgres swap 시점에 `enum DiagnosisStatus { processing completed expired }` 정의 + schema 갱신).
 
-- [ ] **3.2** `prisma/schema.prisma`에 `ServiceMode` enum 정의
-  ```prisma
-  enum ServiceMode {
-    couple
-    single
-  }
-  ```
+- [⏸ INFRA-002 위임] **3.2** `prisma/schema.prisma` 에 `ServiceMode` enum 정의
+  > **DB-002 §3.2 일관 (Q6):** DB-002 의 `ServiceMode` enum 정의도 INFRA-002 위임 상태. Diagnosis.mode 도 동일 사유 + 동일 대체 패턴. **TS 레벨에서는 DB-002 `user.ts` 의 `ServiceModeType` 재사용** (diagnosis.ts 에서 재정의 금지 — Q6 핵심 경계).
 
-- [ ] **3.3** `prisma/schema.prisma`에 `Diagnosis` 모델 정의
+- [x] **3.3** `prisma/schema.prisma` 에 `Diagnosis` 모델 정의 — **4/29 산출물 보존 (사용자 가드)**
+  > 현 schema.prisma `model Diagnosis` (L24–42, 본 ISSUE 미수정):
   ```prisma
   model Diagnosis {
-    id           String           @id @default(cuid())
-    userId       String           @map("user_id")
-    deadline     DateTime?        @db.Date
-    status       DiagnosisStatus  @default(processing)
-    filters      Json             @db.JsonB
-    mode         ServiceMode
-    deadlineMode Boolean          @default(false) @map("deadline_mode")
-    createdAt    DateTime         @default(now()) @map("created_at")
+    id           String   @id @default(uuid())
+    userId       String   @map("user_id")
+    addressA     String   @map("address_a")              // Q2 현실 추인 (NOT NULL)
+    addressB     String?  @map("address_b") // nullable for single mode  // Q2 현실 추인
+    filters      String   @default("{}") // JSON string (SQLite has no JSONB)  // Q1 String JSON 패턴
+    candidates   String   @default("[]") // JSON string array of CandidateArea  // Q1 JSON embed (CandidateArea 모델 미존재)
+    mode         String   @default("couple") // couple | single             // Q6 ServiceModeType (user.ts) 재사용
+    deadlineMode Boolean  @default(false) @map("deadline_mode")
+    deadline     DateTime? // nullable, for deadline mode
+    status       String   @default("completed") // processing | completed | expired  // Q3 동기 처리 정합
+    createdAt    DateTime @default(now()) @map("created_at")
 
-    user         User             @relation(fields: [userId], references: [id], onDelete: Cascade)
-    candidates   CandidateArea[]
-    shareLinks   ShareLink[]
+    user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+    shareLink ShareLink?       // Q5 1:0..1 (ShareLink.diagnosisId @unique 강제)
 
-    @@index([userId, createdAt(sort: Desc)])
+    @@index([userId])  // Q4 단일 인덱스 (복합 인덱스 = INFRA-002 후 AC-5 ⏸)
     @@map("diagnoses")
   }
   ```
+  > **명세 v1.0 가정과 차이 8건 (현실 추인 — ★ Q1~Q5 결정 반영):**
+  > 1. `id` 기본값: `cuid()` → `uuid()` (User 와 일관)
+  > 2. **`addressA` / `addressB` 컬럼 추가 (Q2)** — 명세 v1.0 누락분, REQ-FUNC-003 + REQ-FUNC-021 도메인 정합. SRS ERD §6.2.2 보완은 별도 ISSUE 위임 (§9.5).
+  > 3. **`filters` 타입 (Q1 동일 로직)**: `Json @db.JsonB` → `String + JSON string` (SQLite JSONB 미지원). INFRA-002 후 Postgres JSONB 전환.
+  > 4. **`candidates` 컬럼 (Q1)**: 명세 v1.0 의 별도 `CandidateArea` 모델 → 현실 추인 `String @default("[]")` JSON array embed. CandidateArea 별도 테이블 미생성. INFRA-002 + CMD-DIAG-003 후 정규화 재평가 (§9.1).
+  > 5. **`status` 기본값 (Q3)**: `'processing'` → `'completed'` (동기 처리 정합 — Vercel 10s + Server Action 저장만 담당). 비동기 큐 도입 시 'processing' 재평가 (§9.2).
+  > 6. **`mode` / `status` TS 타입 (Q6)**: Prisma enum → String + 주석 + TS union 대체. `DiagnosisStatusType` Phase B 산출물 (§3.13), `ServiceModeType` DB-002 user.ts 재사용.
+  > 7. **`@@index` (Q4)**: 복합 `@@index([userId, createdAt(sort: Desc)])` → 단일 `@@index([userId])`. INFRA-002 후 복합 인덱스 추가 (AC-5 ⏸).
+  > 8. **`shareLink` 카디널리티 (Q5)**: `shareLinks ShareLink[]` (1:N) → `shareLink ShareLink?` (1:0..1, `ShareLink.diagnosisId @unique` 강제). 채널별 분리 시 1:N 재평가 (§9.4).
 
-- [ ] **3.4** `prisma/schema.prisma`에 `CandidateArea` 모델 정의 (별도 테이블)
-  ```prisma
-  model CandidateArea {
-    id            String    @id @default(cuid())
-    diagnosisId   String    @map("diagnosis_id")
-    name          String                          // 행정동 이름
-    coordLat      Float     @map("coord_lat")
-    coordLng      Float     @map("coord_lng")
-    commuteAJson  Json      @map("commute_a_json") @db.JsonB  // CommuteInfoDTO 직렬화
-    commuteBJson  Json      @map("commute_b_json") @db.JsonB  // CommuteInfoDTO 직렬화
-    score         Float     @default(0)
-    rank          Int       @default(0)
-    createdAt     DateTime  @default(now()) @map("created_at")
+- [⏸ INFRA-002 후 + CMD-DIAG-003 재평가] **3.4** `prisma/schema.prisma` 에 `CandidateArea` 모델 정의 (별도 테이블)
+  > **Q1 결정 (★ 핵심):** 현실 추인 — `Diagnosis.candidates String @default("[]")` JSON array embed 패턴 보존. CandidateArea 별도 모델 미생성.
+  > **사유:**
+  > - SQLite JSONB 미지원 + in-memory fake 환경에서 정규화 효과 0
+  > - 현 `src/lib/db.ts` 의 fake API 가 candidates 를 JSON string 으로 다루는 인터페이스 보존 → 후행 mock 라우트 호환성 유지
+  > - 정규화는 **INFRA-002 (Postgres swap) + CMD-DIAG-003 (스코어링 엔진 도입 시점)** 에서 자연스러움 (인덱스 + score/rank 컬럼 추가 가치 발생)
+  > **§9.1 follow-up 트리거 기록**.
 
-    diagnosis     Diagnosis @relation(fields: [diagnosisId], references: [id], onDelete: Cascade)
+- [x] **3.5** `User` 모델에 `Diagnosis` 관계 추가 (DB-002 확장) — **이미 활성 (DB-002 PR #76)**
+  > 현 schema.prisma 의 `model User` (DB-002 산출물 검증됨):
+  > - `diagnoses Diagnosis[]` 관계 필드 활성 상태
+  > - DB-002 §3.3 명세 갱신 시 "관계 필드 활성화 상태 유지 (주석 처리 아님)" 명시됨
+  > - 본 ISSUE 신규 작업 없음. Phase A 에서 main HEAD `d916a6f` (PR #76 머지본) 검증으로 확정.
 
-    @@index([diagnosisId, rank])
-    @@map("candidate_areas")
-  }
-  ```
+- [x] **3.6** 마이그레이션 실행 — **4/29 `_init` 산출물 보존**
+  > 4/29 `_init` migration 이 이미 `diagnoses` + `share_links` 테이블 생성 포함. 본 ISSUE 신규 migration 미생성 (사용자 가드).
+  > 확인 항목 (§2 migration SQL 인용 참조):
+  > - ✅ `diagnoses` 테이블 생성 (CREATE TABLE)
+  > - ✅ `id` PK + `email`/`unique_url` UNIQUE INDEX
+  > - ✅ Q1~Q5 결정 모두 migration SQL 과 정합 (addressA/B / filters String / candidates / status default / 단일 인덱스 / share_links.diagnosis_id @unique)
+  > - ✅ FK CASCADE (diagnoses_user_id_fkey, share_links_diagnosis_id_fkey)
+  > - ✅ `password` 컬럼 0건 (User 모델 — DB-002 AC-6 일관)
 
-- [ ] **3.5** `User` 모델에 `Diagnosis` 관계 추가 (DB-002 확장)
-  ```prisma
-  // model User에 추가
-  diagnoses Diagnosis[]
-  ```
+- [x] **3.7** Prisma Client 재생성 — **Phase A 통과**
+  > Phase A.7-2: `npx prisma generate` exit 0, `Generated Prisma Client (7.8.0) to ./src/generated/prisma`.
 
-- [ ] **3.6** 마이그레이션 실행
-  - 명령어: `npx prisma migrate dev --name add_diagnosis_and_candidate_area`
-  - 생성 파일: `prisma/migrations/{timestamp}_add_diagnosis_and_candidate_area/migration.sql`
+- [⏸ INFRA-002 후] **3.8** 마이그레이션 dry-run 검증 — `npx prisma migrate diff` drift 0건
+  > **사유:** Q1 결정으로 CandidateArea 모델 미생성 + Q4 결정으로 복합 인덱스 미생성 → 본 ISSUE 단계의 schema 와 명세 v1.0 가정 간 drift 는 의도된 차이. 명세 v1.0 의 dry-run 가정은 INFRA-002 + Q1 정규화 + Q4 복합 인덱스 추가 시점에 의미 발생.
 
-- [ ] **3.7** Prisma Client 재생성
-  - 명령어: `npx prisma generate`
+- [⏸ skip] **3.9** `prisma/seed.ts` 에 Diagnosis + CandidateArea 시드 추가 — **seed.ts 가드 일관 + Q1 mismatch**
+  > **Q8 결정. 이유 (DB-001/002 §3.9 일관 + 추가 Q1 mismatch):**
+  > 1. 4/29 seed.ts 의 `test@onday.kr` upsert 패턴 보존 (DB-001 Q4 + DB-002 §3.9 가드)
+  > 2. `tsx` 가 onday-app/node_modules 부재 (Phase A.6 재확인) — 실 seed 실행 자체 보류
+  > 3. **Q1 mismatch:** 명세 §3.9 시드의 `candidates: { create: [...] }` nested write 가 Q1 결정 (CandidateArea 모델 미존재) 과 schema 차원 충돌. 본 ISSUE 단계에서 추가 시 (a) CandidateArea 부분 제거 + (b) candidates 를 JSON.stringify 직렬화 + (c) addressA/B 추가 (Q2) + (d) filters JSON.stringify 등 대규모 변형 필요 → 가드 모순
+  > 4. 실 seed 실행 결정은 **INFRA-002 후 + Q1 (CandidateArea 정규화) 재평가 + seed runner 결정 (tsx 설치 / Prisma 7 자체 TS runner / .js 사전 컴파일) 함께** (§9.9)
 
-- [ ] **3.8** 마이그레이션 dry-run 검증
-  - 명령어: `npx prisma migrate diff --from-schema-datamodel prisma/schema.prisma --to-migrations prisma/migrations --shadow-database-url "file:./shadow.db"`
-  - drift 0건 확인
+- [⏸ TEST-* 위임] **3.10** `__tests__/db/diagnosis-schema.spec.ts` — 스키마 검증 8 케이스
+  > **Q7 결정. 이유 (DB-001 §3.10 + DB-002 §3.10 일관 + Q1~Q5 결정 mismatch):**
+  > 1. `vitest.config.ts` 부재 (Phase A.6 재확인) → spec 작성해도 실행 불가
+  > 2. 현 `src/lib/db.ts` 가 in-memory fake → spec 검증 meaningless
+  > 3. TEST-* 시점에 vitest config + 모든 ISSUE 의 spec 일괄 작성이 자연스러움
+  > 4. 본 ISSUE 검증은 (a) Phase A/B/D CLI (`prisma validate` / `generate` / `tsc --noEmit` / env-less `npm run build`) + (b) §2 migration SQL 정합 read-only + (c) Phase D grep password 로 충족
+  > **★ 명세 §3.10 의 8 spec 케이스가 Q1~Q5 결정으로 8 / 8 무의미 — TEST-* 위임 사유 강화:**
+  >
+  > | 명세 §3.10 케이스 | 검증 대상 | Q1~Q5 결정으로 본 ISSUE 단계 실효성 |
+  > |---|---|---|
+  > | 1. status 기본값 `'processing'` | Diagnosis.status default | ❌ Q3 결정으로 `'completed'` — spec 자체 수정 필요 |
+  > | 2. CandidateArea FK 연결 | CandidateArea 존재 | ❌ Q1 결정 — 모델 미존재 |
+  > | 3. User 삭제 → Diagnosis CASCADE | 실 PrismaClient CASCADE | ❌ in-memory fake 미지원 |
+  > | 4. Diagnosis 삭제 → CandidateArea CASCADE | CandidateArea + CASCADE | ❌ Q1 결정 — 모델 미존재 |
+  > | 5. filters JSONB 구조 저장 | `@db.JsonB` 컬럼 | ❌ SQLite JSONB 미지원 (Q1 동일) |
+  > | 6. commuteAJson JSONB | CandidateArea + JSONB | ❌ Q1 결정 — 모델 미존재 |
+  > | 7. `@@index([userId, createdAt])` | 복합 인덱스 | ❌ Q4 결정 — 단일 인덱스 |
+  > | 8. `@@index([diagnosisId, rank])` | CandidateArea 인덱스 | ❌ Q1 결정 — 모델 미존재 |
+  >
+  > **단, `__tests__/db/.gitkeep` 빈 디렉토리는 보존** — INFRA-001 산출물 (`dc2ca37`), TEST-* 시점에 spec 추가될 위치.
 
-- [ ] **3.9** `prisma/seed.ts`에 테스트용 Diagnosis + CandidateArea 시드 데이터 추가
+- [⏸ Q1 + API-002 위임] **3.11** CandidateAreaDTO ↔ Prisma CandidateArea 1:1 매칭 매트릭스
+  > **Q1 결정으로 CandidateArea 모델 미존재** → 본 ISSUE 단계에서 매핑 매트릭스 작성 불가능.
+  > **`CandidateAreaDTO` 자체는 API-002 산출물 (Q6 핵심 경계)** — DB-003 책임 외. API-002 ISSUE 가 `lib/types/diagnosis.ts` 에 append 시 매트릭스 정합 검증 수행.
+  > INFRA-002 + Q1 정규화 + API-002 작업 동시 활성화 시점에 본 매트릭스 의미 발생.
+
+- [⏸ INFRA-002] **3.12** Supabase 프로덕션 마이그레이션 SQL 확인
+  > Postgres 환경에서 `@db.JsonB` / `@db.Date` / `@db.Uuid` 어노테이션 + RLS + FK 검증. INFRA-002 swap 시점 통합 작업.
+
+- [x] **3.13** ★ **`src/lib/types/diagnosis.ts` — Phase B 산출물 (본 ISSUE 핵심)**
+  > 신규 작성 6줄 (헤더 주석 4종 + 빈줄 + export 1개). TS union 으로 schema 의 `String` 컬럼을 좁혀 타입 안전성 제공.
   ```typescript
-  const diagnosis = await prisma.diagnosis.create({
-    data: {
-      userId: testUser.id,
-      status: 'completed',
-      filters: { maxCommuteTime: 60, budgetMin: 5000, budgetMax: 15000 },
-      mode: 'couple',
-      deadlineMode: false,
-      candidates: {
-        create: [
-          { name: '합정동', coordLat: 37.5496, coordLng: 126.9139, commuteAJson: { durationMinutes: 35, transportType: 'transit', transfers: 1, walkingMinutes: 8 }, commuteBJson: { durationMinutes: 28, transportType: 'transit', transfers: 0, walkingMinutes: 10 }, score: 85, rank: 1 },
-          { name: '상수동', coordLat: 37.5477, coordLng: 126.9227, commuteAJson: { durationMinutes: 33, transportType: 'transit', transfers: 1, walkingMinutes: 7 }, commuteBJson: { durationMinutes: 30, transportType: 'transit', transfers: 1, walkingMinutes: 9 }, score: 80, rank: 2 },
-          { name: '연남동', coordLat: 37.5660, coordLng: 126.9246, commuteAJson: { durationMinutes: 38, transportType: 'transit', transfers: 1, walkingMinutes: 10 }, commuteBJson: { durationMinutes: 25, transportType: 'transit', transfers: 0, walkingMinutes: 6 }, score: 78, rank: 3 },
-        ],
-      },
-    },
-  });
+  // schema.prisma 의 status 는 SQLite enum 미지원으로 String 타입 (// processing | completed | expired 주석으로 가능값 명시).
+  // 본 파일은 TS union 으로 좁혀 타입 안전성 제공. 실 Prisma enum 강제는 INFRA-002 시점 (Postgres swap).
+  // 본 파일은 DIAGNOSIS 도메인 단일 진입점 — 후속 API-002 가 DiagnosisDTO / CandidateAreaDTO / CommuteInfoDTO 등 DTO 를 본 파일에 append 예정.
+  // mode 는 user.ts 의 ServiceModeType 재사용 — diagnosis.ts 에서 재정의 금지. API-002 가 DTO 정의 시 `import { ServiceModeType } from './user'` 패턴 사용.
+
+  export type DiagnosisStatusType = 'processing' | 'completed' | 'expired';
   ```
+  > **WHY (헤더 주석 4종 명시):**
+  > 1. schema 가 `String` 인 이유: SQLite enum 미지원 (Q3)
+  > 2. 실 Prisma enum 강제 = INFRA-002 시점 (Postgres swap) (Q3/Q6)
+  > 3. DIAGNOSIS 도메인 단일 진입점 — 후속 API-002 가 `DiagnosisDTO` / `CandidateAreaDTO` / `CommuteInfoDTO` 등 DTO 를 본 파일에 append 예정 (Q1 = Q6 핵심 경계)
+  > 4. `mode` 는 user.ts 의 `ServiceModeType` 재사용 — diagnosis.ts 에서 재정의 금지 + API-002 가 DTO 정의 시 `import { ServiceModeType } from './user'` 패턴 (Q6)
+  >
+  > **★ 절대 금지 (Q1 = Q6 경계):**
+  > - `CandidateAreaDTO` / `CommuteInfoDTO` / `DiagnosisDTO` 등 모든 DTO 작성 금지 — API-002 영역
+  > - `ServiceModeType` 재정의 금지 (user.ts 재사용)
+  > - `DiagnosisStatusType` union 1개 + 헤더 주석 외 어떤 export 도 추가 금지
+  >
+  > **path alias:** tsconfig.json `"@/*": ["./src/*"]` → `import type { DiagnosisStatusType } from '@/lib/types/diagnosis'` 사용 가능 (후속 ISSUE).
+  > **검증:** `npx tsc --noEmit` exit 0 (Phase A 기준선 유지, 회귀 0).
 
-- [ ] **3.10** `__tests__/db/diagnosis-schema.spec.ts`에 스키마 검증 테스트
-  ```typescript
-  describe('Diagnosis + CandidateArea 스키마 검증', () => {
-    it('Diagnosis 생성 시 status 기본값이 processing', async () => { /* ... */ });
-    it('CandidateArea는 diagnosisId FK로 Diagnosis에 연결', async () => { /* ... */ });
-    it('User 삭제 시 관련 Diagnosis CASCADE 삭제', async () => { /* ... */ });
-    it('Diagnosis 삭제 시 관련 CandidateArea CASCADE 삭제', async () => { /* ... */ });
-    it('filters JSONB에 DiagnosisFilters 구조 저장 성공', async () => { /* ... */ });
-    it('commuteAJson JSONB에 CommuteInfoDTO 구조 저장 성공', async () => { /* ... */ });
-    it('@@index([userId, createdAt]) 인덱스가 적용됨', async () => { /* ... */ });
-    it('@@index([diagnosisId, rank]) 인덱스가 적용됨', async () => { /* ... */ });
-  });
-  ```
+### ★ Q1~Q8 결정 vs 명세 v1.0 mismatch 추적 표 (현실 추인 한눈 비교)
 
-- [ ] **3.11** CandidateAreaDTO ↔ Prisma CandidateArea 1:1 매칭 검증 매트릭스
-
-  | CandidateAreaDTO (API-002) | Prisma CandidateArea (DB-003) | 비고 |
-  |---|---|---|
-  | `id: string` | `id: String @id @default(cuid())` | ✅ |
-  | `name: string` | `name: String` | ✅ |
-  | `coord.lat` | `coordLat: Float` | JSONB 분해 → 개별 컬럼 |
-  | `coord.lng` | `coordLng: Float` | JSONB 분해 → 개별 컬럼 |
-  | `commuteA: CommuteInfoDTO` | `commuteAJson: Json @db.JsonB` | JSONB 직렬화 |
-  | `commuteB: CommuteInfoDTO` | `commuteBJson: Json @db.JsonB` | JSONB 직렬화 |
-  | `score: number` | `score: Float` | ✅ |
-  | `rank: number` | `rank: Int` | ✅ |
-
-- [ ] **3.12** Supabase 프로덕션 마이그레이션 SQL 확인
-  - `prisma/migrations/manual/` 디렉토리에 FK 및 인덱스 관련 수동 마이그레이션 SQL 필요 시 작성
-  - Supabase PostgreSQL에서 `@db.JsonB` 컬럼이 정상 동작하는지 확인
+| Q | 분기 | 명세 v1.0 가정 | 현실 (4/29 schema) | 결정 | 후속 트리거 |
+|---|---|---|---|---|---|
+| **Q1** ★ | CandidateArea 정규화 | 별도 `model CandidateArea` + `coordLat`/`coordLng`/`commuteAJson`/`commuteBJson` JSONB + 복합 인덱스 | `Diagnosis.candidates String @default("[]")` JSON array embed, CandidateArea 모델 부재 | (A) 현실 추인 JSON embed | INFRA-002 + CMD-DIAG-003 정규화 재평가 (§9.1) |
+| **Q2** | addressA / addressB | 명세 v1.0 에 없음 (filters JSONB 안에 포함 가정 가능) | `addressA String` NOT NULL + `addressB String?` nullable (single 용) | (A) 현실 추인 | SRS ERD §6.2.2 보완 별도 ISSUE (§9.5) |
+| **Q3** | status 기본값 | `'processing'` (비동기 큐 모델) | `'completed'` (동기 처리 모델 — Vercel 10s + Server Action 저장만 담당) | (C) 현실 추인 + §9 비동기 재평가 | INFRA-002 + 비동기 처리 ISSUE (§9.2) |
+| **Q4** | 복합 인덱스 | `@@index([userId, createdAt(sort: Desc)])` | `@@index([userId])` 단일 | (C) 현실 추인 + AC-5 ⏸ | INFRA-002 (AC-5 트리거, §9.3) |
+| **Q5** | Diagnosis ↔ ShareLink | `shareLinks ShareLink[]` (1:N) | `shareLink ShareLink?` (1:0..1) + `diagnosisId @unique` | (C) 현실 추인 + §9 1:N 재평가 | 베타 피드백 + INFRA-002 + SHARE_LINK ISSUE (§9.4) |
+| **Q6** ★ | TS 타입 신규 | 없음 (Prisma enum 직접 사용 가정) | DB-002 user.ts 패턴 — String + 주석 → TS union 으로 좁힘 | (B) `src/lib/types/diagnosis.ts` 신규 — DiagnosisStatusType union 만, DTO 는 API-002 영역 | API-002 ↔ DB-003 협업 (diagnosis.ts append, §9.8) |
+| **Q7** | spec | 8 케이스 spec 작성 | vitest config + in-memory fake 부재 — 8 / 8 무의미 | (A) TEST-* 위임 (DB-001/002 일관) | TEST-* (vitest config + spec 일괄, §9.7) |
+| **Q8** | seed.ts | Diagnosis + CandidateArea nested write | tsx 부재 + Q1 (CandidateArea 미존재) mismatch | (A) seed.ts 가드 보존 (DB-001/002 일관) | INFRA-002 + Q1 재평가 + seed runner 결정 (§9.9) |
 
 ---
 
-## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD — DB-002 ⏸ 패턴 일관)
 
-**AC-1 (정상):** 마이그레이션 dry-run 성공
-- **Given** `prisma/schema.prisma`에 Diagnosis + CandidateArea 모델이 정의된 상태
-- **When** `npx prisma migrate dev --name add_diagnosis_and_candidate_area` 실행
-- **Then** 마이그레이션 파일 생성 + SQLite DB에 테이블 생성, `npx prisma migrate diff` drift 0건
+**AC-1 (정상):** 마이그레이션 dry-run 성공 — **⏸ Q1 + INFRA-002 후 검증**
+- **Given** `prisma/schema.prisma` 의 Diagnosis 모델은 4/29 `_init` migration 으로 생성됨 (현실 추인). CandidateArea 모델은 Q1 결정으로 부재.
+- **When** 본 ISSUE 단계: `npm run db:validate` 실행
+- **Then** ✅ Phase A.7-1: `"valid 🚀"` 통과 (현 schema 자체는 valid). 명세 v1.0 의 `add_diagnosis_and_candidate_area` 신규 migration 가정은 본 ISSUE 미수행 (사용자 가드).
+- **⏸ INFRA-002 + Q1 정규화 시점**: CandidateArea 모델 추가 + `migrate diff` drift 0건 검증.
 
-**AC-2 (정상):** FK CASCADE 동작 검증 — User 삭제 시
-- **Given** User + Diagnosis + CandidateArea 3건이 연결된 상태
-- **When** `prisma.user.delete({ where: { id: userId } })` 실행
-- **Then** 관련 Diagnosis 전부 삭제, 관련 CandidateArea 전부 삭제, 잔여 레코드 0건
+**AC-2 (정상):** FK CASCADE 동작 검증 — User 삭제 시 — **⏸ INFRA-002 swap 후 검증**
+- Migration SQL 의 `CONSTRAINT "diagnoses_user_id_fkey" ... ON DELETE CASCADE` 로 DB 레벨 제약 보장 (§2 인용).
+- **⏸ 현 `src/lib/db.ts` 가 in-memory fake (`prisma.user.delete` CASCADE 미지원). 실 PrismaClient swap (INFRA-002) 후 검증 가능**.
 
-**AC-3 (정상):** FK CASCADE 동작 검증 — Diagnosis 삭제 시
-- **Given** Diagnosis + CandidateArea 3건이 연결된 상태
-- **When** `prisma.diagnosis.delete({ where: { id: diagnosisId } })` 실행
-- **Then** 관련 CandidateArea 전부 삭제, User는 영향 없음
+**AC-3 (정상):** FK CASCADE 동작 검증 — Diagnosis 삭제 시 — **⏸ Q1 + INFRA-002 후 검증**
+- Q1 결정으로 CandidateArea 모델 미존재 — Diagnosis 삭제 시 CASCADE 대상이 ShareLink (1:0..1, `share_links_diagnosis_id_fkey` ON DELETE CASCADE) 만.
+- **⏸ INFRA-002 + Q1 정규화 시점**: CandidateArea CASCADE 검증 추가.
 
-**AC-4 (경계):** JSONB 컬럼에 CommuteInfoDTO 구조 저장·조회
-- **Given** `commuteAJson`에 `{ durationMinutes: 35, transportType: 'transit', transfers: 1, walkingMinutes: 8 }` 저장
-- **When** `prisma.candidateArea.findFirst()` 조회
-- **Then** `commuteAJson` 필드가 원본 JSON과 동일, 타입 캐스팅 없이 JavaScript 객체로 접근 가능
+**AC-4 (경계):** JSONB 컬럼에 CommuteInfoDTO 구조 저장·조회 — **⏸ Q1 + INFRA-002 후 검증**
+- Q1 결정으로 SQLite `String + JSON.stringify` 패턴. Postgres `@db.JsonB` 미적용.
+- **⏸ INFRA-002 + Q1 정규화 + JSONB 컬럼 추가 후 검증**.
 
-**AC-5 (경계):** 복합 인덱스 적용 검증
-- **Given** 마이그레이션 완료 상태
-- **When** 생성된 SQL 파일에서 인덱스 구문 확인
-- **Then** `CREATE INDEX ... ON "diagnoses" ("user_id", "created_at" DESC)` 존재, `CREATE INDEX ... ON "candidate_areas" ("diagnosis_id", "rank")` 존재
+**AC-5 (경계):** 복합 인덱스 적용 검증 — **⏸ Q4 + INFRA-002 후 검증 (★ 명시적 트리거)**
+- Q4 결정으로 현 schema 는 `@@index([userId])` 단일. Migration SQL: `CREATE INDEX "diagnoses_user_id_idx" ON "diagnoses"("user_id")`.
+- **⏸ INFRA-002 swap 후 복합 인덱스 `@@index([userId, createdAt(sort: Desc)])` 추가 + `CREATE INDEX ... ON "diagnoses" ("user_id", "created_at" DESC)` 존재 검증** — AC-5 의 INFRA-002 트리거.
 
-**AC-6 (예외):** enum 유효성 — 잘못된 status 값 삽입 시도
-- **Given** Prisma Client가 `DiagnosisStatus` enum을 사용
-- **When** `status: 'invalid_status'` 로 create 시도
-- **Then** TypeScript 컴파일 에러 발생 (런타임 도달 전 차단)
+**AC-6 (예외):** enum 유효성 — 잘못된 status 값 삽입 시도 — **✅ TS union 충족 (Q6)**
+- **Given** `src/lib/types/diagnosis.ts` 의 `DiagnosisStatusType = 'processing' | 'completed' | 'expired'` union (Phase B 산출물)
+- **When** `status: 'invalid_status'` 로 객체 생성 시도
+- **Then** ✅ TypeScript 컴파일 에러 발생 — `'invalid_status'` is not assignable to `DiagnosisStatusType` (Phase B 검증 `tsc --noEmit` exit 0 으로 보장)
+- **단** schema 의 `status String` 자체는 DB 레벨에서 임의 문자열 허용. 실 Prisma enum 강제는 INFRA-002 swap 시점에 schema 갱신으로 추가 (§3.1).
 
-**AC-7 (정합성):** API-002 CandidateAreaDTO와 Prisma CandidateArea 1:1 매칭
-- **Given** API-002의 `CandidateAreaDTO` 필드 목록
-- **When** DB-003의 `CandidateArea` 모델 컬럼과 대조
-- **Then** 3.11 매칭 매트릭스의 모든 행이 ✅
+**AC-7 (정합성):** API-002 CandidateAreaDTO 와 Prisma CandidateArea 1:1 매칭 — **⏸ Q1 + API-002 위임**
+- Q1 결정으로 CandidateArea 모델 미존재 + Q6 결정으로 DTO 정의는 API-002 영역.
+- **⏸ INFRA-002 + Q1 정규화 + API-002 작업 (diagnosis.ts 에 DTO append) 동시 활성화 시점에 1:1 매칭 매트릭스 검증**.
 
 ---
 
@@ -246,52 +320,128 @@ export interface CommuteInfoDTO {
 
 | NFR ID | SRS 본문 인용 | 본 태스크에서의 검증 방법 |
 |---|---|---|
-| REQ-NF-001 | "두 동선 교차 계산 응답 시간 — p95 ≤ 8,000ms" (§4.2.1) | `@@index([userId, createdAt(sort: Desc)])` 인덱스로 사용자별 최근 진단 조회 최적화. `explain analyze`로 인덱스 활용 확인 |
-| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | DB 관련 에러 발생 시 Sentry 전달 가능한 구조 — 에러 타입에 테이블명, 작업명 포함 |
+| REQ-NF-001 | "두 동선 교차 계산 응답 시간 — p95 ≤ 8,000ms" (§4.2.1) | Q3 결정 근거 (동기 처리 정합 → `status @default("completed")`). 복합 인덱스 `@@index([userId, createdAt DESC])` 는 사용자별 최근 진단 조회 최적화 — **INFRA-002 후 (AC-5 ⏸)**. 본 ISSUE 단계는 in-memory fake 로 인덱스 실효성 0 |
+| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | INFRA-001 의 `next.config.ts` withSentryConfig silent skip 패턴 정합. DB 관련 에러 발생 시 Sentry 전달은 MON-001 시점 활성화 |
 
 ---
 
 ## 6. 📦 Deliverables (산출물 명시)
 
-- `prisma/schema.prisma` (Diagnosis + CandidateArea 모델, DiagnosisStatus + ServiceMode enum)
-- `prisma/migrations/{timestamp}_add_diagnosis_and_candidate_area/migration.sql`
-- `prisma/seed.ts` (테스트용 Diagnosis + CandidateArea 시드)
-- `__tests__/db/diagnosis-schema.spec.ts` (스키마 검증 8개 케이스)
+### DB-003 신규/수정 산출물 (본 ISSUE)
+- `onday-app/src/lib/types/diagnosis.ts` (신규 — DiagnosisStatusType union + 헤더 주석 4종, 6줄)
+- `tasks/DB-003.md` (본 문서 명세 갱신 — 현실 추인, Q1~Q8 결정 반영)
+
+### DB-003 에서 보존 (4/29 onday-app + INFRA-001 / DB-001 / DB-002 산출물, 본 ISSUE 미수정)
+- `onday-app/prisma/schema.prisma` (4/29, `model Diagnosis` + `model ShareLink` + 4모델 정의, sqlite 하드코딩, 단일 인덱스, 1:0..1 관계)
+- `onday-app/prisma/migrations/20260429125124_init/migration.sql` (4/29, `diagnoses` + `share_links` 테이블 포함)
+- `onday-app/prisma.config.ts` (4/29, Prisma 7 신 파일)
+- `onday-app/prisma/seed.ts` (4/29, PrismaBetterSqlite3 adapter — Q8 가드)
+- `onday-app/src/lib/db.ts` (5/3, in-memory store — ★ 사용자 가드 핵심, Q1/Q7 근거)
+- **`onday-app/src/lib/types/user.ts`** (DB-002 PR #76 산출물 — `ServiceModeType` 재사용 대상, Q6 경계)
+- `onday-app/src/lib/types/errors/.gitkeep` (INFRA-001 `dc2ca37` 산출물, `errors/` 서브디렉토리용)
+- `onday-app/__tests__/db/.gitkeep` (INFRA-001 빈 디렉토리, TEST-* 시점 spec 추가 위치)
+- `onday-app/package.json` / `.env` / `.env.example` / `.gitignore` (INFRA-001 + DB-001 정합)
+
+### DB-003 에서 위임 (후속 ISSUE)
+- `DiagnosisStatus` / `ServiceMode` Prisma enum 정의 → **INFRA-002** (Postgres swap 시점)
+- `model CandidateArea` (정규화) + JSONB 컬럼 → **INFRA-002 + CMD-DIAG-003** (스코어링 엔진 도입 시점 재평가)
+- 복합 인덱스 `@@index([userId, createdAt(sort: Desc)])` → **INFRA-002** (AC-5 트리거)
+- `src/lib/mappers/diagnosis-mapper.ts` → INFRA-002 후 재평가
+- `__tests__/db/diagnosis-schema.spec.ts` (8 케이스) → **TEST-*** (vitest config 부재 + 8/8 무의미)
+- `prisma/seed.ts` Diagnosis + CandidateArea 시드 실행 → INFRA-002 이후 + Q1 재평가 + seed runner 결정 함께
+- `CandidateAreaDTO` / `CommuteInfoDTO` / `DiagnosisDTO` 등 DTO → **API-002** (Q6 핵심 경계 — diagnosis.ts append 패턴)
 
 ---
 
 ## 7. 🔗 Dependencies (의존성 — 양방향)
 
-### 선행:
-- **DB-001:** Prisma 프로젝트 초기화 (`prisma/schema.prisma` datasource 설정)
-- **DB-002:** `model User` — Diagnosis.userId FK 대상
+### 선행 (이 태스크 시작 전 필요):
 
-### 후행:
-- **DB-004:** SHARE_LINK 테이블 — Diagnosis.id FK 참조
-- **API-002:** DiagnosisDTO, CandidateAreaDTO — Prisma 모델 기반 DTO 매핑 검증
-- **CMD-DIAG-004:** saveDiagnosisResult — Prisma Diagnosis + CandidateArea 동시 INSERT
-- **QRY-DIAG-001:** GET /api/diagnosis/[id] — Prisma include 조회
-- **CMD-DL-001:** 데드라인 모드 — Diagnosis.deadlineMode 활용
-- **MOCK-001:** Diagnosis Mock 데이터 — DB 스키마 기반
+- **DB-002** (PR #76 머지 완료, main `d916a6f`): `model User` (Prisma) + `src/lib/types/user.ts` (`ServiceModeType` union 재사용 대상 — Q6 경계)
+- **DB-001** (PR #75 머지 완료, main `1ef7d84`): Prisma 7 초기화 + npm scripts 8종 + `onday-app/docs/prisma-env-setup.md` (간접 선행)
+
+### 후행 (이 태스크 완료 후 차례로 가능):
+
+- **DB-004** (SHARE_LINK 스키마): **현실 추인 패턴 예고** — `share_links` 테이블 이미 4/29 정의 + `diagnosisId @unique` (Q5 일관 답습 예정)
+- **DB-006** (SAVED_SEARCH 스키마): User FK + 단일 인덱스 패턴 답습
+- **DB-007** (Supabase Auth 연동 USER 정렬): INFRA-002 + DB-007 시점
+- **API-002** (Diagnosis 도메인 DTO): ★ **Q6 경계 협업** — `lib/types/diagnosis.ts` 에 DTO append + `import { ServiceModeType } from './user'` 패턴
+- **CMD-DIAG-004** (saveDiagnosisResult Server Action): in-memory fake `prisma.diagnosis.create` 미지원 영역 → INFRA-002 후 활성화 (Q1)
+- **QRY-DIAG-001** (GET /api/diagnosis/[id]): 동일 — in-memory fake 한계 (Q1)
+- **CMD-DL-001** (데드라인 모드): `deadlineMode Boolean` 활용 (이미 schema)
+- **CMD-SINGLE-001** (싱글 모드): `mode='single'` + `addressB` nullable 활용 (Q2 추인 효과)
+- **MOCK-001** (Diagnosis Mock 데이터): candidates JSON string 패턴 일관 (Q1)
+- **INFRA-002** (Supabase Postgres 프로비저닝): in-memory → 실 PrismaClient swap + schema 의 datasource provider env 화 + `DiagnosisStatus` / `ServiceMode` enum 정의 + CandidateArea 정규화 가능성 + 복합 인덱스 추가 + AC-1 / AC-2 / AC-3 / AC-4 / AC-5 검증 활성화
+- **TEST-*** : vitest config + `__tests__/db/diagnosis-schema.spec.ts` 작성 (8 케이스 일괄)
+- **CMD-DIAG-003** (스코어링 엔진): Q1 §9.1 트리거 — CandidateArea 정규화 + score/rank 컬럼 추가 가치 발현 시점
+
+### Q6 핵심 경계 (DB-003 ↔ API-002 협업 패턴)
+
+- DB-003 산출물 `src/lib/types/diagnosis.ts` = `DiagnosisStatusType` union 1개 + 헤더 주석 4종 **만**
+- API-002 가 동일 파일에 `DiagnosisDTO` / `CandidateAreaDTO` / `CommuteInfoDTO` **append** (단일 진입점)
+- API-002 가 `import type { ServiceModeType } from './user'` 패턴으로 mode 재사용 (재정의 금지)
+- 본 ISSUE 에서 DTO 작성 절대 금지 — Q1 (C) 배제 사유와 동일
 
 ---
 
 ## 8. 🧪 Test Plan (검증 절차)
 
-- **단위 테스트:** `__tests__/db/diagnosis-schema.spec.ts` — 8개 케이스 (기본값, FK CASCADE, JSONB, 인덱스, enum)
-- **마이그레이션 검증:** `npx prisma migrate diff` drift 0건
-- **타입 검증:** `npx tsc --noEmit` 통과
-- **수동 검증:**
-  1. Prisma Studio(`npx prisma studio`)에서 Diagnosis + CandidateArea CRUD 확인
-  2. SQLite에서 `PRAGMA index_list('diagnoses')` 실행 → 인덱스 존재 확인
-- **CI 게이트:** `tsc --noEmit`, `npx prisma migrate diff` drift 0건, Jest 100%, ESLint 통과
+- **단위 테스트:** ⏸ TEST-* 위임 (§3.10 참조, 8 케이스 8/8 무의미). 본 ISSUE 미작성.
+- **CLI 검증 (Phase A/B/D 통과):**
+  1. `npm run db:validate` (= `npx prisma validate`) — exit 0 `"valid 🚀"` (Phase A.7-1)
+  2. `npx prisma generate` — exit 0 (Phase A.7-2, Prisma Client 7.8.0)
+  3. `npx tsc --noEmit` — exit 0 (Phase A.7-3 baseline + Phase B 회귀 0)
+  4. env-less `npm run build` — exit 0, **Middleware 32.5 kB** (INFRA-001 AC-4 기준선 일치, Phase A.8 + Phase D)
+  5. `grep -i "password" onday-app/prisma/schema.prisma` — User 모델 내 0건 + ShareLink `passwordHash` 별도 정상 필드 (DB-002 AC-6 보조 확인, Phase D)
+- **타입 검증:** Phase B `tsc --noEmit` exit 0 — `@/lib/types/diagnosis` 의 `DiagnosisStatusType` 활성
+- **DB 검증:** ⏸ INFRA-002 swap 후 (AC-1 / AC-2 / AC-3 / AC-4 / AC-5 활성)
+- **CI 게이트 (본 ISSUE):** `prisma validate` + `prisma generate` + `tsc --noEmit` + env-less `npm run build` 통과 (Phase D)
 
 ---
 
-## 9. 🚧 Open Questions / Risks (보류 사항)
+## 9. 🚧 Open Questions / Risks (보류 사항 — Q1~Q8 follow-up 8종 + 보조)
 
-1. **CMD-DIAG-003 (스코어링 엔진):** SRS §6.7 CLD에 ScoringEngine.score/rank 기준이 상세 미정. 본 태스크에서는 `score: Float @default(0)`, `rank: Int @default(0)` 컬럼만 정의. 실제 스코어링 로직은 CMD-DIAG-003 작성 후 구현.
-2. **CandidateArea 테이블 분리 결정 근거:** SRS ERD에는 CandidateArea가 별도 엔터티로 명시되지 않음. 본 태스크에서 별도 테이블로 분리하는 이유: (1) 후보 동네별 클릭/공유 추적 가능, (2) 무료 미리보기 1곳 분리(REQ-FUNC-011), (3) 인덱스 기반 순위 조회 최적화.
-3. **API-002 ↔ DB-003 정합성 follow-up:** API-002 작성 시 추정한 CandidateAreaDTO와 본 Prisma 모델의 불일치가 있을 경우 API-002 ISSUE 갱신 필요.
-4. **MOCK-001 ↔ DB-003 정합성 follow-up:** MOCK-001의 `MOCK_CANDIDATES_NORMAL`과 DB-003 스키마의 컬럼 일치 확인 필요.
-5. **coord를 개별 컬럼(coordLat, coordLng)으로 분리한 이유:** JSONB로 저장하면 인덱싱이 불가하고, 지리 쿼리 확장 시 PostGIS 연동이 어려움. 개별 Float 컬럼으로 저장하여 향후 공간 인덱스 추가 가능성 확보.
+### §9.1 ★ Q1 CandidateArea 정규화 = INFRA-002 + CMD-DIAG-003 재평가
+- 현 `Diagnosis.candidates String @default("[]")` JSON array embed → INFRA-002 (Postgres swap) + CMD-DIAG-003 (스코어링 엔진 도입 — score/rank 컬럼 추가 가치 발현) 시점에 정규화 재평가.
+- 별도 `model CandidateArea` + `coordLat`/`coordLng` + `commuteAJson`/`commuteBJson` JSONB + `@@index([diagnosisId, rank])` 추가.
+- in-memory fake `src/lib/db.ts` 의 `prisma.candidateArea.*` API 도 동시 활성화 필요.
+
+### §9.2 ★ Q3 비동기 큐 도입 시 status 기본값 'processing' = INFRA-002 + 비동기 처리 ISSUE 트리거
+- 현 동기 처리 모델 (Vercel 10s + Server Action 저장만 담당) → `status @default("completed")` 도메인 정합.
+- 비동기 큐/워커 도입 시 (예: 더 비싼 통계 보강) `'processing'` 중간 상태 의미 발생 → 별도 ISSUE 트리거.
+
+### §9.3 ★ Q4 복합 인덱스 = INFRA-002 (AC-5 트리거)
+- 현 `@@index([userId])` 단일 → INFRA-002 swap 후 `@@index([userId, createdAt(sort: Desc)])` 복합 인덱스 추가.
+- AC-5 의 INFRA-002 트리거 명시: "CREATE INDEX ... ON "diagnoses" ("user_id", "created_at" DESC) 존재 검증".
+
+### §9.4 ★ Q5 채널별 분리 1:N = 베타 피드백 + INFRA-002 + SHARE_LINK 관련 ISSUE 트리거
+- 현 1:0..1 (`ShareLink.diagnosisId @unique`) → MVP 단일 공유 시나리오 (REQ-FUNC-011).
+- 채널별 분리 공유 (카카오톡/이메일/슬랙 등) 요구 발생 시 → 베타 피드백 + INFRA-002 + SHARE_LINK 관련 ISSUE 트리거. SRS ERD `DIAGNOSIS ──< SHARE_LINK` 도식과의 정합 검토 포함.
+- 후행 영향: DB-004 (SHARE_LINK 스키마) 도 동일 schema (`diagnosisId @unique`) 현실 추인 예정. CMD-SHARE-001~004 는 "재발급 = update" 패턴.
+
+### §9.5 ★ Q2 SRS ERD §6.2.2 addressA/B 보완 = SSoT 갱신 별도 ISSUE 위임
+- 현 schema 에 `addressA String` NOT NULL + `addressB String?` nullable 존재 (REQ-FUNC-003 + REQ-FUNC-021 도메인 정합).
+- 명세 v1.0 누락분 — SRS ERD §6.2.2 자체 갱신은 본 ISSUE 책임 외. SSoT 갱신 별도 ISSUE 작성 위임 (DB-001/002 §9 follow-up 패턴 일관).
+
+### §9.6 mapper 구현 = INFRA-002 후 재평가
+- 현 `src/lib/db.ts` 가 in-memory fake → Prisma Diagnosis 타입 부재 → mapper 매핑 대상 없음.
+- INFRA-002 swap 후 PrismaClient.diagnosis 활성화되면 그 시점에 `src/lib/mappers/diagnosis-mapper.ts` 구현 + 재평가.
+
+### §9.7 spec 작성 = TEST-*
+- vitest config 부재 + in-memory fake 검증 무의미 + 명세 §3.10 8 케이스 8/8 무의미.
+- TEST-* 시점에 config + 모든 spec 일괄 작성 (DB-001 §3.10 + DB-002 §3.10 일관).
+
+### §9.8 ★ Q6 API-002 ↔ DB-003 협업 (diagnosis.ts append 패턴)
+- DB-003 산출물 `src/lib/types/diagnosis.ts` = `DiagnosisStatusType` union 1개 + 헤더 주석 4종 만.
+- API-002 ISSUE 시작 시 본 파일에 `DiagnosisDTO` / `CandidateAreaDTO` / `CommuteInfoDTO` append + `import type { ServiceModeType } from './user'` 패턴 사용.
+- 본 파일 헤더 주석 (3) + (4) 가 합의 형성 근거.
+
+### §9.9 DB-003 seed runner = INFRA-002 후 + Q1 재평가 함께
+- 현 seed.ts 가드 (DB-001 §3.9 + DB-002 §3.9 일관) + tsx 부재.
+- 실 seed 실행 결정 = INFRA-002 (in-memory → 실 Prisma 전환) + Q1 (CandidateArea 정규화) 재평가 + seed runner 결정 (tsx 설치 / Prisma 7 자체 TS runner / .js 사전 컴파일 등) **함께** 일괄 결정.
+
+### 보조 follow-up
+
+- **DB-003 ~ 007 ISSUE 현실 추인 패턴 예고 (DB-001/002 일관):** 4모델 (User / Diagnosis / ShareLink / SavedSearch) 모두 4/29 schema 에 이미 정의됨. 각 ISSUE 는 "신규 작성" → "현실 추인 + INFRA-002 Postgres 어노테이션 추가" 패턴.
+- **AuthProvider enum `guest` 값 추가 여부 (DB-002 §9 일관):** CMD-AUTH-004 작업 시 재검토.
+- **`@default(uuid())` vs DB-007 의 `@db.Uuid`:** DB-007 swap 시 `auth.users.id` 직접 삽입 구조로 `@default` 제거 + `@db.Uuid` 어노테이션 추가. INFRA-002 시점에 마이그레이션 충돌 없이 가능한지 검증 필요.


### PR DESCRIPTION
## 산출물 (2 commits, 2 files)

| 커밋 | 종류 | 파일 | 변경량 |
|---|---|---|---|
| `dcfc773` | feat | `onday-app/src/lib/types/diagnosis.ts` (신규) | +6 |
| `f291eed` | docs | `tasks/DB-003.md` (현실 동기화) | +365/-215 |

`main` (`d916a6f` PR #76 머지본) 대비 변경: **정확히 2 파일** (`git diff main --name-only` 검증). `onday-app/src/lib/types/user.ts` (DB-002 산출물) 변경 0건 확인.

## ✅ AC 검증 결과 표

| 검증 | 결과 |
|---|---|
| `npx prisma validate` (`npm run db:validate`) | ✅ exit 0 — `"valid 🚀"` |
| `npx prisma generate` | ✅ exit 0 — Prisma Client 7.8.0 → `./src/generated/prisma` |
| `npx tsc --noEmit` | ✅ exit 0 (Phase A 기준선 유지, 회귀 0) |
| env-less `npm run build` | ✅ exit 0 — 13/13 static pages, **Middleware 32.5 kB** (INFRA-001 AC-4 기준선 정확히 일치, 회귀 0) |
| `grep -i "password"` (User 모델 L10–22 범위) | ✅ **0건** (DB-002 AC-6 일관). ShareLink L48 `passwordHash` 는 별도 정상 필드 — 본 AC 범위 외 |
| `@/lib/types/diagnosis` import 가능성 | ✅ path alias `@/*` → `./src/*` (tsconfig.json L25–29) + tsc/build 통과 |

### AC 표 (DB-002 ⏸ 패턴 일관)

| AC | 상태 | 비고 |
|---|---|---|
| AC-1 마이그레이션 dry-run | ⏸ Q1 + INFRA-002 후 검증 | 현 schema 자체는 `valid 🚀` 통과. 4/29 `_init` 보존 + Q1 CandidateArea 미생성 |
| AC-2 User 삭제 CASCADE | ⏸ INFRA-002 swap 후 | Migration SQL `ON DELETE CASCADE` 로 DB 레벨은 보장 |
| AC-3 Diagnosis 삭제 CASCADE | ⏸ Q1 + INFRA-002 후 | Q1 결정으로 CandidateArea 미존재. ShareLink (1:0..1) CASCADE 만 활성 |
| AC-4 JSONB 저장 | ⏸ Q1 + INFRA-002 후 | SQLite String JSON 패턴, Postgres `@db.JsonB` 미적용 |
| AC-5 복합 인덱스 | ⏸ Q4 + INFRA-002 후 (★ 명시적 트리거) | 현 `@@index([userId])` 단일, INFRA-002 swap 시 복합 인덱스 추가 + `CREATE INDEX ... ("user_id", "created_at" DESC)` 검증 |
| AC-6 enum 유효성 | ✅ TS union 충족 (Q6) | `DiagnosisStatusType` 컴파일 에러로 invalid status 차단 |
| AC-7 CandidateAreaDTO 매트릭스 | ⏸ Q1 + API-002 위임 | Q6 핵심 경계 — DTO 정의는 API-002 영역 |

## ★ Q1~Q8 결정 vs 명세 v1.0 mismatch 추적 표

| Q | 분기 | 명세 v1.0 | 현실 (4/29 schema) | 결정 | 후속 트리거 |
|---|---|---|---|---|---|
| **Q1** ★ | CandidateArea 정규화 | 별도 `model CandidateArea` + JSONB + 복합 인덱스 | `Diagnosis.candidates String JSON array embed`, 모델 부재 | (A) 현실 추인 JSON embed | INFRA-002 + CMD-DIAG-003 (§9.1) |
| **Q2** | addressA/B | 명세 v1.0 누락 | `addressA String` NOT NULL + `addressB String?` nullable | (A) 현실 추인 | SRS ERD §6.2.2 보완 별도 ISSUE (§9.5) |
| **Q3** | status 기본값 | `'processing'` (비동기) | `'completed'` (동기, Vercel 10s) | (C) 현실 추인 + §9 비동기 재평가 | INFRA-002 + 비동기 ISSUE (§9.2) |
| **Q4** | 복합 인덱스 | `@@index([userId, createdAt DESC])` | `@@index([userId])` 단일 | (C) 현실 추인 + AC-5 ⏸ | INFRA-002 AC-5 (§9.3) |
| **Q5** | Diagnosis ↔ ShareLink | `ShareLink[]` 1:N | `ShareLink?` 1:0..1 + `diagnosisId @unique` | (C) 현실 추인 + §9 1:N 재평가 | 베타 피드백 + SHARE_LINK ISSUE (§9.4) |
| **Q6** ★ | TS 타입 신규 | 없음 (Prisma enum 가정) | DB-002 user.ts 패턴 답습 | (B) `diagnosis.ts` 신규 — union 만, DTO=API-002 | API-002 협업 (§9.8) |
| **Q7** | spec | 8 케이스 작성 | vitest + fake 부재 → 8/8 무의미 | (A) TEST-* 위임 | TEST-* (§9.7) |
| **Q8** | seed.ts | nested write | tsx 부재 + Q1 mismatch | (A) 가드 보존 | INFRA-002 + Q1 재평가 (§9.9) |

## §3.13 — `src/lib/types/diagnosis.ts` (Phase B 산출물, 6줄)

```typescript
// schema.prisma 의 status 는 SQLite enum 미지원으로 String 타입 (// processing | completed | expired 주석으로 가능값 명시).
// 본 파일은 TS union 으로 좁혀 타입 안전성 제공. 실 Prisma enum 강제는 INFRA-002 시점 (Postgres swap).
// 본 파일은 DIAGNOSIS 도메인 단일 진입점 — 후속 API-002 가 DiagnosisDTO / CandidateAreaDTO / CommuteInfoDTO 등 DTO 를 본 파일에 append 예정.
// mode 는 user.ts 의 ServiceModeType 재사용 — diagnosis.ts 에서 재정의 금지. API-002 가 DTO 정의 시 `import { ServiceModeType } from './user'` 패턴 사용.

export type DiagnosisStatusType = 'processing' | 'completed' | 'expired';
```

### ★ Q1 = Q6 핵심 경계 (절대 준수)

| 항목 | 본 ISSUE |
|---|---|
| `CandidateAreaDTO` / `CommuteInfoDTO` / `DiagnosisDTO` 작성 | ✅ **0건** (API-002 영역) |
| `ServiceModeType` 재정의 | ✅ **0건** (user.ts 재사용, 주석으로만 안내) |
| `DiagnosisStatusType` union + 헤더 주석 외 export | ✅ **0건** |
| 범위 확장 ("기왕 만드는 김에") | ✅ **0건** |

→ **본 파일 정확히 1 export, 6 줄.** DB-002 user.ts (12줄)보다 미니멀.

## §9 follow-up 9종 (Q1~Q8 + 보조)

| § | 항목 | 트리거 |
|---|---|---|
| §9.1 ★ | Q1 CandidateArea 정규화 | INFRA-002 + CMD-DIAG-003 |
| §9.2 ★ | Q3 비동기 큐 도입 시 `'processing'` 재평가 | INFRA-002 + 비동기 처리 ISSUE |
| §9.3 ★ | Q4 복합 인덱스 추가 | INFRA-002 (AC-5 명시적 트리거 — `CREATE INDEX ... ("user_id", "created_at" DESC)` 검증) |
| §9.4 ★ | Q5 채널별 분리 1:N 재평가 | 베타 피드백 + SHARE_LINK ISSUE |
| §9.5 ★ | Q2 SRS ERD §6.2.2 addressA/B 보완 | SSoT 갱신 별도 ISSUE (본 ISSUE 책임 외) |
| §9.6 | mapper 구현 | INFRA-002 후 재평가 |
| §9.7 | spec + vitest config | TEST-* (DB-001/002 일관) |
| §9.8 ★ | API-002 ↔ DB-003 협업 (`diagnosis.ts` append + `ServiceModeType` import) | API-002 ISSUE 시작 시점 |
| §9.9 | seed runner | INFRA-002 + Q1 재평가 함께 |

## 가드 12종 (절대 불변, 본 PR 변경 0)

- `prisma/schema.prisma` · `prisma.config.ts` · `prisma/migrations/20260429125124_init/` · `prisma/seed.ts`
- `src/lib/db.ts` (in-memory store — INFRA-002 swap 대상, Q1/Q7 근거)
- **`src/lib/types/user.ts`** (DB-002 PR #76 산출물 — `ServiceModeType` 재사용 대상, Q6 경계) ✅ 변경 0건 확인
- `src/lib/types/errors/.gitkeep` (INFRA-001 `dc2ca37`)
- `__tests__/db/.gitkeep` (INFRA-001 — TEST-* 시점 spec 추가 위치)
- `package.json` / `.env` / `.env.example` / `.gitignore`
- design 루트: `CLAUDE.md` / `AGENTS.md` / `docs/` / `.claude/` / `README-*`
- `tasks/06_TASK_LIST_v1.3.md`

## 위임 (후속 ISSUE — §9 Open Q)

| 항목 | 위임 대상 |
|---|---|
| `DiagnosisStatus` / `ServiceMode` Prisma enum 정의 | **INFRA-002** (Postgres swap) |
| `model CandidateArea` (정규화) + JSONB | **INFRA-002 + CMD-DIAG-003** (스코어링 엔진 도입 시점) |
| 복합 인덱스 `@@index([userId, createdAt DESC])` | **INFRA-002** (AC-5 트리거) |
| `src/lib/mappers/diagnosis-mapper.ts` | INFRA-002 후 재평가 |
| `__tests__/db/diagnosis-schema.spec.ts` (8 케이스) | **TEST-*** (vitest config 부재 + 8/8 무의미) |
| `prisma/seed.ts` Diagnosis 시드 | INFRA-002 + Q1 재평가 + seed runner 결정 함께 |
| `CandidateAreaDTO` / `CommuteInfoDTO` / `DiagnosisDTO` 등 DTO | **API-002** (Q6 핵심 경계 — `diagnosis.ts` append 패턴) |
| AC-1 / AC-2 / AC-3 / AC-4 / AC-5 / AC-7 (DB 레벨) | INFRA-002 + API-002 후 활성 |

## 상세 명세

[`tasks/DB-003.md`](./tasks/DB-003.md) — 현실 동기화 갱신본 (447줄, 580 line changed, +365/-215)

## 후행 ISSUE 현실 추인 패턴 예고

- **DB-004 (SHARE_LINK 스키마)**: 본 ISSUE 의 Q5 결정 (1:0..1 + `diagnosisId @unique`) 일관 답습 예정
- **DB-006 (SAVED_SEARCH 스키마)**: User FK + 단일 인덱스 패턴 답습
- **DB-007 (Supabase Auth USER 정렬)**: INFRA-002 + auth.users FK 정렬
- **API-002 (Diagnosis DTO)**: ★ Q6 경계 협업 — `diagnosis.ts` 에 DTO append + `ServiceModeType` import 패턴

Refs #7