### PR TITLE
docs(DB-004): SHARE_LINK 명세 현실 동기화 (Q1~Q8 + 1:0..1 + helper/DTO/RLS 위임)

### DIFF
--- a/tasks/DB-004.md
+++ b/tasks/DB-004.md
@@ -1,19 +1,28 @@
 ---
 name: Feature Task
-title: "[Feature] DB-004: SHARE_LINK 테이블 Prisma 스키마 정의 및 마이그레이션"
+title: "[Feature] DB-004: SHARE_LINK 도메인 명세 현실 동기화 (기존 onday-app/ ShareLink schema 베이스 — helper = CMD-SHARE-001 / DTO = API-003 / RLS = INFRA-002+DB-007 위임. 본 ISSUE 산출물 = 명세 동기화만, 코드 0)"
 labels: ['feature', 'priority:H', 'epic:Data Foundation', 'wave:1']
 assignees: []
 ---
 
 ## 1. 🎯 Summary
 
-- **기능명:** [DB-004] SHARE_LINK 테이블 Prisma 스키마 정의 및 마이그레이션
+- **기능명:** [DB-004] SHARE_LINK 도메인 명세 현실 동기화. ShareLink schema 자체는 4/29 산출물로 이미 완전 정의됨 (현실 추인). helper / DTO / RLS / spec / seed 모두 후행 ISSUE 위임. 본 ISSUE 산출물 = `tasks/DB-004.md` 1 파일 (코드 변경 0건).
 - **목적 (Why):**
-  - **비즈니스:** 배우자 공유 링크(F2)의 데이터 기반을 확립한다. UUID v4 고유 URL, 30일 만료, 선택적 비밀번호 보호, 미리보기 추적 기능을 지원하는 SHARE_LINK 테이블을 정의한다.
-  - **사용자 가치:** 진단 결과를 배우자에게 안전하게 공유하고, 만료·비밀번호·열람 횟수 추적을 통해 개인정보 보호와 사용 편의성을 동시에 제공한다.
+  - **비즈니스:** 배우자 공유 링크(F2)의 데이터 기반은 이미 4/29 schema 에 완전 정의되어 있으며, 본 ISSUE 는 명세 v1.0 과 현실 간 정합성을 동기화하고 후행 ISSUE 위임 트리거를 명시한다. UUID v4 고유 URL + 30일 만료 + 선택적 비밀번호 + 미리보기 추적 모두 schema 레벨에서 보장됨.
+  - **사용자 가치:** 진단 결과를 배우자에게 안전하게 공유하고, 만료·비밀번호·열람 횟수 추적 인프라가 schema 레벨에서 확보됨 (`@unique` 강제 + `passwordHash` nullable + `viewCount` Int + `freePreviewUsed` Boolean). 실 동작 로직은 CMD-SHARE-001 (helper 함수 + bcrypt 추출) + API-003 (DTO 정의) + INFRA-002+DB-007 (RLS) 협업으로 활성화.
 - **범위 (What):**
-  - ✅ 만드는 것: `model ShareLink` Prisma 스키마, FK 관계 (Diagnosis→ShareLink, CASCADE), `password_hash` (bcrypt — ShareLink 보호용), `expires_at` (30일 만료), `view_count`/`free_preview_used`, 마이그레이션 파일
-  - ❌ 만들지 않는 것: 공유 링크 CRUD 로직(CMD-SHARE 범위), bcrypt 해싱 로직(CMD-SHARE-001), 결제 관련 스키마, **USER 테이블 비밀번호 컬럼 (절대 금지 — DB-002 범위)**
+  - ✅ 만드는 것: 본 명세 현실 동기화 (`tasks/DB-004.md`) — Q1~Q8 결정 반영 + mismatch 추적 표 + §9 follow-up 8종
+  - ❌ 만들지 않는 것 (Q1~Q8 결정 일관):
+    - **`prisma/schema.prisma` 의 `model ShareLink` 신규 작성 / 수정** — 4/29 부트스트랩 시 이미 완전 정의됨 (사용자 가드). Q1 (`diagnosisId @unique` 1:0..1) + Q2 (`@unique` 자동 UNIQUE INDEX) + Q8 (모든 컬럼 명확 타입) 모두 현실 정합.
+    - **신규 마이그레이션 (`add_share_link`)** — 4/29 `_init` migration 의 `share_links` 테이블 + UNIQUE INDEX 2종 + FK CASCADE 이미 존재. 사용자 가드.
+    - **`lib/types/share-link-db.ts` helper 함수 (calculateExpiresAt / isShareLinkExpired / generateShareLinkToken)** — Q3 결정: 등가 인라인 로직이 이미 onday-app mock 라우트 5곳에 동작 중. DB-* 일관 원칙 ("DB ISSUE = type/스키마/인프라 만, 동작 로직 = 후행 CMD-*/API-*") 위반. **CMD-SHARE-001 위임** (helper 추출 + bcrypt 해싱 추가 + 인라인 호출처 통합).
+    - **`prisma/seed.ts` ShareLink 시드** — Q4 결정: DB-001/002/003 가드 일관 + 3중 mismatch (Q3 helper 미작성 → import 불가 / DB-003 Diagnosis 시드 미생성 → diagnosis 참조 불가 / tsx 부재 → 실행 불가).
+    - **`__tests__/db/share-link-schema.spec.ts`** — Q5 결정: vitest config 부재 + in-memory fake meaningless. 명세 §3.9 의 9 spec 케이스가 Q1~Q4 결정으로 9/9 무의미 (helper 검증 2건 추가 무의미). **TEST-* 위임 (DB-001/002/003 §3.10 일관)**.
+    - **`prisma/migrations/manual/003_share_link_rls.sql` RLS SQL** — Q6 결정: `prisma/migrations/manual/` 디렉토리 자체 부재 + SQLite RLS 미지원 + Supabase 환경 비활성. **INFRA-002 + DB-007 위임** (auth.users FK + 모든 테이블 RLS 일괄 작성).
+    - **`ShareLinkMetaDTO` 등 DTO 정의** — Q7 결정: DB-003 Q6 핵심 경계 일관 ("DB-* = base type, DTO = API-* 영역"). **API-003 위임** (`src/lib/types/share-link.ts` 신규 작성 + `ShareLinkMetaDTO` 정의 + `isExpired` / `hasPassword` runtime 계산).
+    - **`src/lib/types/share-link.ts` TS union 타입 신규** — Q8 결정: ShareLink 모든 컬럼이 명확 타입 (String UUID/bcrypt, Int, Boolean, DateTime). 좁힐 enum 가능성 String 컬럼 0건. DB-002/003 패턴 ("schema `String + 주석` → TS union") 의 트리거 조건 자체가 없음. **TS 타입 미작성 — DB-001 패턴 유사 (산출물 = 명세 갱신만)**. 억지로 dead file 생성 금지.
+    - **password / password_hash / salt 컬럼 (USER 테이블)** — DB-002 가드 (OAuth-only, 절대 금지). ShareLink 의 `passwordHash` 는 별도 모델의 정상 필드 (REQ-FUNC-010 공유 링크 비밀번호 보호 — 본 ISSUE 영역). 두 컬럼은 도메인적으로 완전 분리.
 - **복잡도:** L
 - **Wave:** 1 (Data Foundation 트랙)
 
@@ -25,250 +34,267 @@ assignees: []
 
 - **REQ-FUNC-009** (§4.1.2): "시스템은 진단 리포트 생성 완료 후 '공유 링크 생성' 버튼을 제공해야 하며, 클릭 시 고유 URL(UUID v4, entropy ≥ 128bit)을 생성하여 클립보드에 복사해야 한다. 링크 생성 응답 시간은 500ms 이내여야 한다."
 - **REQ-FUNC-010** (§4.1.2): "공유 링크의 유효기간은 생성일로부터 30일 이상이어야 한다. 만료된 링크 접근 시 '이 링크는 만료되었습니다' 안내 페이지를 1초 이내에 로딩하고, 원 사용자에게 재생성 알림 푸시를 발송해야 한다. 만료된 링크에서 개인정보 노출은 0건이어야 한다."
-- **REQ-FUNC-011** (§4.1.2): "배우자(비회원)가 공유 링크를 클릭하면 앱 설치 없이 모바일 웹에서 리포트 전체를 열람하고 무료 미리보기 1곳을 확인할 수 있어야 한다."
+- **REQ-FUNC-011** (§4.1.2): "배우자(비회원)가 공유 링크를 클릭하면 앱 설치 없이 모바일 웹에서 리포트 전체를 열람하고 무료 미리보기 1곳을 확인할 수 있어야 한다." — Q1 결정 (1:0..1 단일 공유 시나리오) 의 도메인 근거
+- **REQ-NF-006** (§4.2.1): "공유 링크 생성 응답 시간 — ≤ 500ms" — Q2 결정 (`@unique` 자동 UNIQUE INDEX 로 조회 O(log n) 보장) 의 충족 근거
 - **REQ-NF-020** (§4.2.3): "공유 링크 보안 — URL entropy ≥ 128bit (UUID v4), 열람 비밀번호 옵션, 열람 로그 실시간 알림"
 - **REQ-NF-021** (§4.2.3): "비인가 제3자 공유 링크 개인정보 접근 차단 — 비인가 접근 시 개인정보 노출 0건"
-- **REQ-NF-006** (§4.2.1): "공유 링크 생성 응답 시간 — ≤ 500ms"
 
-### ERD 컬럼 (§6.2.3 SHARE_LINK — SRS SSOT)
+### `prototypes/design/CLAUDE.md` §4 인용 (핵심 데이터 모델)
 
-| 필드명 | 타입 | 제약조건 | 설명 |
-|---|---|---|---|
-| `id` | UUID | PK, NOT NULL | 공유 링크 고유 식별자 |
-| `diagnosis_id` | UUID | FK → DIAGNOSIS.id, NOT NULL | 공유 대상 진단 |
-| `unique_url` | VARCHAR(255) | UNIQUE, NOT NULL | 고유 URL (UUID v4, entropy ≥ 128bit) |
-| `password_hash` | VARCHAR(255) | NULLABLE | 열람 비밀번호 해시 (선택 설정, bcrypt) |
-| `view_count` | INTEGER | NOT NULL, DEFAULT 0 | 열람 횟수 |
-| `free_preview_used` | BOOLEAN | NOT NULL, DEFAULT FALSE | 무료 미리보기 사용 여부 |
-| `expires_at` | DATE | NOT NULL | 만료일 (생성일 + 30일) |
-| `created_at` | TIMESTAMP | NOT NULL, DEFAULT NOW() | 생성일시 |
+> "SHARE_LINK — UUID v4 entropy ≥ 128bit, 만료 30일" — Q1 (1:0..1 단일 공유) + Q3 (helper 30일 계산 = CMD-SHARE-001 위임) 도메인 정합 근거
 
-### ShareLink 비밀번호 vs USER 비밀번호 명확화
+### ERD 컬럼 vs 현 schema.prisma (§6.2.3 SHARE_LINK — 현실 추인)
 
-| 구분 | ShareLink 비밀번호 (DB-004) | USER 비밀번호 (DB-002) |
+| 필드명 | SRS 정의 | 현 schema.prisma (4/29 산출물) | Q | 정합성 |
+|---|---|---|---|---|
+| `id` | UUID PK, NOT NULL | `String @id @default(uuid())` | — | ✅ Prisma 7 UUID v4 자동 (entropy ≥ 128bit) |
+| `diagnosis_id` | UUID FK → DIAGNOSIS.id, NOT NULL | `String @unique @map("diagnosis_id")` ★ **`@unique` 추가됨** | **Q1** | ⚠️ **현실 추인 1:0..1** (명세 v1.0 의 1:N 가정 → 정정). DB-003 §3.3 `shareLink ShareLink?` 와 양쪽 모델 일치 |
+| `unique_url` | VARCHAR(255) UNIQUE, NOT NULL | `String @unique @map("unique_url") // UUID v4` | — | ✅ |
+| `password_hash` | VARCHAR(255) NULLABLE | `String? @map("password_hash") // bcrypt hash` | — | ✅ |
+| `view_count` | INTEGER DEFAULT 0 | `Int @default(0) @map("view_count")` | — | ✅ |
+| `free_preview_used` | BOOLEAN DEFAULT FALSE | `Boolean @default(false) @map("free_preview_used")` | — | ✅ |
+| `expires_at` | DATE NOT NULL | `DateTime @map("expires_at")` | — | ⚠️ SQLite TIMESTAMP (Postgres `@db.Date` 미적용, INFRA-002 후) |
+| `created_at` | TIMESTAMP DEFAULT NOW() | `DateTime @default(now()) @map("created_at")` | — | ✅ |
+| FK CASCADE | (관계) | `diagnosis Diagnosis @relation(...) onDelete: Cascade` | — | ✅ |
+| 명시적 `@@index([diagnosisId])` | 명세 §3.1 추가 | **부재** — `@unique` 자동 UNIQUE INDEX 로 충족 | **Q2** | ⚠️ **현실 추인** — Prisma `@unique` 가 `CREATE UNIQUE INDEX` 자동 생성. 명세의 `@@index` 명시는 redundant |
+| 명시적 `@@index([uniqueUrl])` | 명세 §3.1 추가 | **부재** — `@unique` 자동 UNIQUE INDEX | **Q2** | ⚠️ 명세 v1.0 자체의 redundant 표기 (이미 `@unique` 명시 + 또 `@@index` 추가) |
+| Q8 enum 가능성 String 컬럼 | — | **0건** — 모든 String 컬럼은 UUID 형식 (id/diagnosisId/uniqueUrl) 또는 bcrypt hash (passwordHash) | **Q8** | DB-002/003 의 `String + 주석 // enum 가능값` 패턴 자체 부재 → TS union 신규 작성 트리거 0 |
+
+### Q2 redundancy 사유 명시 (사용자 결정 (C) 일관)
+
+Prisma `@unique` 가 자동으로 `CREATE UNIQUE INDEX` SQL 발행 (migration 인용 §2 참조: `share_links_diagnosis_id_key` + `share_links_unique_url_key`). 명세 v1.0 §3.1 의 `@@index([diagnosisId])` / `@@index([uniqueUrl])` 명시는:
+- `@@index([uniqueUrl])`: 이미 `@unique` 와 redundant (명세 작성 시점의 일관성 오류)
+- `@@index([diagnosisId])`: 명세 v1.0 의 1:N 가정 (`@unique` 없음) 과 결합된 표기 → Q1 결정 (1:0..1 + `@unique` 보존) 하에서는 redundant
+- **현실 추인**: `@unique` 자동 UNIQUE INDEX 로 충족. REQ-NF-006 (≤ 500ms) 조회 O(log n) 보장.
+
+### 4/29 `_init` migration 의 share_links 테이블 검증
+
+```sql
+-- prisma/migrations/20260429125124_init/migration.sql (4/29 산출물, 본 ISSUE 미수정)
+
+CREATE TABLE "share_links" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "diagnosis_id" TEXT NOT NULL,
+    "unique_url" TEXT NOT NULL,
+    "password_hash" TEXT,                              -- ShareLink 정상 필드 (User 모델 아님)
+    "view_count" INTEGER NOT NULL DEFAULT 0,
+    "free_preview_used" BOOLEAN NOT NULL DEFAULT false,
+    "expires_at" DATETIME NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "share_links_diagnosis_id_fkey" FOREIGN KEY ("diagnosis_id") REFERENCES "diagnoses" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX "share_links_diagnosis_id_key" ON "share_links"("diagnosis_id");   -- Q1 1:0..1 DB 레벨 강제
+CREATE UNIQUE INDEX "share_links_unique_url_key" ON "share_links"("unique_url");        -- Q2 UNIQUE INDEX 자동
+```
+
+- ✅ Q1 (`diagnosisId @unique` 1:0..1) DB 레벨 강제 입증
+- ✅ Q2 (`@unique` 자동 UNIQUE INDEX) 입증 — REQ-NF-006 조회 성능 충족
+- ✅ FK CASCADE 정합 (REQ-NF-021 Diagnosis 삭제 시 ShareLink 동반 삭제)
+- ✅ User 모델 password 컬럼 0건 (DB-002 AC-6 일관). ShareLink 의 `password_hash` 는 별도 모델 정상 필드 — REQ-FUNC-010 공유 링크 비밀번호 보호용 (도메인 완전 분리)
+
+### ShareLink 비밀번호 vs USER 비밀번호 명확화 (DB-002 AC-6 일관)
+
+| 구분 | ShareLink `passwordHash` (DB-004) | USER 비밀번호 (DB-002) |
 |---|---|---|
-| **허용 여부** | ✅ 허용 (REQ-FUNC-010) | ❌ 절대 금지 (OAuth-only) |
+| **허용 여부** | ✅ 허용 (REQ-FUNC-010 공유 링크 비밀번호 보호) | ❌ 절대 금지 (OAuth-only) |
 | **용도** | 공유 링크 선택적 보호용 | — |
-| **저장 방식** | bcrypt 해시 (REQ-NF-020) | — |
+| **저장 방식** | bcrypt 해시 (REQ-NF-020), 실 bcrypt 추출 = CMD-SHARE-001 위임 | — |
 | **Prisma 컬럼** | `passwordHash String? @map("password_hash")` | 없음 |
+| **현 onday-app 인라인 동작** | `app/api/share/route.ts:42` mock hash (`mock_hash_${password}`) → CMD-SHARE-001 시점 실 bcrypt 교체 대상 | — |
+
+### Q3 helper 인라인 호출처 5곳 (★ 핵심 — CMD-SHARE-001 통합 대상)
+
+본 ISSUE 가 helper 함수를 미작성하는 사유: **등가 인라인 로직이 이미 onday-app mock 라우트 5곳에 동작 중**. 본 ISSUE 에서 helper 추출 시 (i) 호출처 수정 = onday-app/src/app/* 가드 위반, (ii) 호출처 미수정 = dead code.
+
+| # | 위치 | 인라인 로직 (현 동작) | 명세 §3.7 등가 함수 | CMD-SHARE-001 통합 |
+|---|---|---|---|---|
+| 1 | `app/api/share/route.ts:42` | `passwordHash = password ? \`mock_hash_${password}\` : null` (Mock bcrypt) | (bcrypt 해싱 — CMD-SHARE-001 의 추가 책임) | 실 `bcrypt.hash(password, 10)` 교체 |
+| 2 | `app/api/share/route.ts:46` | `uniqueUrl: randomUUID()` | `generateShareLinkToken(): string` | helper 추출 + 호출 |
+| 3 | `app/api/share/route.ts:48` | `expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days` | `calculateExpiresAt(createdAt?: Date): Date` | helper 추출 + 호출 |
+| 4 | `app/api/share/[uuid]/route.ts:24` | `if (shareLink.expiresAt < new Date()) { ... "expired" ... 410 ... }` | `isShareLinkExpired(expiresAt: Date): boolean` | helper 추출 + 호출 |
+| 5 | `app/share/[uuid]/page.tsx:20` | `if (shareLink.expiresAt < new Date()) { type: "expired" ... }` | `isShareLinkExpired(expiresAt: Date): boolean` (동일) | helper 추출 + 호출 |
+
+→ 5곳 모두 본 ISSUE 미수정 (가드 14종에 포함). CMD-SHARE-001 시점에 helper 추출 + 인라인 호출처 통합 + bcrypt 실 구현이 일괄 작업.
 
 ### 선행 태스크 산출물
 
 | 선행 Task ID | 제공 산출물 | 본 태스크에서의 사용처 |
 |---|---|---|
-| DB-003 | `model Diagnosis` Prisma 스키마 (id, userId FK 등) | ShareLink.diagnosisId FK가 Diagnosis.id를 참조 |
-| DB-001 | `prisma/schema.prisma` datasource + `lib/db.ts` | Prisma CLI 명령어 실행 기반 |
+| **DB-003** (PR #77 머지 완료, main `18de316`) | `model Diagnosis` (4/29) + `shareLink ShareLink?` 1:0..1 역관계 (DB-003 §3.3 Q5 결정 PR #77 머지본) + `src/lib/types/diagnosis.ts` (DiagnosisStatusType union) | ShareLink.diagnosisId FK 대상 + Q1 양쪽 모델 일치 검증 |
+| **DB-001 / DB-002** (PR #75 / #76 머지 완료) | Prisma 7 초기화 + `prisma/migrations/20260429125124_init/` (share_links 테이블 포함) + `src/lib/types/user.ts` | 간접 선행 (CLI 검증 인프라) |
 
-### MOCK-002 정합성 검증
+### 후행 ISSUE 정합성 (현실 추인 패턴 + Q1~Q8 결정 트리거)
 
-| MOCK-002 Mock 객체 | DB-004 Prisma 모델 | 정합성 |
+| 후행 ISSUE | 영향 | Q 결정 |
 |---|---|---|
-| `ShareLinkMetaDTO.id` | `ShareLink.id` (String @id @default(uuid())) | ✅ |
-| `ShareLinkMetaDTO.uniqueUrl` | `ShareLink.uniqueUrl` (String @unique) | ✅ |
-| `ShareLinkMetaDTO.viewCount` | `ShareLink.viewCount` (Int @default(0)) | ✅ |
-| `ShareLinkMetaDTO.expiresAt` | `ShareLink.expiresAt` (DateTime) | ✅ |
-| `ShareLinkMetaDTO.isExpired` | 런타임 계산 (`expiresAt < now()`) — Prisma 모델에 컬럼 없음 | ✅ DTO에서 계산 |
-| `ShareLinkMetaDTO.hasPassword` | 런타임 계산 (`passwordHash !== null`) — Prisma 모델에 컬럼 없음 | ✅ DTO에서 계산 |
-| `ShareLinkMetaDTO.freePreviewUsed` | `ShareLink.freePreviewUsed` (Boolean @default(false)) | ✅ |
-
-### 배치 1~4 ISSUE 정합성 검증 대상
-
-| 기존 ISSUE | 검증 항목 | 검증 결과 |
-|---|---|---|
-| API-003.md | ERD 컬럼 표 (§6.2.3 인용) — id, diagnosis_id, unique_url, password_hash, view_count, free_preview_used, expires_at, created_at | ✅ 본 Prisma 모델과 1:1 일치 |
-| MOCK-002.md | ShareLinkMetaDTO 구조 (Task 3.3~3.6) — 7개 필드 | ✅ 위 매트릭스 참조, 모두 정합 |
-| CMD-SHARE-001~004 (미작성) | DB-004 SHARE_LINK 스키마 의존 | ✅ 본 ISSUE가 선행으로 정의 |
+| **CMD-SHARE-001** (공유 링크 생성 Server Action) | ★ Q3 helper 추출 + bcrypt 해싱 추가 + 인라인 호출처 5곳 통합 | Q3 |
+| CMD-SHARE-002 ~ 004 (재발급 / 비밀번호 / 만료) | `diagnosisId @unique` 1:0..1 정합 — 재발급 = update 패턴 | Q1 |
+| **API-003** (ShareLink DTO) | ★ `src/lib/types/share-link.ts` 신규 작성 + `ShareLinkMetaDTO` 정의 + `isExpired` / `hasPassword` runtime 계산 | Q7 |
+| MOCK-002 (ShareLink Mock 데이터) | `MOCK_SHARE_LINK_META_VALID/EXPIRED/PASSWORD` 와 API-003 DTO 정합 검증 | Q7 |
+| QRY-SHARE-001 (리포트 SSR 열람) | `app/share/[uuid]/page.tsx:20` 인라인 `isShareLinkExpired` 동등 로직 → CMD-SHARE-001 helper 통합 후 호출 | Q3 |
+| **INFRA-002** (Supabase Postgres) | 실 PrismaClient swap + Postgres `@db.Date`/`@db.JsonB` + AC-1~AC-5 활성 | Q1~Q5 |
+| **DB-007** (Supabase Auth USER 정렬) | Q6 RLS SQL 일괄 작성 (`migrations/manual/003_share_link_rls.sql` + 모든 테이블 RLS) | Q6 |
+| TEST-* | vitest config + 9 케이스 일괄 작성 | Q5 |
 
 ---
 
 ## 3. 🛠️ Task Breakdown (실행 체크리스트)
 
-- [ ] **3.1** `prisma/schema.prisma`에 `model ShareLink` 정의
+- [x] **3.1** `prisma/schema.prisma` 에 `model ShareLink` 정의 — **4/29 산출물 보존 (사용자 가드)**
+  > 현 schema.prisma `model ShareLink` (L44–57, 본 ISSUE 미수정) — Q1/Q2/Q8 결정과 모두 정합:
   ```prisma
   model ShareLink {
-    id              String    @id @default(uuid())
-    diagnosisId     String    @map("diagnosis_id")
-    uniqueUrl       String    @unique @map("unique_url")
-    passwordHash    String?   @map("password_hash")
-    viewCount       Int       @default(0) @map("view_count")
-    freePreviewUsed Boolean   @default(false) @map("free_preview_used")
-    expiresAt       DateTime  @map("expires_at")
-    createdAt       DateTime  @default(now()) @map("created_at")
+    id              String   @id @default(uuid())
+    diagnosisId     String   @unique @map("diagnosis_id")     // Q1 ★ 1:0..1 강제 (DB-003 §3.3 일관)
+    uniqueUrl       String   @unique @map("unique_url") // UUID v4
+    passwordHash    String?  @map("password_hash") // bcrypt hash
+    viewCount       Int      @default(0) @map("view_count")
+    freePreviewUsed Boolean  @default(false) @map("free_preview_used")
+    expiresAt       DateTime @map("expires_at")
+    createdAt       DateTime @default(now()) @map("created_at")
 
-    diagnosis       Diagnosis @relation(fields: [diagnosisId], references: [id], onDelete: Cascade)
+    diagnosis Diagnosis @relation(fields: [diagnosisId], references: [id], onDelete: Cascade)
 
-    @@index([diagnosisId])
-    @@index([uniqueUrl])
     @@map("share_links")
   }
   ```
+  > **명세 v1.0 가정과 차이 3건 (현실 추인 — Q1/Q2/Q8 반영):**
+  > 1. **`diagnosisId` 제약 (Q1)**: 명세 v1.0 의 `String @map("diagnosis_id")` (1:N) → 현실 `String @unique @map("diagnosis_id")` (1:0..1 강제). DB-003 §3.3 `shareLink ShareLink?` 와 양쪽 모델 일치 필수 (Q1 §9.4 follow-up).
+  > 2. **`@@index([diagnosisId])` / `@@index([uniqueUrl])` (Q2)**: 명세 v1.0 의 명시적 인덱스 → 현실 부재 (`@unique` 자동 UNIQUE INDEX 로 충족). redundancy 사유 §2 기록.
+  > 3. **enum 가능성 String 컬럼 (Q8)**: 명세에 없음 + 현실에도 없음. 모든 String 컬럼이 UUID 형식 또는 bcrypt hash — 좁힐 union 0건. DB-002/003 패턴 적용 불가 → TS 타입 신규 작성 미실시.
 
-- [ ] **3.2** `prisma/schema.prisma`의 `model Diagnosis`에 ShareLink 역관계 추가
+- [x] **3.2** `prisma/schema.prisma` 의 `model Diagnosis` 에 ShareLink 역관계 추가 — **DB-003 PR #77 머지본에서 활성**
+  > 현 schema.prisma `model Diagnosis` (L24–42) — DB-003 §3.3 Q5 결정 PR #77 머지본:
   ```prisma
-  // model Diagnosis에 추가 (DB-003에서 이미 shareLinks 필드가 정의되어 있을 수 있음)
-  shareLinks ShareLink[]
+  // model Diagnosis (DB-003 PR #77 머지본 §3.3)
+  shareLink ShareLink?       // Q5 1:0..1 (ShareLink.diagnosisId @unique 강제)
   ```
+  > **본 ISSUE Q1 결정 (1:0..1)** 과 양쪽 모델 일치 — schema valid. 명세 v1.0 §3.2 의 `shareLinks ShareLink[]` (1:N) 가정은 DB-003 Q5 결정 시점에 이미 1:0..1 로 정정됨.
 
-- [ ] **3.3** UUID v4 고유 URL 생성 전략 문서화 — entropy ≥ 128bit
-  - `@default(uuid())` — Prisma의 UUID v4 생성 (128bit entropy 보장)
-  - `uniqueUrl` 컬럼에 `@unique` 제약조건으로 중복 방지
-  - 실제 공유 URL은 `https://domain/share/{uniqueUrl}` 형식
+- [x] **3.3** UUID v4 고유 URL 생성 전략 문서화 — entropy ≥ 128bit — **Prisma 7 자동**
+  > 현 schema: `id String @id @default(uuid())` + `uniqueUrl String @unique @map("unique_url")`. Prisma 7 의 `@default(uuid())` 가 UUID v4 자동 생성 (128bit entropy 보장). `@unique` 제약조건으로 중복 방지.
+  > 실 공유 URL 형식: `https://onday-design-project.vercel.app/share/{uniqueUrl}` (Vercel 라이브 — [[project-critical-path-progress]]).
+  > **Q3 결정으로 `generateShareLinkToken()` helper 추출은 CMD-SHARE-001 위임** — 현 `app/api/share/route.ts:46` 의 `randomUUID()` 인라인 호출이 등가 동작 중.
 
-- [ ] **3.4** `npx prisma validate` 실행하여 스키마 문법 검증
+- [x] **3.4** `npx prisma validate` 실행하여 스키마 문법 검증 — **Phase A 통과**
+  > Phase A.7: `npm run db:validate` exit 0, `"valid 🚀"`. 본 ISSUE 신규 수정 없음 → 회귀 0.
 
-- [ ] **3.5** `npx prisma migrate dev --name add_share_link` 실행, 마이그레이션 SQL 검토
-  - 생성 파일: `prisma/migrations/{timestamp}_add_share_link/migration.sql`
-  - 확인 항목:
-    - `share_links` 테이블 생성
-    - `id` PK
-    - `diagnosis_id` FK → `diagnoses.id` ON DELETE CASCADE
-    - `unique_url` UNIQUE
-    - `password_hash` NULLABLE
-    - `view_count` DEFAULT 0
-    - `free_preview_used` DEFAULT FALSE
-    - `expires_at` NOT NULL
-    - `created_at` DEFAULT NOW()
-    - INDEX on `diagnosis_id`, INDEX on `unique_url`
+- [x] **3.5** `npx prisma migrate dev --name add_share_link` 실행, 마이그레이션 SQL 검토 — **4/29 `_init` 보존**
+  > 4/29 `_init` migration 이 이미 `share_links` 테이블 + UNIQUE INDEX 2종 + FK CASCADE 포함 (§2 SQL 인용). 본 ISSUE 신규 migration 미생성 (사용자 가드).
+  > 확인 항목 (§2 migration SQL 정합):
+  > - ✅ `share_links` 테이블 생성 (CREATE TABLE)
+  > - ✅ `id` PK
+  > - ✅ `diagnosis_id` FK → `diagnoses.id` ON DELETE CASCADE
+  > - ✅ `unique_url` UNIQUE (Q2 자동)
+  > - ✅ `password_hash` NULLABLE
+  > - ✅ `view_count` DEFAULT 0
+  > - ✅ `free_preview_used` DEFAULT FALSE
+  > - ✅ `expires_at` NOT NULL
+  > - ✅ `created_at` DEFAULT NOW()
+  > - ✅ UNIQUE INDEX 2종: `share_links_diagnosis_id_key` (Q1) + `share_links_unique_url_key` (Q2)
 
-- [ ] **3.6** `npx prisma generate` 실행하여 Prisma Client 타입 재생성
+- [x] **3.6** `npx prisma generate` 실행 — **Phase A 통과**
+  > Phase A.7: `npx prisma generate` exit 0, `Generated Prisma Client (7.8.0) to ./src/generated/prisma`.
 
-- [ ] **3.7** `lib/types/share-link-db.ts`에 ShareLink DB 관련 유틸리티 타입 정의
-  ```typescript
-  // lib/types/share-link-db.ts
+- [⏸ CMD-SHARE-001 위임] **3.7** `lib/types/share-link-db.ts` helper 함수 — **Q3 결정**
+  > **사유 5종 (DB-* 일관 원칙 + 등가 인라인 동작 중 + CMD-SHARE-001 응집성):**
+  > 1. **DB-* 일관 원칙 위반 회피**: DB-002 `user.ts` + DB-003 `diagnosis.ts` 모두 **type only** (DTO 도 API-002 위임). helper 3개는 type 이 아닌 동작 로직 (정책 + 계산 + 인프라 함수) → DB-* 책임 외.
+  > 2. **등가 인라인 로직이 이미 동작 중** (§2 helper 호출처 5곳 표 참조):
+  >    - `app/api/share/route.ts:46` `randomUUID()` ↔ `generateShareLinkToken`
+  >    - `app/api/share/route.ts:48` `new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)` ↔ `calculateExpiresAt`
+  >    - `app/api/share/[uuid]/route.ts:24` + `app/share/[uuid]/page.tsx:20` `shareLink.expiresAt < new Date()` ↔ `isShareLinkExpired`
+  > 3. **CMD-SHARE-001 자연스러운 응집성**: bcrypt 해싱 + UUID v4 + 30일 계산 + DB INSERT + 응답 ≤ 500ms 모두 한 Server Action 내 로직 → helper 추출 + 호출처 통합 + bcrypt 실 구현 일괄 작업이 응집성 높음. `app/api/share/route.ts:42` mock bcrypt (`mock_hash_${password}`) 도 동시 교체 대상.
+  > 4. **가드 위반 회피**: helper 추출 시 (i) 호출처 5곳 수정 = `onday-app/src/app/*` 가드 위반, (ii) 호출처 미수정 = dead code.
+  > 5. **INFRA-002 + CMD-SHARE-001 동시 활성화**: in-memory fake → 실 PrismaClient swap (INFRA-002) + mock 라우트 → 실 Server Action 전환 (CMD-SHARE-001) 시점이 helper 추출 + bcrypt 추가 + 호출처 통합의 도메인적 순서.
+  > **§9 follow-up 트리거**: CMD-SHARE-001 helper 추출 + bcrypt salt round 결정 (§9.1).
 
-  /** ShareLink 생성 시 만료일 계산 — 생성일 + 30일 */
-  export function calculateExpiresAt(createdAt: Date = new Date()): Date {
-    const expiresAt = new Date(createdAt);
-    expiresAt.setDate(expiresAt.getDate() + 30);
-    return expiresAt;
-  }
+- [⏸ skip] **3.8** `prisma/seed.ts` 에 ShareLink 시드 추가 — **Q4 결정 (DB-001/002/003 일관)**
+  > **3중 mismatch:**
+  > 1. **Q3 결정 (helper 미작성)** → 명세 §3.8 의 `import { calculateExpiresAt } from '../lib/types/share-link-db'` 불가 (helper 정의 자체 없음)
+  > 2. **DB-003 §3.9 가드** → Diagnosis 시드 미생성 (DB-003 Q1 CandidateArea mismatch 사유) → `diagnosisId: diagnosis.id` 참조 불가 (선행 시드 부재)
+  > 3. **tsx 부재 (Phase A.5 재확인)** → seed 추가해도 실행 자체 불가
+  > **사유 (DB-001/002/003 §3.9 일관):** (i) 4/29 seed.ts 가드 + (ii) tsx 부재 + (iii) INFRA-002 후 실 실행 + (iv) `prisma.seed` 항목 비움. **§9 follow-up**: ShareLink 시드 = INFRA-002 + DB-003 Diagnosis 시드 재평가 + Q3 helper 추출 동시 활성화 시점 일괄 작성 (§9.2).
 
-  /** ShareLink 만료 여부 판단 */
-  export function isShareLinkExpired(expiresAt: Date): boolean {
-    return new Date() > expiresAt;
-  }
+- [⏸ TEST-* 위임] **3.9** `__tests__/db/share-link-schema.spec.ts` — 9 케이스 — **Q5 결정 (DB-001/002/003 §3.10 일관)**
+  > **사유 (DB-001/002/003 §3.10 4종 + Q3 추가 영향):**
+  > 1. `vitest.config.ts` 부재 (Phase A.5 재확인) → spec 작성해도 실행 불가
+  > 2. 현 `src/lib/db.ts` 가 in-memory fake → spec 검증 meaningless
+  > 3. TEST-* 시점에 vitest config + 모든 ISSUE spec 일괄 작성
+  > 4. 본 ISSUE 검증은 CLI (validate/generate/tsc/build) + grep + read-only 정합으로 충족
+  >
+  > **★ 명세 §3.9 의 9 spec 케이스가 Q1~Q4 결정으로 9 / 9 무의미:**
+  >
+  > | 명세 §3.9 케이스 | Q 결정 영향 |
+  > |---|---|
+  > | 1. ShareLink 생성 + UUID 자동 | ❌ in-memory fake — Prisma uuid 자동 생성 검증 무의미 |
+  > | 2. uniqueUrl UNIQUE 제약 | ❌ in-memory fake — DB 제약 검증 무의미 |
+  > | 3. passwordHash NULLABLE | ❌ in-memory fake — DB 제약 검증 무의미 |
+  > | 4. viewCount / freePreviewUsed 기본값 | ❌ 동일 |
+  > | 5. Diagnosis 삭제 CASCADE | ❌ in-memory fake CASCADE 미지원 |
+  > | 6. FK 위반 (nonexistent diagnosisId) | ❌ 동일 |
+  > | 7. `calculateExpiresAt()` 30일 정확성 | ❌ **Q3 helper 미작성** → 검증 불가 |
+  > | 8. `isShareLinkExpired()` 정확성 | ❌ **Q3 helper 미작성** → 검증 불가 |
+  > | 9. 기타 | ❌ 동일 |
+  >
+  > **단, `__tests__/db/.gitkeep` 빈 디렉토리는 보존** — INFRA-001 `dc2ca37` 산출물, TEST-* 시점 spec 추가 위치.
 
-  /** UUID v4 entropy ≥ 128bit 생성 (crypto.randomUUID 사용) */
-  export function generateShareLinkToken(): string {
-    return crypto.randomUUID(); // 128bit entropy
-  }
-  ```
+- [⏸ INFRA-002 + DB-007 위임] **3.10** `prisma/migrations/manual/003_share_link_rls.sql` RLS SQL — **Q6 결정**
+  > **사유 5종:**
+  > 1. `prisma/migrations/manual/` 디렉토리 자체 부재 (확인됨)
+  > 2. SQLite RLS 미지원 (Postgres 전용)
+  > 3. Supabase 환경 비활성 (INFRA-002 swap 전)
+  > 4. DB-007 의 `auth.users` FK + RLS 정렬과 일괄 작성이 자연스러움
+  > 5. DB-001/002/003 의 Supabase 관련 위임 패턴 일관
+  > **§9 follow-up 트리거**: INFRA-002 + DB-007 시점에 모든 테이블 RLS 일괄 작성 (§9.5).
 
-- [ ] **3.8** `prisma/seed.ts`에 ShareLink 시드 데이터 추가
-  ```typescript
-  import { calculateExpiresAt } from '../lib/types/share-link-db';
+- [⏸ API-003 위임] **3.11** MOCK-002 정합성 + `ShareLinkMetaDTO` 매트릭스 — **Q7 결정 (DB-003 Q6 경계 일관)**
+  > **사유 (DB-003 Q6 핵심 경계 답습):**
+  > - DB-003 의 `diagnosis.ts` 헤더 주석 (3) 인용: "후속 API-002 가 DiagnosisDTO / CandidateAreaDTO / CommuteInfoDTO 등 DTO 를 본 파일에 append 예정". DB-004 도 동일 — `ShareLinkMetaDTO` 정의는 API-003 책임.
+  > - API-003 가 `src/lib/types/share-link.ts` **신규 작성** + `ShareLinkMetaDTO` 정의 + `isExpired` / `hasPassword` runtime 계산. **DB-003 의 append 패턴과 다름** — DB-004 는 base type 자체가 없으므로 (Q8 결정) API-003 가 처음부터 작성.
+  > - MOCK-002 의 `MOCK_SHARE_LINK_META_VALID / EXPIRED / PASSWORD` 정합 검증은 API-003 + MOCK-002 동시 작업 시점.
+  > **§9 follow-up 트리거**: API-003 + MOCK-002 (§9.3 / §9.4).
 
-  const shareLink = await prisma.shareLink.create({
-    data: {
-      diagnosisId: diagnosis.id,    // DB-003 시드의 diagnosis 참조
-      uniqueUrl: 'seed-share-001',
-      passwordHash: null,           // 비밀번호 없음
-      viewCount: 0,
-      freePreviewUsed: false,
-      expiresAt: calculateExpiresAt(),
-    },
-  });
+### ★ Q1~Q8 결정 vs 명세 v1.0 mismatch 추적 표 (DB-003 §3 끝 패턴 답습)
 
-  const shareLinkWithPassword = await prisma.shareLink.create({
-    data: {
-      diagnosisId: diagnosis.id,
-      uniqueUrl: 'seed-share-002',
-      passwordHash: '$2b$10$mock-bcrypt-hash',  // 테스트용 Mock 해시
-      viewCount: 2,
-      freePreviewUsed: true,
-      expiresAt: calculateExpiresAt(),
-    },
-  });
-  ```
-
-- [ ] **3.9** `__tests__/db/share-link-schema.spec.ts`에 스키마 검증 테스트 작성
-  ```typescript
-  import { prisma } from '@/lib/db';
-  import { calculateExpiresAt, isShareLinkExpired } from '@/lib/types/share-link-db';
-
-  describe('SHARE_LINK 테이블 스키마 검증', () => {
-    let diagnosisId: string;
-
-    beforeAll(async () => {
-      // 테스트용 User + Diagnosis 생성
-      const user = await prisma.user.create({ data: { email: 'share-test@example.com', authProvider: 'kakao' } });
-      const diagnosis = await prisma.diagnosis.create({
-        data: { userId: user.id, filters: {}, mode: 'couple' },
-      });
-      diagnosisId = diagnosis.id;
-    });
-
-    afterAll(async () => { await prisma.$disconnect(); });
-
-    it('ShareLink 생성 시 id가 UUID 형식으로 자동 생성된다', async () => { /* ... */ });
-    it('uniqueUrl에 UNIQUE 제약조건이 적용된다', async () => { /* ... */ });
-    it('passwordHash가 NULLABLE이다', async () => { /* ... */ });
-    it('viewCount 기본값이 0이다', async () => { /* ... */ });
-    it('freePreviewUsed 기본값이 false이다', async () => { /* ... */ });
-    it('Diagnosis 삭제 시 ShareLink CASCADE 삭제', async () => { /* ... */ });
-    it('존재하지 않는 diagnosisId로 생성 시 FK 에러', async () => { /* ... */ });
-    it('calculateExpiresAt()가 30일 후 날짜를 반환한다', () => {
-      const now = new Date('2026-04-25T00:00:00.000Z');
-      const expires = calculateExpiresAt(now);
-      expect(expires.toISOString()).toBe('2026-05-25T00:00:00.000Z');
-    });
-    it('isShareLinkExpired()가 만료 여부를 정확히 판단한다', () => {
-      expect(isShareLinkExpired(new Date('2020-01-01'))).toBe(true);
-      expect(isShareLinkExpired(new Date('2030-01-01'))).toBe(false);
-    });
-  });
-  ```
-
-- [ ] **3.10** Supabase 프로덕션 환경 RLS 정책 SQL 작성
-  - 파일: `prisma/migrations/manual/003_share_link_rls.sql`
-  ```sql
-  ALTER TABLE public.share_links ENABLE ROW LEVEL SECURITY;
-
-  -- 공유 링크는 인증 여부와 무관하게 uniqueUrl로 조회 가능 (비회원 열람)
-  CREATE POLICY "Anyone can read share links by unique_url" ON public.share_links
-    FOR SELECT USING (true);
-
-  -- 공유 링크 생성/수정은 인증된 사용자만 (service_role 또는 진단 소유자)
-  CREATE POLICY "Authenticated users can manage share links" ON public.share_links
-    FOR ALL USING (auth.role() = 'service_role');
-  ```
-
-- [ ] **3.11** MOCK-002 정합성 최종 확인
-  - `MOCK_SHARE_LINK_META_VALID`, `MOCK_SHARE_LINK_META_EXPIRED`, `MOCK_SHARE_LINK_META_PASSWORD`의 필드가 본 Prisma 모델의 컬럼 + 런타임 계산 필드(`isExpired`, `hasPassword`)와 정합하는지 코드 레벨 확인
+| Q | 분기 | 명세 v1.0 가정 | 현실 (4/29 schema) | 결정 | 후속 트리거 |
+|---|---|---|---|---|---|
+| **Q1** ★ | ShareLink 카디널리티 | `diagnosisId String` (1:N) + `@@index([diagnosisId])` | `diagnosisId String @unique` (1:0..1) + DB-003 §3.3 `shareLink ShareLink?` 양쪽 정합 | (C) 현실 추인 1:0..1 + §9 채널별 분리 재평가 메모 | DB-003 §9.4 + 본 §9.6 양쪽 트리거 (베타 피드백 + SHARE_LINK ISSUE) |
+| **Q2** | 인덱스 명시 | `@@index([diagnosisId])` + `@@index([uniqueUrl])` 명시 | `@unique` 자동 UNIQUE INDEX (`share_links_diagnosis_id_key` + `share_links_unique_url_key`) | (C) 현실 추인 + redundancy 사유 §2 명시 | — (REQ-NF-006 자동 충족) |
+| **Q3** ★ | `share-link-db.ts` helper 함수 | 3개 함수 (`calculateExpiresAt` / `isShareLinkExpired` / `generateShareLinkToken`) | 등가 인라인 5곳 동작 중 (`app/api/share/*` + `app/share/[uuid]/page.tsx`) | (A) CMD-SHARE-001 위임 | CMD-SHARE-001 helper 추출 + bcrypt 실 구현 + 호출처 통합 (§9.1) |
+| **Q4** | seed.ts ShareLink 시드 | 2건 (비번 있음/없음) | 부재 (DB-001/002/003 가드 일관) | (A) seed.ts 가드 보존 | INFRA-002 + Q1 재평가 + seed runner 결정 (§9.2) |
+| **Q5** | spec | 9 케이스 | vitest config 부재 + 9/9 무의미 | (A) TEST-* 위임 (DB-001/002/003 일관) | TEST-* (vitest config + spec 일괄, §9.7) |
+| **Q6** | RLS SQL | `manual/003_share_link_rls.sql` Supabase RLS | `manual/` 디렉토리 부재 + SQLite RLS 미지원 | (A) INFRA-002 + DB-007 위임 | INFRA-002 + DB-007 일괄 RLS (§9.5) |
+| **Q7** ★ | `ShareLinkMetaDTO` 정의 | API-003 / MOCK-002 산출물 | — (본 ISSUE 책임 외) | (A) API-003 위임 (DB-003 Q6 경계 일관) | API-003 + MOCK-002 (§9.3 / §9.4) |
+| **Q8** ★ | TS 타입 신규 작성 | 명세에 없음 | 좁힐 enum 가능성 String 컬럼 0건 (UUID/bcrypt/Int/Boolean/DateTime 명확 타입) | (A) 미작성 (DB-001 패턴 유사) | — (API-003 가 share-link.ts 처음부터 작성) |
 
 ---
 
-## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD — DB-002/003 ⏸ 패턴 일관)
 
-**AC-1 (정상):** ShareLink 생성 및 UUID v4 검증
-- **Given** 유효한 Diagnosis 레코드가 존재하는 상태
-- **When** `prisma.shareLink.create({ data: { diagnosisId, uniqueUrl: crypto.randomUUID(), expiresAt: calculateExpiresAt() } })` 실행
-- **Then** ShareLink 레코드가 생성되며, `id`가 UUID 형식, `uniqueUrl`이 UUID v4 형식 (entropy ≥ 128bit), `viewCount === 0`, `freePreviewUsed === false`
+**AC-1 (정상):** ShareLink 생성 및 UUID v4 검증 — **⏸ CMD-SHARE-001 + INFRA-002 후 검증**
+- **Given** 유효한 Diagnosis 레코드가 존재하는 상태 (DB-003 Q1 in-memory fake JSON embed)
+- **When** `prisma.shareLink.create({ data: { diagnosisId, uniqueUrl: ..., expiresAt: ... } })` 실행
+- **Then** ✅ schema 자체는 `valid 🚀` (Phase A.7 통과) — `id` / `uniqueUrl` UUID 형식, `viewCount === 0`, `freePreviewUsed === false` 기본값 보장 (`@default(uuid())`, `@default(0)`, `@default(false)`)
+- **⏸ 현 `src/lib/db.ts` in-memory fake** — Q3 인라인 호출처 (`app/api/share/route.ts:46-48`) 가 mock 동작. CMD-SHARE-001 (helper 추출 + bcrypt) + INFRA-002 (실 PrismaClient) 후 실 검증.
 
-**AC-2 (예외):** 동일 uniqueUrl 중복 생성 시 UNIQUE 에러
-- **Given** `uniqueUrl = 'dup-url-001'`로 ShareLink가 이미 존재
-- **When** 동일 `uniqueUrl`로 `prisma.shareLink.create()` 시도
-- **Then** Prisma `P2002` Unique constraint failed 에러 발생, 중복 행 0건
+**AC-2 (예외):** 동일 uniqueUrl 중복 생성 시 UNIQUE 에러 — **⏸ INFRA-002 후 검증**
+- Migration SQL 의 `CREATE UNIQUE INDEX "share_links_unique_url_key"` 로 DB 레벨 제약 보장.
+- **⏸ 현 in-memory fake — 실 PrismaClient swap 후 P2002 에러 검증**.
 
-**AC-3 (예외):** 존재하지 않는 diagnosisId로 생성 시 FK 에러
-- **Given** `diagnoses` 테이블에 `id = 'nonexistent'` 레코드가 없는 상태
-- **When** 해당 `diagnosisId`로 ShareLink 생성 시도
-- **Then** Prisma `P2003` Foreign key constraint failed 에러 발생
+**AC-3 (예외):** 존재하지 않는 diagnosisId FK 에러 — **⏸ INFRA-002 후 검증**
+- Migration SQL 의 `CONSTRAINT "share_links_diagnosis_id_fkey" ... ON DELETE CASCADE` 로 DB 레벨 강제.
+- **⏸ in-memory fake 미지원 — INFRA-002 후 P2003 에러 검증**.
 
-**AC-4 (경계):** 30일 만료일 정확성
-- **Given** `createdAt = 2026-04-25T00:00:00.000Z`
-- **When** `calculateExpiresAt(createdAt)` 호출
-- **Then** 반환값이 `2026-05-25T00:00:00.000Z` (정확히 30일 후)
+**AC-4 (경계):** 30일 만료일 정확성 — **⏸ CMD-SHARE-001 위임**
+- Q3 결정으로 `calculateExpiresAt()` helper 미작성. 현 인라인 `new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)` (`app/api/share/route.ts:48`) 동작.
+- **⏸ CMD-SHARE-001 시점에 helper 추출 + 30일 정확성 검증 (`createdAt = 2026-04-25T00:00:00.000Z` → `2026-05-25T00:00:00.000Z`)**.
 
-**AC-5 (경계):** Diagnosis CASCADE 삭제 시 ShareLink 동반 삭제
-- **Given** Diagnosis에 연결된 ShareLink 2건이 존재
-- **When** `prisma.diagnosis.delete({ where: { id: diagnosisId } })` 실행
-- **Then** 관련 ShareLink 2건 모두 삭제, 잔여 레코드 0건
+**AC-5 (경계):** Diagnosis CASCADE 삭제 시 ShareLink 동반 삭제 — **⏸ INFRA-002 후 검증**
+- Q1 1:0..1 + `diagnosisId @unique` + Migration `ON DELETE CASCADE` → DB 레벨 강제.
+- **⏸ in-memory fake 미지원 — INFRA-002 후 실 PrismaClient CASCADE 검증**.
 
-**AC-6 (정합성):** MOCK-002 ShareLink Mock과 스키마 정합
-- **Given** MOCK-002의 `ShareLinkMetaDTO` 필드 목록 (id, uniqueUrl, viewCount, expiresAt, isExpired, hasPassword, freePreviewUsed)
-- **When** DB-004의 Prisma ShareLink 모델 컬럼과 대조
-- **Then** id/uniqueUrl/viewCount/expiresAt/freePreviewUsed는 1:1 매칭, isExpired/hasPassword는 런타임 계산으로 정합 확인
+**AC-6 (정합성):** MOCK-002 ShareLink Mock 과 스키마 정합 — **⏸ API-003 + MOCK-002 위임**
+- Q7 결정으로 `ShareLinkMetaDTO` 정의는 API-003 영역. MOCK-002 의 `MOCK_SHARE_LINK_META_*` 와 schema 컬럼 + runtime 계산 필드 (`isExpired` / `hasPassword`) 정합은 API-003 + MOCK-002 동시 작업 시점에 검증.
 
 ---
 
@@ -276,20 +302,43 @@ assignees: []
 
 | NFR ID | SRS 본문 인용 | 본 태스크에서의 검증 방법 |
 |---|---|---|
-| REQ-NF-020 | "공유 링크 보안 — URL entropy ≥ 128bit (UUID v4), 열람 비밀번호 옵션, 열람 로그 실시간 알림" (§4.2.3) | `uniqueUrl`에 UUID v4 사용 (128bit entropy). `passwordHash` NULLABLE 컬럼으로 비밀번호 옵션 지원. `viewCount`로 열람 추적 |
-| REQ-NF-021 | "비인가 접근 시 개인정보 노출 0건" (§4.2.3) | 만료 링크 접근 시 `isShareLinkExpired()` 검증 후 데이터 미반환 — 스키마 레벨에서 `expires_at` NOT NULL 제약으로 만료일 누락 방지 |
-| REQ-NF-006 | "공유 링크 생성 응답 시간 — ≤ 500ms" (§4.2.1) | `@@index([diagnosisId])` + `@@index([uniqueUrl])` 인덱스로 조회 성능 보장. 생성 시 UUID 생성 + DB INSERT만으로 500ms 이내 달성 가능 |
+| REQ-NF-020 | "공유 링크 보안 — URL entropy ≥ 128bit (UUID v4), 열람 비밀번호 옵션, 열람 로그 실시간 알림" (§4.2.3) | ✅ schema 충족: `uniqueUrl @unique @default(uuid())` (128bit entropy) + `passwordHash String?` NULLABLE + `viewCount Int @default(0)`. bcrypt 실 구현 = CMD-SHARE-001 |
+| REQ-NF-021 | "비인가 접근 시 개인정보 노출 0건" (§4.2.3) | ✅ schema 충족: `expires_at NOT NULL` + Q3 인라인 `shareLink.expiresAt < new Date()` 분기 (`app/api/share/[uuid]/route.ts:24`) 가 만료 link 데이터 미반환 (status 410) |
+| REQ-NF-006 | "공유 링크 생성 응답 시간 — ≤ 500ms" (§4.2.1) | ✅ schema 충족: Q2 결정으로 `@unique` 자동 UNIQUE INDEX 2종 (`share_links_diagnosis_id_key` + `share_links_unique_url_key`) → 조회 O(log n) 보장. 실 측정 = CMD-SHARE-001 + INFRA-002 후 |
 
 ---
 
 ## 6. 📦 Deliverables (산출물 명시)
 
-- `prisma/schema.prisma` (model ShareLink + Diagnosis 역관계)
-- `prisma/migrations/{timestamp}_add_share_link/migration.sql`
-- `prisma/migrations/manual/003_share_link_rls.sql` (RLS 정책)
-- `lib/types/share-link-db.ts` (calculateExpiresAt, isShareLinkExpired, generateShareLinkToken)
-- `prisma/seed.ts` (ShareLink 시드 데이터 추가)
-- `__tests__/db/share-link-schema.spec.ts` (스키마 검증 테스트 9개 케이스)
+### DB-004 신규/수정 산출물 (본 ISSUE) — 정확히 1 파일
+- `tasks/DB-004.md` (본 문서 명세 갱신 — 현실 추인, Q1~Q8 결정 반영)
+- **코드 변경 0건** (Q8 결정으로 TS 타입 파일도 미작성, DB-001 패턴 유사)
+
+### DB-004 에서 보존 (14종, 본 ISSUE 미수정)
+- `onday-app/prisma/schema.prisma` (4/29, `model ShareLink` 4모델 통합 정의)
+- `onday-app/prisma/migrations/20260429125124_init/migration.sql` (4/29, `share_links` 테이블 + UNIQUE INDEX 2종 + FK CASCADE)
+- `onday-app/prisma.config.ts` / `onday-app/prisma/seed.ts` (4/29)
+- `onday-app/src/lib/db.ts` (in-memory store)
+- **`onday-app/src/lib/types/user.ts`** (DB-002 PR #76 머지본)
+- **`onday-app/src/lib/types/diagnosis.ts`** (DB-003 PR #77 머지본)
+- `onday-app/src/lib/types/errors/.gitkeep` (INFRA-001 `dc2ca37`)
+- `onday-app/__tests__/db/.gitkeep` (INFRA-001, TEST-* 시점 spec 추가 위치)
+- `onday-app/package.json` / `.env` / `.env.example` / `.gitignore`
+- **★ Q3 helper 인라인 호출처 5곳** (CMD-SHARE-001 통합 대상):
+  - `onday-app/src/app/api/share/route.ts` (L42 bcrypt mock, L46 randomUUID, L48 30일 계산)
+  - `onday-app/src/app/api/share/[uuid]/route.ts` (L24 만료 비교)
+  - `onday-app/src/app/share/[uuid]/page.tsx` (L20 만료 비교)
+- design 루트: `CLAUDE.md` / `AGENTS.md` / `docs/` / `.claude/` / `README-*` / `06_TASK_LIST_v1.3.md`
+
+### DB-004 에서 위임 (후속 ISSUE — 8종)
+- helper 3개 (`calculateExpiresAt` / `isShareLinkExpired` / `generateShareLinkToken`) + bcrypt 실 구현 + 인라인 호출처 5곳 통합 → **CMD-SHARE-001** (Q3)
+- bcrypt salt round 결정 → CMD-SHARE-001 / CMD-SHARE-004
+- `src/lib/types/share-link.ts` 신규 + `ShareLinkMetaDTO` + `isExpired` / `hasPassword` runtime 계산 → **API-003** (Q7)
+- MOCK-002 ShareLink Mock 정합 → MOCK-002
+- 실 PrismaClient swap + AC-1~AC-5 활성 → **INFRA-002**
+- RLS SQL `manual/003_share_link_rls.sql` → **INFRA-002 + DB-007** (Q6)
+- spec 9 케이스 + vitest config → **TEST-*** (Q5)
+- 채널별 분리 1:N 재평가 → 베타 피드백 + SHARE_LINK ISSUE (Q1, DB-003 §9.4 양쪽 트리거)
 
 ---
 
@@ -297,44 +346,92 @@ assignees: []
 
 ### 선행 (이 태스크 시작 전 필요):
 
-- **DB-001:** `prisma/schema.prisma` datasource + `lib/db.ts`
-- **DB-003:** `model Diagnosis` — ShareLink.diagnosisId FK 대상
+- **DB-003** (PR #77 머지 완료, main `18de316`): `model Diagnosis` (4/29) + `shareLink ShareLink?` 1:0..1 역관계 (DB-003 §3.3 Q5 결정) + `src/lib/types/diagnosis.ts`
+- **DB-002** (PR #76 머지 완료, main `d916a6f`) / **DB-001** (PR #75 머지 완료, main `1ef7d84`): 간접 선행 (Prisma 7 초기화 + npm scripts + USER 도메인 타입)
 
 ### 후행 (이 태스크 완료 후 차례로 가능):
 
-- **API-003:** ShareLink DTO — DB-004의 Prisma 모델을 기반으로 DTO 변환
-- **MOCK-002:** ShareLink Mock — DB-004 스키마 기반 Mock 객체 타입 검증
-- **CMD-SHARE-001:** 공유 링크 생성 Server Action — DB-004의 ShareLink 모델로 CREATE + bcrypt 해싱
-- **CMD-SHARE-004:** 비밀번호 검증 — DB-004의 `passwordHash` 컬럼 활용
-- **QRY-SHARE-001:** 리포트 SSR 열람 — DB-004의 ShareLink 조회 + 만료 검증
+- **CMD-SHARE-001** (공유 링크 생성 Server Action): ★ **Q3 helper 추출 + bcrypt 실 구현 + 인라인 호출처 5곳 통합** (`app/api/share/route.ts:42, 46, 48` + `[uuid]/route.ts:24` + `page.tsx:20`)
+- **CMD-SHARE-002 ~ 004** (재발급 / 비밀번호 / 만료): Q1 1:0..1 정합 — "재발급 = update" 패턴 채택
+- **API-003** (ShareLink DTO): ★ Q7 — `src/lib/types/share-link.ts` 신규 작성 + `ShareLinkMetaDTO` 정의 + runtime 계산
+- **MOCK-002** (ShareLink Mock 데이터): API-003 DTO 정합 검증
+- **QRY-SHARE-001** (리포트 SSR 열람): `app/share/[uuid]/page.tsx:20` 인라인 → CMD-SHARE-001 helper 통합 후 호출
+- **INFRA-002** (Supabase Postgres): 실 PrismaClient swap + AC-1~AC-5 활성
+- **DB-007** (Supabase Auth + RLS): Q6 RLS SQL 일괄 작성
+- **TEST-*** : vitest config + 9 케이스 spec
+
+### ★ Q1 양쪽 트리거 (DB-003 §9.4 ↔ 본 §9.6 동시 활성)
+
+DB-003 §9.4 follow-up 인용:
+> "채널별 분리 공유 (카카오톡/이메일/슬랙) 요구 발생 시 1:N 재평가 — 베타 피드백 + INFRA-002 + SHARE_LINK 관련 ISSUE 트리거. SRS ERD `DIAGNOSIS ──< SHARE_LINK` 도식 정합 검토 포함."
+
+→ 본 §9.6 follow-up 도 동일 트리거 명시 — 미래 재평가 시점에 DB-003 + DB-004 양쪽 메모 동시 활성. Diagnosis ↔ ShareLink 양쪽 모델 동시 갱신 필요.
 
 ---
 
 ## 8. 🧪 Test Plan (검증 절차)
 
-- **단위 테스트:** `__tests__/db/share-link-schema.spec.ts` — 9개 케이스 (UUID 생성, UNIQUE uniqueUrl, NULLABLE passwordHash, viewCount 기본값, freePreviewUsed 기본값, CASCADE 삭제, FK 위반, 30일 만료 계산, 만료 판단)
-- **마이그레이션 검증:** `npx prisma migrate diff` drift 0건
-- **타입 검증:** `npx tsc --noEmit` 통과
-- **수동 검증:**
-  1. `npx prisma studio`에서 ShareLink 테이블 CRUD 확인
-  2. 만료일이 정확히 30일 후인지 시드 데이터로 확인
-- **CI 게이트:** `npx prisma validate`, `tsc --noEmit`, Jest 테스트 통과
+- **단위 테스트:** ⏸ TEST-* 위임 (§3.9 참조, 9/9 무의미). 본 ISSUE 미작성.
+- **CLI 검증 (Phase A/D 통과):**
+  1. `npm run db:validate` — exit 0 `"valid 🚀"` (Phase A.7)
+  2. `npx prisma generate` — exit 0 (Phase A.7, Prisma Client 7.8.0)
+  3. `npx tsc --noEmit` — exit 0 (Phase A.7 baseline 유지, 코드 변경 0 → 회귀 0)
+  4. env-less `npm run build` — exit 0, **Middleware 32.5 kB** (INFRA-001 AC-4 기준선, Phase A.8 + Phase D)
+  5. `grep -i "password" onday-app/prisma/schema.prisma` — User 모델 내 0건 (DB-002 AC-6 일관, Phase D) + ShareLink L48 `passwordHash` 별도 정상 필드 (본 ISSUE 영역)
+- **타입 검증:** Phase A `tsc --noEmit` exit 0 — 코드 변경 0 → 회귀 0
+- **DB 검증:** ⏸ INFRA-002 swap 후 (AC-1~AC-5 활성)
+- **CI 게이트 (본 ISSUE):** `prisma validate` + `prisma generate` + `tsc --noEmit` + env-less `npm run build` 통과 (Phase D)
 
 ---
 
-## 9. 🚧 Open Questions / Risks (보류 사항)
+## 9. 🚧 Open Questions / Risks (보류 사항 — Q1~Q8 follow-up 8종 + 보조)
 
-### 정합성 follow-up (배치 1~4 검증 결과)
+### §9.1 ★ Q3 helper 추출 + bcrypt 실 구현 + 인라인 호출처 5곳 통합 = CMD-SHARE-001
+- 인라인 호출처 5곳 (`app/api/share/route.ts:42, 46, 48` + `[uuid]/route.ts:24` + `page.tsx:20`) 을 CMD-SHARE-001 시점에 helper 호출로 리팩토링.
+- `calculateExpiresAt(createdAt?: Date): Date` + `isShareLinkExpired(expiresAt: Date): boolean` + `generateShareLinkToken(): string` 3개 추출.
+- bcrypt salt round 결정 (`bcrypt.hash(password, 10)` 권장) — 명세 §9.1 일관 보조 결정.
+- 위치 결정: `src/features/share/` 또는 `src/lib/share-link/` — CMD-SHARE-001 ISSUE 가 결정.
 
-| 갱신 대상 ISSUE | 갱신 사유 | 우선순위 |
-|---|---|---|
-| MOCK-002.md | Mock 객체의 `ShareLinkMetaDTO` 필드가 본 Prisma 모델과 정합 확인됨. `isExpired`/`hasPassword`는 런타임 계산 필드로 Prisma 모델에 컬럼이 없는 것이 정상. 정합성 OK — follow-up 없음 | — |
-| API-003.md | ERD 컬럼 표와 본 Prisma 모델 정합 확인됨. 모든 컬럼이 1:1 매칭. 정합성 OK — follow-up 없음 | — |
-| DB-003.md | Task 3.3에서 `shareLinks ShareLink[]` 관계 필드가 이미 선언됨. 정합성 OK — follow-up 없음 | — |
+### §9.2 Q4 ShareLink 시드 = INFRA-002 + DB-003 Diagnosis 시드 재평가 + Q3 helper 추출 동시 활성화
+- 현 seed.ts 가드 (DB-001/002/003 일관) + tsx 부재.
+- 실 seed 실행 결정 = INFRA-002 (in-memory → 실 Prisma 전환) + DB-003 Q1 (CandidateArea 정규화) 재평가 + Q3 helper 추출 (CMD-SHARE-001) **함께** 일괄 결정.
+- seed runner 결정 (tsx 설치 / Prisma 7 자체 TS runner / .js 사전 컴파일 등) DB-001 §3.9 일관 적용.
 
-### 기타 보류 사항
+### §9.3 Q7 `ShareLinkMetaDTO` 정의 = API-003
+- `src/lib/types/share-link.ts` 신규 작성 (DB-003 의 `diagnosis.ts` 와 달리 base type 부재로 처음부터 작성).
+- `ShareLinkMetaDTO` 인터페이스 + `isExpired` / `hasPassword` runtime 계산 필드.
+- DB-003 의 `DiagnosisStatusType` 같은 base union 재사용 불필요 (Q8 — ShareLink 좁힐 enum 컬럼 0건).
 
-1. **bcrypt 해싱 비용:** `passwordHash` 컬럼에 저장할 bcrypt 해시의 salt round는 CMD-SHARE-001에서 결정. 일반적으로 `bcrypt.hash(password, 10)` (salt round 10) 사용 권장. — CMD-SHARE-001 작업 시 확정.
-2. **만료 링크 자동 삭제 vs 조회 시 검증:** SRS에서 "만료된 링크 접근 시 안내 페이지"를 요구하므로, 만료된 레코드를 물리 삭제하지 않고 `isShareLinkExpired()` 런타임 검증으로 처리. Cron Job으로 오래된 만료 링크를 정리하는 것은 향후 검토.
-3. **SRS ERD의 `unique_url` 컬럼과 `id` 컬럼 역할 구분:** SRS ERD에서 `unique_url`이 별도 UNIQUE 컬럼으로 정의됨. `id` (PK)와 `unique_url` (공유 토큰)을 분리하는 이유: PK는 내부 참조용, unique_url은 외부 공유용. URL에 PK를 노출하지 않아 보안 강화.
-4. **free_preview_used 상태 관리:** 무료 미리보기 1곳을 "어떤 후보 동네"로 할지는 CMD-SHARE-001/QRY-SHARE-001에서 결정. DB-004는 boolean 플래그만 제공.
+### §9.4 Q7 MOCK-002 정합 = API-003 + MOCK-002 동시 작업
+- `MOCK_SHARE_LINK_META_VALID / EXPIRED / PASSWORD` 와 API-003 의 `ShareLinkMetaDTO` 정합 검증.
+- `isExpired` / `hasPassword` runtime 계산 필드 일관성 확인.
+
+### §9.5 Q6 RLS SQL = INFRA-002 + DB-007
+- `prisma/migrations/manual/` 디렉토리 부재 + SQLite RLS 미지원 → INFRA-002 + DB-007 시점에 모든 테이블 RLS 일괄 작성.
+- 명세 §3.10 SQL 가정:
+  ```sql
+  ALTER TABLE public.share_links ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY "Anyone can read share links by unique_url" ON public.share_links FOR SELECT USING (true);
+  CREATE POLICY "Authenticated users can manage share links" ON public.share_links FOR ALL USING (auth.role() = 'service_role');
+  ```
+
+### §9.6 ★ Q1 채널별 분리 1:N 재평가 = 베타 피드백 + INFRA-002 + SHARE_LINK 관련 ISSUE
+- 현 1:0..1 (`diagnosisId @unique`) → MVP 단일 공유 시나리오 (REQ-FUNC-011).
+- 채널별 분리 공유 (카카오톡/이메일/슬랙) 요구 발생 시 → 베타 피드백 + INFRA-002 + SHARE_LINK 관련 ISSUE 트리거.
+- **DB-003 §9.4 와 동일 재평가 트리거 (미래 양쪽 동시 활성)** — Diagnosis ↔ ShareLink 양쪽 모델 동시 갱신.
+- SRS ERD `DIAGNOSIS ──< SHARE_LINK` 도식과의 정합 검토 포함.
+
+### §9.7 Q5 spec 작성 = TEST-*
+- vitest config 부재 + in-memory fake 검증 무의미 + 9 / 9 무의미 (Q1~Q4 결정 영향).
+- TEST-* 시점에 config + 모든 spec 일괄 작성 (DB-001/002/003 §3.10 일관).
+
+### §9.8 Q1 ↔ DB-003 §3.3 / §9.4 양쪽 모델 정합 검증 (현실 추인 완료)
+- 본 ISSUE Q1 (1:0..1) + DB-003 §3.3 (`shareLink ShareLink?`) 양쪽 일치 — Phase A.3 검증 완료.
+- 미래 재평가 시점에 양쪽 명세 동시 갱신 필요 (§9.6 트리거 시).
+
+### 보조 follow-up
+
+- **만료 링크 자동 삭제 vs 조회 시 검증:** SRS REQ-FUNC-010 "만료된 링크 접근 시 안내 페이지" 요구 → 만료된 레코드 물리 삭제하지 않고 `isShareLinkExpired()` 런타임 검증 (현 인라인 `expiresAt < new Date()` 패턴 일관). Cron Job 으로 오래된 만료 링크 정리 = 향후 검토 (운영 단계).
+- **SRS ERD 의 `unique_url` vs `id` 역할 구분:** `id` (PK, 내부 참조) / `unique_url` (공유 토큰, 외부 노출). URL 에 PK 노출 안 함 → 보안 강화. 명세 v1.0 §9 일관.
+- **free_preview_used 상태 관리:** 무료 미리보기 1곳을 "어떤 후보 동네" 로 할지는 CMD-SHARE-001 / QRY-SHARE-001 에서 결정. DB-004 는 Boolean 플래그만 제공.
+- **DB-005 ~ 007 ISSUE 현실 추인 패턴 예고 (DB-001/002/003/004 일관):** 4모델 (User/Diagnosis/ShareLink/SavedSearch) 모두 4/29 schema 에 이미 정의됨. 각 ISSUE 는 "신규 작성" → "현실 추인 + INFRA-002 후 RLS/enum/JSONB 추가" 패턴.


### PR DESCRIPTION
## 산출물 (1 commit, 1 file — ★ 코드 변경 0건)

| 커밋 | 종류 | 파일 | 변경량 |
|---|---|---|---|
| `3a03d4c` | docs | `tasks/DB-004.md` (현실 동기화) | +346/-249 |

`main` (`18de316` PR #77 머지본) 대비 변경: **정확히 1 파일** (`git diff main --name-only` 검증). **코드 변경 0건** — Q8 결정 (ShareLink 좁힐 enum 컬럼 0건) + Q3 결정 (helper = CMD-SHARE-001 위임) + Q7 결정 (DTO = API-003 위임) 누적 결과. DB-001 패턴 유사 (Phase B 생략).

★ **feat 커밋 없음 — 코드 변경 0건이라 정상.** "코드/문서 분리" 원칙은 분리할 코드가 없을 뿐 (위반 아님). 억지로 dead file 만들지 않음.

## ✅ AC 검증 결과 표

| 검증 | 결과 |
|---|---|
| `npm run db:validate` (= `npx prisma validate`) | ✅ exit 0 — `"valid 🚀"` |
| `npx prisma generate` | ✅ exit 0 — Prisma Client 7.8.0 → `./src/generated/prisma` |
| `npx tsc --noEmit` | ✅ exit 0 (Phase A 기준선 유지, 코드 변경 0 → 회귀 0) |
| env-less `npm run build` | ✅ exit 0 — 13/13 static pages, **Middleware 32.5 kB** (INFRA-001 AC-4 기준선 정확히 일치, **5번째 회귀 0** — INFRA-001/DB-001/002/003/004 누적 보존) |
| `grep -i "password"` (User 모델 L10–22) | ✅ **0건** (DB-002 AC-6 일관). ShareLink L48 `passwordHash` 는 별도 정상 필드 — 본 ISSUE 영역 (REQ-FUNC-010 공유 링크 비밀번호 보호) |

### AC 표 (DB-002/003 ⏸ 패턴 일관)

| AC | 상태 | 비고 |
|---|---|---|
| AC-1 ShareLink 생성 + UUID 검증 | ⏸ CMD-SHARE-001 + INFRA-002 후 | schema 자체 valid 🚀. Q3 인라인 호출처 (`route.ts:46-48`) mock 동작 중 |
| AC-2 uniqueUrl UNIQUE 에러 | ⏸ INFRA-002 후 | DB 레벨: `CREATE UNIQUE INDEX "share_links_unique_url_key"` 강제 |
| AC-3 FK 에러 (nonexistent diagnosisId) | ⏸ INFRA-002 후 | DB 레벨: `share_links_diagnosis_id_fkey ON DELETE CASCADE` |
| AC-4 30일 만료일 정확성 | ⏸ CMD-SHARE-001 위임 | Q3 helper 미작성. 현 인라인 `Date.now() + 30 * 24 * 60 * 60 * 1000` 동작 |
| AC-5 Diagnosis CASCADE 시 ShareLink 동반 삭제 | ⏸ INFRA-002 후 | Q1 1:0..1 + Migration `ON DELETE CASCADE` |
| AC-6 MOCK-002 정합 | ⏸ API-003 + MOCK-002 위임 | Q7 DTO 정의 = API-003 영역 |

## ★ Q1~Q8 결정 vs 명세 v1.0 mismatch 추적 표

| Q | 분기 | 명세 v1.0 | 현실 (4/29 schema) | 결정 | 후속 트리거 |
|---|---|---|---|---|---|
| **Q1** ★ | 카디널리티 | `diagnosisId String` (1:N) + `@@index` | `@unique` 1:0..1 + DB-003 §3.3 정합 | (C) 현실 추인 + §9.6 메모 | DB-003 §9.4 ↔ 본 §9.6 양쪽 트리거 |
| **Q2** | 인덱스 명시 | `@@index([diagnosisId])` + `@@index([uniqueUrl])` | `@unique` 자동 UNIQUE INDEX 2종 | (C) 현실 추인 + redundancy 사유 §2 | — (REQ-NF-006 자동 충족) |
| **Q3** ★ | helper 함수 | 3개 함수 (`calculateExpiresAt` 등) | 등가 인라인 5곳 동작 중 | (A) CMD-SHARE-001 위임 | CMD-SHARE-001 helper 추출 + bcrypt (§9.1) |
| **Q4** | seed | 시드 2건 | 부재 (가드 일관) | (A) 가드 보존 | INFRA-002 + Q1 재평가 + seed runner (§9.2) |
| **Q5** | spec | 9 케이스 | vitest 부재 + 9/9 무의미 | (A) TEST-* 위임 | TEST-* (§9.7) |
| **Q6** | RLS SQL | `manual/` Supabase RLS | `manual/` 부재 + SQLite 미지원 | (A) INFRA-002 + DB-007 위임 | INFRA-002 + DB-007 (§9.5) |
| **Q7** ★ | DTO 정의 | API-003 / MOCK-002 | — (본 ISSUE 책임 외) | (A) API-003 위임 (DB-003 Q6 경계 일관) | API-003 + MOCK-002 (§9.3 / §9.4) |
| **Q8** ★ | TS 타입 신규 | 명세에 없음 | 좁힐 enum 컬럼 0건 | (A) 미작성 (DB-001 패턴) | — (API-003 가 `share-link.ts` 처음 작성) |

## ★ §3.7 helper 인라인 호출처 5곳 (CMD-SHARE-001 통합 대상)

| # | 위치 | 인라인 로직 (현 동작) | 명세 등가 함수 | CMD-SHARE-001 통합 |
|---|---|---|---|---|
| 1 | `app/api/share/route.ts:42` | `passwordHash = password ? \`mock_hash_${password}\` : null` | (bcrypt — CMD-SHARE-001 추가 책임) | 실 `bcrypt.hash(password, 10)` 교체 |
| 2 | `app/api/share/route.ts:46` | `uniqueUrl: randomUUID()` | `generateShareLinkToken` | helper 추출 + 호출 |
| 3 | `app/api/share/route.ts:48` | `expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)` | `calculateExpiresAt` | helper 추출 + 호출 |
| 4 | `app/api/share/[uuid]/route.ts:24` | `if (shareLink.expiresAt < new Date()) { ... 410 ... }` | `isShareLinkExpired` | helper 추출 + 호출 |
| 5 | `app/share/[uuid]/page.tsx:20` | `if (shareLink.expiresAt < new Date()) { type: "expired" ... }` | `isShareLinkExpired` | helper 추출 + 호출 |

→ **5곳 모두 본 PR 미수정** (가드 14종에 포함). CMD-SHARE-001 시점 일괄 통합.

## §9 follow-up 9종 (Q1~Q8 + 보조)

| § | 항목 | 트리거 |
|---|---|---|
| **§9.1 ★** | Q3 helper 추출 + bcrypt 실 구현 + 인라인 호출처 5곳 통합 | CMD-SHARE-001 |
| §9.2 | Q4 ShareLink 시드 | INFRA-002 + DB-003 Q1 재평가 + Q3 helper 추출 동시 활성 |
| **§9.3 ★** | Q7 `ShareLinkMetaDTO` + `share-link.ts` 신규 (DB-003 의 append 아닌 처음부터 작성) | API-003 |
| §9.4 | Q7 MOCK-002 정합 | API-003 + MOCK-002 동시 작업 |
| §9.5 | Q6 RLS SQL | INFRA-002 + DB-007 |
| **§9.6 ★** | Q1 채널별 분리 1:N 재평가 | **DB-003 §9.4 ↔ 본 §9.6 양쪽 동시 트리거** (베타 피드백 + INFRA-002 + SHARE_LINK ISSUE) |
| §9.7 | Q5 spec + vitest config | TEST-* |
| §9.8 | Q1 ↔ DB-003 §3.3 / §9.4 양쪽 모델 정합 (현실 추인 완료) | (미래 재평가 시 양쪽 동시 갱신) |
| 보조 | 만료 링크 자동 삭제 / unique_url vs id 역할 / free_preview_used / DB-005~007 패턴 예고 | — |

## 가드 14종 (절대 불변, 본 PR 변경 0)

✅ 가드 6종 검증 표 (PR 내 `git diff main -- <file>` 으로 unchanged 재확인):

| 가드 | 상태 |
|---|---|
| `onday-app/prisma/schema.prisma` | ✅ unchanged |
| `onday-app/src/lib/db.ts` (in-memory) | ✅ unchanged |
| **`onday-app/src/lib/types/user.ts`** (DB-002 PR #76) | ✅ unchanged |
| **`onday-app/src/lib/types/diagnosis.ts`** (DB-003 PR #77) | ✅ unchanged |
| **`onday-app/src/app/api/share/route.ts`** (Q3 호출처 L42/46/48) | ✅ unchanged |
| **`onday-app/src/app/share/[uuid]/page.tsx`** (Q3 호출처 L20) | ✅ unchanged |

기타 가드: `prisma.config.ts` · `migrations(4/29)` · `seed.ts` · `errors/.gitkeep` · `tests/db/.gitkeep` · `package.json` · design 루트 · `06_TASK_LIST_v1.3.md` · `app/api/share/[uuid]/route.ts` (Q3 호출처 L24) — 모두 변경 0건.

## 위임 (후속 ISSUE — §9 Open Q)

| 항목 | 위임 대상 |
|---|---|
| Q3 helper 추출 + bcrypt 실 구현 + 인라인 호출처 5곳 통합 | **CMD-SHARE-001** |
| bcrypt salt round 결정 | CMD-SHARE-001 / CMD-SHARE-004 |
| Q7 `ShareLinkMetaDTO` + `share-link.ts` 신규 + runtime 계산 | **API-003** |
| MOCK_SHARE_LINK_META_* DTO 정합 | MOCK-002 |
| 실 PrismaClient swap + AC-1~AC-5 활성 | **INFRA-002** |
| Q6 RLS SQL + auth.users 정렬 | **INFRA-002 + DB-007** |
| Q5 spec + vitest config | **TEST-*** |
| Q1 채널별 분리 1:N 재평가 | **베타 피드백 + SHARE_LINK ISSUE** (DB-003 §9.4 양쪽 동시 트리거) |

## 상세 명세

[`tasks/DB-004.md`](./tasks/DB-004.md) — 현실 동기화 갱신본 (437줄, 595 line changed, +346/-249)

## 후행 ISSUE 현실 추인 패턴 예고

- **DB-006 (SAVED_SEARCH 스키마)**: User FK + 단일 인덱스 패턴 답습 예상
- **DB-007 (Supabase Auth USER 정렬)**: INFRA-002 + Q6 RLS SQL 일괄 작성 (본 ISSUE §9.5 트리거)
- **API-003 (ShareLink DTO)**: ★ Q7 — `share-link.ts` 신규 작성 + `ShareLinkMetaDTO` 정의 (DB-003 의 append 패턴과 다름)
- **CMD-SHARE-001~004**: ★ Q3 — helper 추출 + bcrypt + 인라인 호출처 5곳 통합

Refs #8