### PR TITLE
docs(DB-006): SAVED_SEARCH 명세 현실 동기화 (Q1~Q8 + id @id+userId @unique PK 컨벤션 + Zod/DTO/RLS 위임)

### DIFF
--- a/tasks/DB-006.md
+++ b/tasks/DB-006.md
@@ -1,21 +1,30 @@
 ---
 name: Feature Task
-title: "[Feature] DB-006: SAVED_SEARCH 테이블 Prisma 스키마 (3필드 단순화 버전)"
+title: "[Feature] DB-006: SAVED_SEARCH 도메인 명세 현실 동기화 (기존 onday-app/ SavedSearch schema 베이스 — Zod = CMD-SAVE-001 / DTO = API-005 / RLS = INFRA-002+DB-007 위임. 본 ISSUE 산출물 = 명세 동기화만, 코드 0)"
 labels: ['feature', 'priority:L', 'epic:Data Foundation', 'wave:1']
 assignees: []
 ---
 
 ## 1. 🎯 Summary
 
-- **기능명:** [DB-006] SAVED_SEARCH 테이블 Prisma 스키마 정의 및 마이그레이션 (user_id, search_params, saved_at 3필드)
+- **기능명:** [DB-006] SAVED_SEARCH 도메인 명세 현실 동기화. SavedSearch schema 자체는 4/29 산출물로 이미 완전 정의됨 (PK 컨벤션 일관성 — DB-001~004 surrogate PK 답습). Zod validator / DTO / RLS / spec / seed 모두 후행 ISSUE 위임. 본 ISSUE 산출물 = `tasks/DB-006.md` 1 파일 (코드 변경 0건, DB-004 패턴 정확히 답습).
 - **목적 (Why):**
-  - **비즈니스:** 반복 이사자(C-04)가 이전 탐색 조건을 저장·복원하여 매 이사 건마다 원점에서 재시작하지 않고, 즉시 새 진단을 수행할 수 있는 데이터 기반을 마련한다.
-  - **사용자 가치:** 세션 종료 시 입력 조건(주소·필터·시간대)이 자동 저장되어, 다음 방문 시 1초 이내에 이전 조건을 복원하고 "진단 시작"만 클릭하면 된다.
+  - **비즈니스:** 반복 이사자(C-04)의 이전 탐색 조건 저장·복원 데이터 기반은 이미 4/29 schema 에 완전 정의되어 있으며, 본 ISSUE 는 명세 v1.0 과 현실 간 정합성을 동기화하고 후행 ISSUE 위임 트리거를 명시한다. UPSERT 패턴 (userId @unique 강제), JSON string 저장 (SQLite), best effort 동작 모두 schema + in-memory fake 레벨에서 보장됨.
+  - **사용자 가치:** 세션 종료 시 입력 조건 자동 저장 → 다음 방문 시 1초 이내 복원 (REQ-FUNC-025) 인프라가 schema + fake API 레벨에서 확보됨. 실 동작 로직은 CMD-SAVE-001 (Zod 추출 + strict/passthrough 확정 + 호출처 7곳 통합) + API-005 (`SearchParams` + `SavedSearchDTO` 정의 + `mode = ServiceModeType` import) + INFRA-002 + DB-007 (실 PrismaClient + RLS) 협업으로 활성화.
 - **범위 (What):**
-  - ✅ 만드는 것: `SAVED_SEARCH` 테이블을 3필드(user_id, search_params, saved_at)로 Prisma 스키마 정의, 마이그레이션 생성, 관련 타입 정의
-  - ❌ 만들지 않는 것: 비교 뷰(REQ-FUNC-026 제거됨), 시나리오 비교(REQ-FUNC-027 제거됨), 행정동 변경 감지(REQ-FUNC-028 제거됨), SavedSearch CRUD 로직(CMD-SAVE-001 범위)
+  - ✅ 만드는 것: 본 명세 현실 동기화 (`tasks/DB-006.md`) — Q1~Q8 결정 반영 + Q1~Q8 mismatch 추적 표 + Q3 Zod 인라인 호출처 8행 위치 기록 + §9 follow-up 8종
+  - ❌ 만들지 않는 것 (Q1~Q8 결정 일관):
+    - **`prisma/schema.prisma` 의 `model SavedSearch` 신규 작성 / 수정** — 4/29 부트스트랩 시 이미 완전 정의됨 (사용자 가드). Q1 (`id @id @default(uuid()) + userId @unique` PK 컨벤션 일관) + Q2 (`searchParams String JSON`) + Q7 (모든 컬럼 명확 타입) 모두 현실 정합.
+    - **신규 마이그레이션 (`add_saved_search`)** — 4/29 `_init` migration 의 `saved_searches` 테이블 + UNIQUE INDEX (`saved_searches_user_id_key`) + FK CASCADE 이미 존재. 사용자 가드.
+    - **`lib/validators/saved-search.ts` Zod schema (`searchParamsSchema`)** — Q3 결정: 등가 인라인 Zod 가 `app/api/save/route.ts` 8행 (L3, L5-7, L13, L22-32, L26, L29, L49, L58) 에 동작 중. DB-* 일관 원칙 ("DB ISSUE = type/스키마/인프라 만, 동작 로직 = 후행 CMD-*/API-*") 위반. **CMD-SAVE-001 위임** + 명세 §9.1 자체가 strict/passthrough 최종 결정을 CMD-SAVE-001 로 직접 위임 명시.
+    - **`prisma/seed.ts` SavedSearch 시드** — Q4 결정: DB-001~004 §3.9 가드 일관 + tsx 부재 + 명세 §3 task list / §6 Deliverables 자체에 seed 미정의.
+    - **`__tests__/db/saved-search-schema.spec.ts`** — Q5 결정: vitest config 부재 + in-memory fake meaningless. 명세 §3.8 의 6 spec 케이스가 Q1~Q3 결정으로 6/6 무의미. **TEST-* 위임 (DB-001~004 §3.10 일관)**.
+    - **`prisma/migrations/manual/002_saved_search_rls.sql` RLS SQL** — Q6 결정: `prisma/migrations/manual/` 디렉토리 자체 부재 + SQLite RLS 미지원 + Supabase 환경 비활성. **INFRA-002 + DB-007 위임** (auth.users FK + 모든 테이블 RLS 일괄 작성, DB-004 Q6 일관).
+    - **`SavedSearchDTO` / `SearchParams` interface 정의 (`lib/types/saved-search.ts`)** — Q8 결정: DB-003 Q6 / DB-004 Q7 경계 일관 ("DB-* = base type, DTO = API-* 영역"). **API-005 위임** (명세 §7 자체가 API-005 매핑 직접 명시 + `mode = ServiceModeType` user.ts import 패턴).
+    - **`src/lib/types/saved-search.ts` TS union 타입 신규** — Q7 결정: SavedSearch 모든 컬럼이 명확 타입 (String UUID/FK, JSON 직렬화 String, DateTime). 좁힐 enum 가능성 String 컬럼 0건. `SearchParams.mode` 는 user.ts `ServiceModeType` 재사용 (DTO 영역 — API-005 위임). **TS 타입 미작성 — DB-001 / DB-004 패턴 유사 (산출물 = 명세 갱신만)**. 억지로 dead file 생성 금지.
+    - **password / password_hash / salt 컬럼** — DB-002 가드 (OAuth-only, 절대 금지). ShareLink 의 `passwordHash` 는 별도 모델 정상 필드 (DB-004 영역). SavedSearch 에는 password 관련 컬럼 0건 (도메인 분리).
 - **복잡도:** L
-- **Wave:** 1 (DB 스키마 트랙)
+- **Wave:** 1 (Data Foundation 트랙)
 
 ---
 
@@ -23,18 +32,63 @@ assignees: []
 
 ### SRS 인용 (REQ ID + 본문 발췌)
 
-- **REQ-FUNC-025** (§4.1.5): "시스템은 사용자가 진단을 완료하고 세션 종료 또는 앱 종료 시 입력 조건(주소·필터·시간대)을 자동 저장해야 한다. 저장은 best effort로 처리하며 실패 시 사용자에게 알리지 않는다. 다음 방문 시 복원 시간은 1초 이내여야 하며, 불러온 주소가 geocoding 실패 시 \"주소를 다시 입력해주세요\" 안내를 표시한다."
-- **REQ-NF-016** (§4.2.2): "입력값 자동 저장 성공률 — Best effort (저장 실패 시 무시, 사용자 미통지)"
+- **REQ-FUNC-025** (§4.1.5): "시스템은 사용자가 진단을 완료하고 세션 종료 또는 앱 종료 시 입력 조건(주소·필터·시간대)을 자동 저장해야 한다. 저장은 best effort 로 처리하며 실패 시 사용자에게 알리지 않는다. 다음 방문 시 복원 시간은 1초 이내여야 하며, 불러온 주소가 geocoding 실패 시 \"주소를 다시 입력해주세요\" 안내를 표시한다."
+- **REQ-NF-016** (§4.2.2): "입력값 자동 저장 성공률 — Best effort (저장 실패 시 무시, 사용자 미통지)" — Q3 결정 (Zod 검증 + UPSERT best effort = CMD-SAVE-001) 근거
+- **REQ-NF-012** (§4.2.2): "서버 오류율 (5xx 응답) ≤ 0.5%" — UPSERT 실패가 500 전파되지 않도록 catch + Sentry 패턴 (CMD-SAVE-001 책임)
 
-### ERD 컬럼 (§6.2.5 SAVED_SEARCH — Rev 1.5 단순화)
+### `prototypes/design/CLAUDE.md` §3 (1인 MVP 제약) 인용
 
-> **Rev 1.5 변경:** 3필드로 단순화. 사용자당 최신 1건만 유지 (UPSERT).
+> "Server Action 은 Geocoding·커버리지 검증·**저장만** 담당."
 
-| 필드명 | 타입 | 제약조건 | 설명 |
+→ SavedSearch UPSERT 는 Server Action 의 저장 책임 영역 (CMD-SAVE-001).
+
+### ERD 컬럼 vs 현 schema.prisma (§6.2.5 SAVED_SEARCH — Rev 1.5 단순화 + 현실 추인)
+
+| 필드명 | SRS 정의 (Rev 1.5) | 현 schema.prisma (4/29 산출물) | Q | 정합성 |
+|---|---|---|---|---|
+| **PK 구조** | `user_id UUID PK (UNIQUE)` (userId 자체 PK 가정) | `id String @id @default(uuid())` (surrogate PK) + `userId String @unique @map("user_id")` | **Q1 ★** | ⚠️ **현실 추인 — surrogate PK 컨벤션 일관** (DB-001~004 모든 모델 동일 패턴). UNIQUE INDEX (`saved_searches_user_id_key`) 자동 생성으로 userId @id PK 와 DB 효과 동일 (사용자당 1건 강제) |
+| `search_params` | `JSONB NOT NULL` | `String @map("search_params") // JSON string` | **Q2** | ⚠️ SQLite JSONB 미지원 → String + JSON.stringify/parse 인라인 패턴 (DB-003 Q1 동일 로직). INFRA-002 후 Postgres `@db.JsonB` 전환 |
+| `saved_at` | `TIMESTAMP DEFAULT NOW()` | `DateTime @default(now()) @map("saved_at")` | — | ✅ |
+| FK CASCADE | (관계) | `user User @relation(... onDelete: Cascade)` | — | ✅ |
+| Q7 enum 가능성 String 컬럼 | — | **0건** — id/userId UUID 형식, searchParams JSON 직렬화 | **Q7** | DB-002/003 의 `String + 주석 // enum 가능값` 패턴 부재 → TS union 신규 작성 트리거 0 |
+
+### ★ Q1 PK 컨벤션 일관성 (DB-001~004 전체 모델 답습 — 미래 모델 가이드)
+
+| 모델 (ISSUE) | PK | UNIQUE 제약 | 카디널리티 |
 |---|---|---|---|
-| `user_id` | UUID | FK → USER.id, PK (UNIQUE) | 저장 사용자 (사용자당 1건) |
-| `search_params` | JSONB | NOT NULL | 저장된 검색 조건 (주소·필터·시간대 등) |
-| `saved_at` | TIMESTAMP | NOT NULL, DEFAULT NOW() | 저장일시 |
+| `User` (DB-002) | `id String @id @default(uuid())` | `email String @unique` | — |
+| `Diagnosis` (DB-003) | `id String @id @default(uuid())` | (없음) | User : Diagnosis = 1:N |
+| `ShareLink` (DB-004) | `id String @id @default(uuid())` | `diagnosisId String @unique` + `uniqueUrl String @unique` | Diagnosis : ShareLink = 1:0..1 |
+| **`SavedSearch` (DB-006 — 현실)** | `id String @id @default(uuid())` | `userId String @unique` | User : SavedSearch = 1:0..1 |
+
+→ **DB-001~004 전체 모델 `id String @id @default(uuid())` surrogate PK + 1:0..1 강제 시 다른 컬럼 `@unique` 컨벤션 일관**. 명세 v1.0 의 `userId @id` 만 단일 비일관 가정.
+
+**DB 효과 동일성 (양쪽 패턴)**:
+- `userId @id` (명세): `user_id PRIMARY KEY` → 사용자당 1건 강제
+- `id @id + userId @unique` (현실): `CREATE UNIQUE INDEX "saved_searches_user_id_key"` 자동 → 사용자당 1건 강제
+- **UPSERT 인터페이스 동일**: `prisma.savedSearch.upsert({ where: { userId } })` 양쪽 모두 동작 (`src/lib/db.ts` fake API + `app/api/save/route.ts:22-32` 이미 해당 패턴 동작 중)
+
+**미래 모델 (DB-007 / Wave 2+) 추가 시 동일 컨벤션 답습 가이드.**
+
+### 4/29 `_init` migration 의 saved_searches 테이블 검증
+
+```sql
+-- prisma/migrations/20260429125124_init/migration.sql (4/29 산출물, 본 ISSUE 미수정)
+
+CREATE TABLE "saved_searches" (
+    "id" TEXT NOT NULL PRIMARY KEY,                                  -- Q1 surrogate PK
+    "user_id" TEXT NOT NULL,
+    "search_params" TEXT NOT NULL,                                   -- Q2 SQLite TEXT (JSON string)
+    "saved_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "saved_searches_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX "saved_searches_user_id_key" ON "saved_searches"("user_id");   -- Q1 @unique 자동 → 사용자당 1건 강제
+```
+
+- ✅ Q1 (surrogate PK + `userId @unique`) DB 레벨 강제 입증 (UNIQUE INDEX 자동 생성)
+- ✅ Q2 (`search_params TEXT NOT NULL`) SQLite TEXT 매핑 — Postgres swap 시 JSONB 전환 가능
+- ✅ FK CASCADE 정합 (REQ-NF-016 best effort + User 삭제 시 SavedSearch 동반 삭제)
+- ✅ password 관련 컬럼 0건 (SavedSearch 도메인 분리)
 
 ### ERD 관계 (§6.2.0)
 
@@ -42,148 +96,194 @@ assignees: []
 USER ||--o{ SAVED_SEARCH : saves
 ```
 
-- User : SavedSearch = 1 : 0..1 관계 (사용자당 최신 1건만 UPSERT)
+- `User : SavedSearch = 1 : 0..1` (Q1 `userId @unique` 강제 + DB-002 PR #76 머지본의 `User.savedSearch SavedSearch?` 단수 역관계 양쪽 정합)
 
 ### 시퀀스 다이어그램 (§6.3.5 간이 저장·불러오기)
 
 - **참여 Actor:** 반복 이사자(C-04), Next.js Client Component, Server Action, Prisma ORM, 카카오 Geocoding
-- **핵심 메시지:** `saveSearch(searchParams)` → `Prisma: SavedSearch UPSERT (user_id 기준, best effort)` → 실패 시 무시
+- **핵심 메시지:** `saveSearch(searchParams)` → `Prisma: SavedSearch UPSERT (userId 기준, best effort)` → 실패 시 무시
+- **현 onday-app 동작**: `app/api/save/route.ts` 의 Route Handler 가 `prisma.savedSearch.upsert({ where: { userId } })` 호출 (in-memory fake). CMD-SAVE-001 시점에 Server Action 으로 전환 + Zod 추출 + bcrypt 등 통합.
+
+### ★ Q3 Zod / UPSERT 인라인 호출처 8행 (`app/api/save/route.ts` 전체 — CMD-SAVE-001 통합 대상)
+
+본 ISSUE 가 Zod schema 를 미작성하는 사유: **등가 인라인 로직이 이미 onday-app mock 라우트에 동작 중**. 본 ISSUE 에서 추출 시 (i) 호출처 수정 = `onday-app/src/app/api/save/route.ts` 가드 위반, (ii) 호출처 미수정 = dead code. 명세 §9.1 자체가 strict/passthrough 최종 결정을 CMD-SAVE-001 로 직접 위임.
+
+| # | 위치 (라인) | 인라인 로직 (현 동작) | 명세 §3.7 등가 함수 | CMD-SAVE-001 통합 |
+|---|---|---|---|---|
+| 1 | `app/api/save/route.ts:3` | `import { z } from "zod"` | (validator 의존성 — 인라인 import) | Zod schema 추출 시 `lib/validators/saved-search.ts` 로 이동 |
+| 2 | `app/api/save/route.ts:5-7` | `saveSearchSchema = z.object({ searchParams: z.record(z.string(), z.unknown()) })` ★ passthrough 변형 | `searchParamsSchema` (strict 또는 passthrough) | strict 정의 + 명세 §9.1 최종 결정 |
+| 3 | `app/api/save/route.ts:13` | `saveSearchSchema.safeParse(body)` | Zod 검증 호출 | helper 추출 + 호출 |
+| 4 | `app/api/save/route.ts:22-32` | `prisma.savedSearch.upsert({ where: { userId }, create: {...}, update: {...} })` | UPSERT 로직 | Server Action 전환 시 best effort 패턴 추가 |
+| 5 | `app/api/save/route.ts:26` | `searchParams: JSON.stringify(parsed.data.searchParams)` (create) | JSON 직렬화 | helper 추출 또는 인라인 유지 결정 |
+| 6 | `app/api/save/route.ts:29` | `searchParams: JSON.stringify(parsed.data.searchParams)` (update) | JSON 직렬화 (동일) | helper 추출 또는 인라인 유지 결정 |
+| 7 | `app/api/save/route.ts:49` | `prisma.savedSearch.findUnique({ where: { userId } })` | 조회 | QRY-SAVE-001 영역 (Server Action) |
+| 8 | `app/api/save/route.ts:58` | `searchParams: JSON.parse(saved.searchParams)` | JSON 역직렬화 | helper 추출 또는 인라인 유지 결정 |
+
+→ 8행 모두 본 ISSUE 미수정 (가드에 포함). CMD-SAVE-001 시점에 Zod schema 추출 + strict/passthrough 최종 결정 + Server Action 전환 + 호출처 통합이 일괄 작업.
 
 ### 선행 태스크 산출물
 
 | 선행 Task ID | 제공 산출물 | 본 태스크에서의 사용처 |
 |---|---|---|
-| DB-002 | `prisma/schema.prisma` 내 `model User` 정의 + USER 테이블 마이그레이션 | SAVED_SEARCH.user_id FK가 USER.id를 참조 |
+| **DB-002** (PR #76 머지 완료, main `d916a6f`) | `model User` (Prisma) + `User.savedSearch SavedSearch?` 1:0..1 역관계 + `src/lib/types/user.ts` (`ServiceModeType` 재사용 대상 — Q8 API-005 `SearchParams.mode` 영역) | SavedSearch.userId FK 대상 + Q1 양쪽 모델 일치 검증 + Q8 `mode` 재사용 |
+| **DB-004** (PR #78 머지 완료, main `0e846b2`) | `tasks/DB-004.md` (DB-001 패턴 적용 첫 사례 — Phase B 생략 + 커밋 1개 docs) | DB-006 동일 패턴 답습 |
+| **DB-003** (PR #77 머지 완료, main `18de316`) / **DB-001** (PR #75 머지 완료, main `1ef7d84`) | 간접 선행 (Prisma 7 초기화 + DIAGNOSIS DTO 위임 패턴) | DB-* 일관 원칙 |
+
+### 후행 ISSUE 정합성 (현실 추인 패턴 + Q1~Q8 결정 트리거)
+
+| 후행 ISSUE | 영향 | Q 결정 |
+|---|---|---|
+| **CMD-SAVE-001** (입력값 자동 저장 Server Action) | ★ Q3 Zod 추출 + strict/passthrough 최종 결정 (명세 §9.1) + 인라인 호출처 8행 통합 + Server Action 전환 + best effort 패턴 | Q3 |
+| **API-005** (SavedSearch DTO) | ★ `src/lib/types/saved-search.ts` 신규 작성 + `SearchParams` interface + `SavedSearchDTO` 정의 + `import { ServiceModeType } from './user'` 패턴 (DB-003 Q6 답습) | Q8 |
+| **QRY-SAVE-001** (저장된 조건 불러오기) | `findUnique({ where: { userId } })` + `JSON.parse(saved.searchParams)` — 현 `route.ts:49, 58` 인라인 → CMD-SAVE-001 helper 통합 후 호출 | Q3 |
+| MOCK / API-005 정합 | `SavedSearchDTO` ↔ MOCK 데이터 정합 검증 (있다면) | Q8 |
+| **INFRA-002** (Supabase Postgres) | 실 PrismaClient swap + `searchParams Json @db.JsonB` 전환 + 인덱싱 평가 + AC-1~AC-4 활성 (DB-003 §9.1 일관) | Q2 / Q3 |
+| **DB-007** (Supabase Auth + RLS) | Q6 RLS SQL 일괄 작성 + auth.users FK 정렬 | Q6 |
+| **TEST-*** | vitest config + 6 케이스 spec | Q5 |
+| **DB-007 / Wave 2+ 모델 추가** | Q1 PK 컨벤션 가이드 (surrogate PK + `@unique`) | Q1 |
 
 ---
 
 ## 3. 🛠️ Task Breakdown (실행 체크리스트)
 
-- [ ] **3.1** `prisma/schema.prisma`에 `model SavedSearch` 정의
+- [x] **3.1** `prisma/schema.prisma` 에 `model SavedSearch` 정의 — **4/29 산출물 보존 (사용자 가드)**
+  > 현 schema.prisma `model SavedSearch` (L59–68, 본 ISSUE 미수정) — Q1/Q2/Q7 결정과 모두 정합:
   ```prisma
   model SavedSearch {
-    userId       String   @id @map("user_id") @db.Uuid
-    searchParams Json     @map("search_params")
+    id           String   @id @default(uuid())               // Q1 ★ surrogate PK 컨벤션 일관
+    userId       String   @unique @map("user_id")            // Q1 ★ @unique 자동 UNIQUE INDEX (사용자당 1건 강제)
+    searchParams String   @map("search_params") // JSON string  // Q2 SQLite JSONB 미지원 → String + JSON.stringify
     savedAt      DateTime @default(now()) @map("saved_at")
-    
-    user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-    
+
+    user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
     @@map("saved_searches")
   }
   ```
-  - `userId`를 `@id`로 설정하여 사용자당 1건만 유지 (UPSERT 패턴)
-  - `onDelete: Cascade` — User 삭제 시 SavedSearch도 함께 삭제
+  > **명세 v1.0 가정과 차이 3건 (현실 추인 — Q1/Q2/Q7 반영):**
+  > 1. **PK 구조 (Q1 ★)**: 명세 v1.0 의 `userId String @id @db.Uuid` (userId 자체 PK) → 현실 `id String @id @default(uuid())` (surrogate PK) + `userId String @unique` (UNIQUE 제약). **DB-001~004 전체 모델 컨벤션 일관**. UPSERT `where: { userId }` 인터페이스 양쪽 동일.
+  > 2. **`searchParams` 타입 (Q2)**: `Json @db.JsonB` → `String + JSON string` (SQLite JSONB 미지원). DB-003 Q1 (filters String) 동일 로직. INFRA-002 후 Postgres `@db.JsonB` 전환 + 인덱싱 평가.
+  > 3. **TS 타입 신규 (Q7)**: 명세에 없음 + 현실에도 없음. 모든 컬럼이 명확 타입 (UUID String, FK String, JSON String, DateTime) — 좁힐 enum 가능성 0건. `SearchParams.mode` 는 user.ts `ServiceModeType` 재사용 (DTO 영역 — API-005 위임).
 
-- [ ] **3.2** `prisma/schema.prisma`의 `model User`에 SavedSearch 역관계 필드 추가
+- [x] **3.2** `prisma/schema.prisma` 의 `model User` 에 SavedSearch 역관계 추가 — **DB-002 PR #76 머지본에서 활성**
+  > 현 schema.prisma `model User` (L10–22, DB-002 PR #76 머지본):
   ```prisma
-  model User {
-    // ... 기존 필드
-    savedSearch  SavedSearch?
-  }
+  // model User (DB-002 산출물 검증됨)
+  savedSearch SavedSearch?       // Q1 1:0..1 (SavedSearch.userId @unique 강제)
   ```
+  > **본 ISSUE Q1 결정 (`userId @unique` 1:0..1)** 과 양쪽 모델 일치 — schema valid. 명세 §3.2 의 "User 모델 확장 필요" 가정은 DB-002 PR #76 머지 시점에 이미 활성.
 
-- [ ] **3.3** `npx prisma validate` 실행하여 스키마 문법 검증
+- [x] **3.3** `npx prisma validate` 실행 — **Phase A 통과**
+  > Phase A.8: `npm run db:validate` exit 0, `"valid 🚀"`. 본 ISSUE 신규 수정 없음 → 회귀 0.
 
-- [ ] **3.4** `npx prisma migrate dev --name add_saved_search` 실행, 생성된 마이그레이션 SQL 검토
-  - 확인 항목:
-    - `saved_searches` 테이블 생성
-    - `user_id` 컬럼이 `UUID` 타입이며 PK
-    - `search_params` 컬럼이 `JSONB` 타입
-    - `saved_at` 컬럼에 `DEFAULT NOW()`
-    - FK 제약조건: `user_id → users.id ON DELETE CASCADE`
+- [x] **3.4** `npx prisma migrate dev --name add_saved_search` 실행 — **4/29 `_init` 보존**
+  > 4/29 `_init` migration 이 이미 `saved_searches` 테이블 + UNIQUE INDEX + FK CASCADE 포함 (§2 SQL 인용). 본 ISSUE 신규 migration 미생성 (사용자 가드).
+  > 확인 항목 (§2 migration SQL 정합):
+  > - ✅ `saved_searches` 테이블 생성 (CREATE TABLE)
+  > - ✅ `id` PK + `user_id` UNIQUE INDEX 자동
+  > - ✅ `search_params` TEXT NOT NULL (SQLite JSON string)
+  > - ✅ `saved_at` DATETIME DEFAULT CURRENT_TIMESTAMP
+  > - ✅ FK CASCADE (saved_searches_user_id_fkey)
 
-- [ ] **3.5** `npx prisma generate` 실행하여 Prisma Client 타입 재생성
+- [x] **3.5** `npx prisma generate` 실행 — **Phase A 통과**
+  > Phase A.8: `npx prisma generate` exit 0, `Generated Prisma Client (7.8.0) to ./src/generated/prisma`.
 
-- [ ] **3.6** `lib/types/saved-search.ts`에 SavedSearchDTO 타입 정의
-  ```typescript
-  export interface SearchParams {
-    addressA?: string;
-    addressB?: string;
-    coordA?: { lat: number; lng: number };
-    coordB?: { lat: number; lng: number };
-    filters?: {
-      maxCommuteTime?: number;  // 분 단위
-      budgetMin?: number;
-      budgetMax?: number;
-      timeSlot?: string;        // "07:00" ~ "09:00"
-    };
-    mode?: 'couple' | 'single';
-    deadlineDate?: string;       // ISO date string, nullable
-  }
-  
-  export interface SavedSearchDTO {
-    userId: string;
-    searchParams: SearchParams;
-    savedAt: Date;
-  }
-  ```
+- [⏸ Q7 미작성 + Q8 API-005 위임] **3.6** `lib/types/saved-search.ts` (`SearchParams` + `SavedSearchDTO`) — **DB-001 / DB-004 패턴 유사 (Q7) + DB-003 Q6 경계 일관 (Q8 API-005 위임)**
+  > **Q7 결정 (TS 타입 미작성):**
+  > - 현 schema SavedSearch 의 모든 String 컬럼은 (1) UUID 형식 (id/userId — `@default(uuid())`), (2) JSON 직렬화 (searchParams). enum 가능값 주석 (`// kakao | naver`) 패턴 부재.
+  > - DB-002 `user.ts` (`AuthProviderType`/`ServiceModeType`) + DB-003 `diagnosis.ts` (`DiagnosisStatusType`) 의 "schema String + 주석 → TS union 좁힘" 트리거 조건 자체가 SavedSearch 에 없음.
+  > - **DB-004 Q8 / DB-001 패턴 유사** — 산출물 = 명세 갱신만, TS 파일 미생성.
+  >
+  > **Q8 결정 (DTO 정의 = API-005 위임):**
+  > - 명세 §7 자체가 `SavedSearchDTO` / `SearchParams` 정의를 API-005 와 연결 명시 ("API-005: SavedSearch 도메인 Request/Response DTO 정의 — DB-006이 제공하는 SavedSearchDTO/SearchParams 타입을 기반으로 API 계약 확장").
+  > - DB-003 Q6 (DTO=API-002) ↔ DB-004 Q7 (DTO=API-003) ↔ **DB-006 Q8 (DTO=API-005)** 체인 일관.
+  > - API-005 가 `src/lib/types/saved-search.ts` 신규 작성 시 `import { ServiceModeType } from './user'` 패턴 (DB-003 Q6 답습) — `SearchParams.mode` 재정의 금지.
+  > **§9 follow-up 트리거**: API-005 (`SearchParams` + `SavedSearchDTO` + `mode = ServiceModeType` import).
 
-- [ ] **3.7** `lib/validators/saved-search.ts`에 `search_params` JSONB 필드의 Zod 스키마 정의
-  ```typescript
-  import { z } from 'zod';
-  
-  export const searchParamsSchema = z.object({
-    addressA: z.string().optional(),
-    addressB: z.string().optional(),
-    coordA: z.object({ lat: z.number(), lng: z.number() }).optional(),
-    coordB: z.object({ lat: z.number(), lng: z.number() }).optional(),
-    filters: z.object({
-      maxCommuteTime: z.number().int().min(1).max(180).optional(),
-      budgetMin: z.number().min(0).optional(),
-      budgetMax: z.number().min(0).optional(),
-      timeSlot: z.string().regex(/^\d{2}:\d{2}$/).optional(),
-    }).optional(),
-    mode: z.enum(['couple', 'single']).optional(),
-    deadlineDate: z.string().datetime().nullable().optional(),
-  });
-  ```
+- [⏸ CMD-SAVE-001 위임] **3.7** `lib/validators/saved-search.ts` Zod schema (`searchParamsSchema`) — **Q3 결정**
+  > **사유 5종 (DB-* 일관 원칙 + 등가 인라인 동작 중 + 명세 §9.1 직접 위임):**
+  > 1. **DB-* 일관 원칙 위반 회피**: DB-002/003 `user.ts`/`diagnosis.ts` 모두 type only. DB-004 Q3 (helper = CMD-SHARE-001 위임). validator/Zod schema 는 동작 로직 (입력 검증 + 비즈니스 정책) → DB-* 책임 외.
+  > 2. **등가 인라인 로직이 이미 동작 중** (§2 Q3 인라인 호출처 8행 표 참조):
+  >    - `app/api/save/route.ts:5-7` 의 `saveSearchSchema = z.object({ searchParams: z.record(z.string(), z.unknown()) })` 가 명세 §3.7 의 `searchParamsSchema` 와 등가 (passthrough 변형)
+  >    - `app/api/save/route.ts:13` safeParse + L22-32 UPSERT + L26/29/49/58 JSON 직렬화/역직렬화 모두 동작
+  > 3. **★ 명세 §9.1 자체가 CMD-SAVE-001 위임 명시**: "Zod 스키마를 `z.object().passthrough()` 로 설정하여 하위 호환성을 유지할지, strict 모드로 갈지 **CMD-SAVE-001 작업 시 확정**." → 본 ISSUE strict 작성 시 §9.1 결정 시점과 충돌. 현실의 `z.record(z.string(), z.unknown())` passthrough 변형은 §9.1 잠정 결정과 정합.
+  > 4. **CMD-SAVE-001 자연스러운 응집성**: Zod 검증 + JSON 직렬화 + UPSERT + best effort 에러 처리 (REQ-NF-016) 모두 한 Server Action 내 로직 → strict 정의 + 인라인 호출처 8행 통합 + strict/passthrough 결정 일괄 작업이 응집성 높음. DB-004 Q3 (helper 추출 + bcrypt + 호출처 통합 = CMD-SHARE-001) 와 정확히 동일 패턴.
+  > 5. **가드 위반 회피**: Zod 추출 시 (i) 호출처 8행 수정 = `onday-app/src/app/api/save/route.ts` 가드 위반, (ii) 호출처 미수정 = dead code.
+  > **§9 follow-up 트리거**: CMD-SAVE-001 Zod 추출 + strict/passthrough 확정 (§9.3).
 
-- [ ] **3.8** `__tests__/db/saved-search-schema.spec.ts`에 SAVED_SEARCH 테이블 스키마 검증 테스트 작성
-  ```typescript
-  describe('SAVED_SEARCH 테이블 스키마 검증', () => {
-    it('user_id가 PK이며 UUID 타입이다', async () => { /* ... */ });
-    it('search_params가 JSONB 타입이며 NOT NULL이다', async () => { /* ... */ });
-    it('saved_at에 DEFAULT NOW()가 적용된다', async () => { /* ... */ });
-    it('동일 user_id로 UPSERT 시 기존 행이 갱신된다', async () => { /* ... */ });
-    it('존재하지 않는 user_id로 INSERT 시 FK 에러가 발생한다', async () => { /* ... */ });
-    it('User 삭제 시 CASCADE로 SavedSearch도 삭제된다', async () => { /* ... */ });
-  });
-  ```
+- [⏸ TEST-* 위임] **3.8** `__tests__/db/saved-search-schema.spec.ts` — 6 케이스 — **Q5 결정 (DB-001~004 §3.10 일관)**
+  > **사유 (DB-001~004 §3.10 4종 + Q1~Q3 추가 영향):**
+  > 1. `vitest.config.ts` 부재 (Phase A.6 재확인) → spec 작성해도 실행 불가
+  > 2. 현 `src/lib/db.ts` 가 in-memory fake → spec 검증 meaningless
+  > 3. TEST-* 시점에 vitest config + 모든 ISSUE spec 일괄 작성
+  > 4. 본 ISSUE 검증은 CLI (validate/generate/tsc/build) + grep + read-only 정합으로 충족
+  >
+  > **★ 명세 §3.8 의 6 spec 케이스가 Q1~Q3 결정으로 6 / 6 무의미:**
+  >
+  > | 명세 §3.8 케이스 | Q 결정 영향 |
+  > |---|---|
+  > | 1. user_id PK + UUID 타입 | ❌ **Q1 결정으로 `id` 가 PK** (`userId @unique`) — spec 자체 수정 필요 |
+  > | 2. search_params JSONB NOT NULL | ❌ **Q2 결정으로 String JSON** (JSONB 미지원) |
+  > | 3. saved_at DEFAULT NOW() | ❌ in-memory fake — DB 제약 검증 무의미 |
+  > | 4. 동일 user_id UPSERT 갱신 | ❌ in-memory fake `upsert` 동작은 하나 DB 레벨 UNIQUE 검증 무의미 |
+  > | 5. FK 위반 (nonexistent user_id) | ❌ in-memory fake FK 미지원 |
+  > | 6. User 삭제 CASCADE | ❌ 동일 (CASCADE 미지원) |
+  >
+  > **단, `__tests__/db/.gitkeep` 빈 디렉토리는 보존** — INFRA-001 `dc2ca37` 산출물, TEST-* 시점 spec 추가 위치.
 
-- [ ] **3.9** Supabase 프로덕션 환경에서 RLS 정책 SQL 작성
-  - 파일: `prisma/migrations/manual/002_saved_search_rls.sql`
-  ```sql
-  ALTER TABLE public.saved_searches ENABLE ROW LEVEL SECURITY;
-  
-  -- 사용자 본인의 저장 조건만 조회/수정 가능
-  CREATE POLICY "Users can manage own saved searches" ON public.saved_searches
-    FOR ALL USING (auth.uid() = user_id);
-  ```
+- [⏸ INFRA-002 + DB-007 위임] **3.9** `prisma/migrations/manual/002_saved_search_rls.sql` RLS SQL — **Q6 결정 (DB-004 Q6 일관)**
+  > **사유 5종:**
+  > 1. `prisma/migrations/manual/` 디렉토리 자체 부재 (Phase A 확인됨)
+  > 2. SQLite RLS 미지원 (Postgres 전용)
+  > 3. Supabase 환경 비활성 (INFRA-002 swap 전)
+  > 4. DB-007 의 `auth.users` FK + RLS 정렬과 일괄 작성이 자연스러움 (`auth.uid() = user_id` 정책 정합)
+  > 5. DB-004 Q6 일관 — 모든 테이블 RLS INFRA-002 + DB-007 일괄
+  > **§9 follow-up 트리거**: INFRA-002 + DB-007 시점에 일괄 작성 (§9.6).
+
+### Q4 — `prisma/seed.ts` SavedSearch 시드 (명세 §3 자체에 미정의)
+
+> **Q4 결정 (가드 보존):** 명세 §3 task list / §6 Deliverables 자체에 seed 항목 부재. DB-001~004 §3.9 가드 일관 적용:
+> 1. 4/29 seed.ts 가드 (사용자 가드 절대 불변)
+> 2. tsx 부재 (Phase A.6 재확인) → 실행 자체 불가
+> 3. INFRA-002 후 실 실행 결정 (in-memory → 실 Prisma 전환 시점)
+> 4. `prisma.seed` 항목 비움
+> **§9 follow-up 트리거**: SavedSearch 시드 = INFRA-002 + tsx runner 결정 함께 (§9.4).
+
+### ★ Q1~Q8 결정 vs 명세 v1.0 mismatch 추적 표 (DB-003/004 §3 끝 패턴 답습)
+
+| Q | 분기 | 명세 v1.0 가정 | 현실 (4/29 schema) | 결정 | 후속 트리거 |
+|---|---|---|---|---|---|
+| **Q1** ★ | PK 구조 | `userId String @id @db.Uuid` (userId 자체 PK) | `id String @id @default(uuid())` + `userId String @unique` (DB-001~004 surrogate PK 컨벤션 일관) | (C) 현실 추인 + §2 PK 컨벤션 일관성 명시 | DB-007 / Wave 2+ 미래 모델 가이드 (§9.8) |
+| **Q2** | searchParams JSONB | `Json @db.JsonB` | `String @map("search_params") // JSON string` (SQLite 미지원) | (C) 현실 추인 + §9 INFRA-002 follow-up | INFRA-002 Postgres `@db.JsonB` + 인덱싱 (§9.2, DB-003 §9.1 일관) |
+| **Q3** ★ | Zod validator | `searchParamsSchema` 명세 §3.7 strict 정의 | 등가 인라인 8행 동작 중 (`app/api/save/route.ts`) | (A) CMD-SAVE-001 위임 (DB-004 Q3 패턴 + 명세 §9.1 직접 위임) | CMD-SAVE-001 Zod 추출 + strict/passthrough 확정 + 호출처 8행 통합 (§9.3) |
+| **Q4** | seed.ts | 명세 §3 자체에 미정의 | 부재 (DB-001~004 가드 일관) | (A) seed.ts 가드 보존 | INFRA-002 + tsx runner 결정 (§9.4) |
+| **Q5** | spec | 6 케이스 | vitest 부재 + 6/6 무의미 | (A) TEST-* 위임 (DB-001~004 일관) | TEST-* (vitest config + spec 일괄, §9.5) |
+| **Q6** | RLS SQL | `manual/002_saved_search_rls.sql` Supabase RLS | `manual/` 디렉토리 부재 + SQLite RLS 미지원 | (A) INFRA-002 + DB-007 위임 (DB-004 Q6 일관) | INFRA-002 + DB-007 일괄 RLS (§9.6) |
+| **Q7** | TS 타입 신규 | 명세 §3.6 `SearchParams` + `SavedSearchDTO` 정의 | 좁힐 enum 컬럼 0건 + `mode = ServiceModeType` 재사용 | (A) 미작성 (DB-004 Q8 / DB-001 패턴) | API-005 가 처음부터 작성 (§9.7) |
+| **Q8** ★ | `SearchParams` / `SavedSearchDTO` 정의 위치 | API-005 / MOCK 영역 | — (본 ISSUE 책임 외) | (A) API-005 위임 (DB-003 Q6 / DB-004 Q7 경계 일관 + 명세 §7 직접 명시) | API-005 + MOCK (§9.7, `mode = ServiceModeType` import 패턴) |
 
 ---
 
-## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD — DB-002/003/004 ⏸ 패턴 일관)
 
-**AC-1 (정상):** 신규 SavedSearch UPSERT 성공
-- **Given** `users` 테이블에 `id = 'user-001'` 레코드가 존재
-- **And** `saved_searches` 테이블에 해당 user_id 레코드가 없는 상태
-- **When** `prisma.savedSearch.upsert({ where: { userId: 'user-001' }, create: { userId: 'user-001', searchParams: {...} }, update: { searchParams: {...} } })` 호출
-- **Then** `saved_searches` 테이블에 1개 행이 생성되며, `user_id = 'user-001'`, `search_params`가 입력한 JSON과 일치, `saved_at`이 현재 시각 ±1초 이내
+**AC-1 (정상):** 신규 SavedSearch UPSERT 성공 — **⏸ CMD-SAVE-001 + INFRA-002 후 검증**
+- **Given** 유효한 User 레코드 + Q3 인라인 호출처 (`app/api/save/route.ts:22-32`) mock 동작 중
+- **When** `prisma.savedSearch.upsert({ where: { userId }, create: {...}, update: {...} })` 실행
+- **Then** ✅ schema 자체 valid 🚀 (Phase A.8) + UNIQUE INDEX (`saved_searches_user_id_key`) DB 레벨 강제 보장
+- **⏸ 현 in-memory fake — 실 PrismaClient swap (INFRA-002) + Server Action 전환 (CMD-SAVE-001) 후 best effort 검증**
 
-**AC-2 (예외):** 존재하지 않는 user_id로 INSERT 시 FK 위반
-- **Given** `users` 테이블에 `id = 'nonexistent'` 레코드가 없는 상태
-- **When** `prisma.savedSearch.create({ data: { userId: 'nonexistent', searchParams: {...} } })` 호출
-- **Then** Prisma `P2003` Foreign key constraint failed 에러가 발생하며, `saved_searches`에 행이 생성되지 않는다
+**AC-2 (예외):** 존재하지 않는 user_id FK 위반 — **⏸ INFRA-002 후 검증**
+- Migration SQL 의 `CONSTRAINT "saved_searches_user_id_fkey" ... ON DELETE CASCADE` 로 DB 레벨 강제.
+- **⏸ in-memory fake FK 미지원 — INFRA-002 후 P2003 에러 검증**.
 
-**AC-3 (예외):** search_params에 빈 객체 저장 시도
-- **Given** `users` 테이블에 유효한 사용자가 존재
-- **When** `searchParams: {}` (빈 JSON)으로 UPSERT 호출
-- **Then** JSONB 필드는 빈 객체 `{}`를 저장하며 에러 없이 성공 (NOT NULL 제약 충족)
+**AC-3 (예외):** searchParams 빈 객체 저장 — **✅ TS / Zod 레벨 충족**
+- **Given** Q3 결정으로 현 인라인 Zod `z.record(z.string(), z.unknown())` passthrough 변형
+- **When** `searchParams: {}` (빈 JSON) 으로 UPSERT 호출
+- **Then** ✅ JSON.stringify(`{}`) = `"{}"` 저장, NOT NULL 제약 충족 (SQLite TEXT)
 
-**AC-4 (경계):** 동일 user_id로 재UPSERT 시 기존 행 갱신 (덮어쓰기)
-- **Given** `saved_searches`에 `user_id = 'user-001'`, `search_params = {"addressA": "서울시 강남구"}` 레코드가 존재
-- **When** 동일 `user_id`로 `search_params = {"addressA": "서울시 마포구"}` UPSERT 호출
-- **Then** `saved_searches` 테이블의 총 행 수는 여전히 1개이며, `search_params.addressA`가 `서울시 마포구`로 갱신되고, `saved_at`이 현재 시각으로 업데이트된다
+**AC-4 (경계):** 동일 user_id 재UPSERT 시 기존 행 갱신 — **⏸ CMD-SAVE-001 + INFRA-002 후 검증**
+- Q1 결정으로 `userId @unique` UNIQUE INDEX 강제 + UPSERT `where: { userId }` 인터페이스.
+- **⏸ in-memory fake `upsert` 동작은 하나 DB 레벨 UNIQUE 검증은 INFRA-002 후**.
 
 ---
 
@@ -191,19 +291,40 @@ USER ||--o{ SAVED_SEARCH : saves
 
 | NFR ID | SRS 본문 인용 | 본 태스크에서의 검증 방법 |
 |---|---|---|
-| REQ-NF-016 | "입력값 자동 저장 성공률 — Best effort (저장 실패 시 무시, 사용자 미통지)" (§4.2.2) | UPSERT 실패 시 에러가 throw되지 않고 로그만 남기는 패턴을 테스트 코드에서 검증. 스키마 레벨에서는 NOT NULL 외 추가 제약 최소화 |
-| REQ-NF-012 | "서버 오류율 (5xx 응답) ≤ 0.5%" (§4.2.2) | SavedSearch UPSERT 실패가 500 에러로 전파되지 않도록, best effort 패턴(catch + Sentry.captureException)이 적용 가능한 스키마 구조인지 확인 |
+| REQ-NF-016 | "입력값 자동 저장 성공률 — Best effort (저장 실패 시 무시, 사용자 미통지)" (§4.2.2) | ✅ schema 충족: `userId @unique` UNIQUE INDEX + FK CASCADE + `search_params NOT NULL` 만. 추가 제약 최소화. UPSERT 실패 시 catch 패턴 = CMD-SAVE-001 책임 |
+| REQ-NF-012 | "서버 오류율 (5xx 응답) ≤ 0.5%" (§4.2.2) | ✅ 현 `app/api/save/route.ts:38-41` 의 try-catch + `console.error` + 500 fallback 패턴. CMD-SAVE-001 시점에 Sentry 통합 |
 
 ---
 
 ## 6. 📦 Deliverables (산출물 명시)
 
-- `prisma/schema.prisma` (SavedSearch 모델 추가 + User 역관계)
-- `prisma/migrations/{timestamp}_add_saved_search/migration.sql`
-- `prisma/migrations/manual/002_saved_search_rls.sql` (RLS 정책)
-- `lib/types/saved-search.ts` (SavedSearchDTO, SearchParams 타입)
-- `lib/validators/saved-search.ts` (search_params Zod 스키마)
-- `__tests__/db/saved-search-schema.spec.ts` (테이블 제약조건 테스트)
+### DB-006 신규/수정 산출물 (본 ISSUE) — 정확히 1 파일
+- `tasks/DB-006.md` (본 문서 명세 갱신 — 현실 추인, Q1~Q8 결정 반영)
+- **코드 변경 0건** (Q7 결정으로 TS 타입 파일도 미작성, DB-001 / DB-004 패턴 유사)
+
+### DB-006 에서 보존 (12종 + ★ Q3 호출처 8행, 본 ISSUE 미수정)
+- `onday-app/prisma/schema.prisma` (4/29, `model SavedSearch` 4모델 통합 정의)
+- `onday-app/prisma/migrations/20260429125124_init/migration.sql` (4/29, `saved_searches` 테이블 + UNIQUE INDEX + FK CASCADE)
+- `onday-app/prisma.config.ts` / `onday-app/prisma/seed.ts` (4/29)
+- `onday-app/src/lib/db.ts` (in-memory store + `savedSearch.{upsert, findUnique}` fake API)
+- **`onday-app/src/lib/types/user.ts`** (DB-002 PR #76 머지본 — `ServiceModeType` 재사용 대상)
+- **`onday-app/src/lib/types/diagnosis.ts`** (DB-003 PR #77 머지본)
+- `onday-app/src/lib/types/errors/.gitkeep` (INFRA-001 `dc2ca37`)
+- `onday-app/__tests__/db/.gitkeep` (INFRA-001, TEST-* 시점 spec 추가 위치)
+- `onday-app/package.json` / `.env` / `.env.example` / `.gitignore`
+- **★ Q3 Zod 인라인 호출처 8행** (CMD-SAVE-001 통합 대상):
+  - `onday-app/src/app/api/save/route.ts` (L3 import, L5-7 schema, L13 safeParse, L22-32 UPSERT, L26/29 stringify, L49 findUnique, L58 parse)
+- design 루트: `CLAUDE.md` / `AGENTS.md` / `docs/` / `.claude/` / `README-*` / `06_TASK_LIST_v1.3.md`
+
+### DB-006 에서 위임 (후속 ISSUE — 8종)
+- Zod schema (`searchParamsSchema`) 추출 + strict/passthrough 최종 결정 (명세 §9.1) + 인라인 호출처 8행 통합 + Server Action 전환 → **CMD-SAVE-001** (Q3)
+- `src/lib/types/saved-search.ts` 신규 + `SearchParams` interface + `SavedSearchDTO` + `mode = ServiceModeType` (user.ts) import → **API-005** (Q7 + Q8)
+- MOCK 데이터 정합 → MOCK 관련 ISSUE
+- 실 PrismaClient swap + AC-1~AC-4 활성 + JSONB 전환 + 인덱싱 → **INFRA-002** (Q2)
+- RLS SQL `manual/002_saved_search_rls.sql` + auth.users FK 정렬 → **INFRA-002 + DB-007** (Q6)
+- spec 6 케이스 + vitest config → **TEST-*** (Q5)
+- SavedSearch 시드 + tsx runner 결정 → INFRA-002 (Q4)
+- 미래 모델 PK 컨벤션 가이드 (DB-007 / Wave 2+) → Q1 일관 답습
 
 ---
 
@@ -211,31 +332,105 @@ USER ||--o{ SAVED_SEARCH : saves
 
 ### 선행 (이 태스크 시작 전 필요):
 
-- **DB-002:** `prisma/schema.prisma` 내 `model User` 정의 + USER 테이블 마이그레이션 — SAVED_SEARCH.user_id FK 대상
+- **DB-002** (PR #76 머지 완료, main `d916a6f`): `model User` (4/29) + `User.savedSearch SavedSearch?` 1:0..1 역관계 + `src/lib/types/user.ts` (`ServiceModeType` 재사용 대상 — Q8 API-005 영역)
+- **DB-004** (PR #78 머지 완료, main `0e846b2`): DB-001 패턴 (Phase B 생략 + 커밋 1개 docs) 적용 첫 사례 — 본 ISSUE 답습
+- **DB-003** (PR #77 머지 완료, main `18de316`) / **DB-001** (PR #75 머지 완료, main `1ef7d84`): 간접 선행 (DTO 위임 체인 + Prisma 7 초기화)
 
 ### 후행 (이 태스크 완료 후 차례로 가능):
 
-- **API-005:** SavedSearch 도메인 Request/Response DTO 정의 — DB-006이 제공하는 SavedSearchDTO/SearchParams 타입을 기반으로 API 계약 확장
-- **CMD-SAVE-001:** 입력값 자동 저장 Server Action — DB-006이 제공하는 Prisma SavedSearch 모델로 UPSERT 로직 구현
-- **QRY-SAVE-001:** 저장된 조건 불러오기 — DB-006이 제공하는 스키마로 SELECT 쿼리 구현
+- **CMD-SAVE-001** (입력값 자동 저장 Server Action): ★ Q3 Zod 추출 + 인라인 호출처 8행 통합 (`app/api/save/route.ts`) + strict/passthrough 최종 결정 (명세 §9.1) + Server Action 전환 + best effort
+- **QRY-SAVE-001** (저장된 조건 불러오기): `findUnique({ where: { userId } })` + `JSON.parse(saved.searchParams)` — 현 `route.ts:49, 58` 인라인 → CMD-SAVE-001 helper 통합 후 호출
+- **API-005** (SavedSearch DTO): ★ Q7 + Q8 — `src/lib/types/saved-search.ts` 신규 + `SearchParams` interface + `SavedSearchDTO` + `mode = ServiceModeType` import 패턴 (DB-003 Q6 답습). 명세 §7 직접 명시.
+- **INFRA-002** (Supabase Postgres): 실 PrismaClient swap + `searchParams Json @db.JsonB` 전환 + 인덱싱 평가 + AC-1~AC-4 활성
+- **DB-007** (Supabase Auth + RLS): Q6 RLS SQL 일괄 작성 (`auth.uid() = user_id` 정책)
+- **TEST-*** : vitest config + 6 케이스 spec
+
+### ★ Q1 PK 컨벤션 — 미래 모델 가이드
+
+DB-001~004 + 본 ISSUE 전체 모델이 `id String @id @default(uuid())` surrogate PK + 1:0..1 강제 시 다른 컬럼 `@unique` 컨벤션 일관. **DB-007 / Wave 2+ 모델 추가 시 동일 컨벤션 답습**. 단일 비일관 방지.
 
 ---
 
 ## 8. 🧪 Test Plan (검증 절차)
 
-- **단위 테스트:** `__tests__/db/saved-search-schema.spec.ts` — 테이블 제약조건 6개 케이스 (PK user_id, JSONB search_params NOT NULL, DEFAULT saved_at, UPSERT 동작, FK 위반, CASCADE 삭제)
-- **단위 테스트:** `__tests__/validators/saved-search.spec.ts` — Zod 스키마 검증 5개 케이스 (유효 입력, 빈 객체, 잘못된 시간대 형식, 범위 초과 maxCommuteTime, nullable deadlineDate)
-- **통합 테스트:** `__tests__/integration/saved-search-upsert.spec.ts` — Prisma 클라이언트로 UPSERT 실행 후 DB 상태 검증
-- **수동 검증:**
-  1. `npx prisma migrate dev` 로컬 실행 후 SQLite에서 테이블 생성 확인
-  2. `npx prisma studio`에서 SavedSearch 테이블 CRUD 수동 검증
-  3. Supabase 프로덕션 DB에서 마이그레이션 + RLS SQL 적용 확인
-- **CI 게이트:** `npx prisma validate` 통과, `tsc --noEmit` 통과, Jest 테스트 100% 통과
+- **단위 테스트:** ⏸ TEST-* 위임 (§3.8 참조, 6/6 무의미). 본 ISSUE 미작성.
+- **CLI 검증 (Phase A/D 통과):**
+  1. `npm run db:validate` — exit 0 `"valid 🚀"` (Phase A.8)
+  2. `npx prisma generate` — exit 0 (Phase A.8, Prisma Client 7.8.0)
+  3. `npx tsc --noEmit` — exit 0 (Phase A.8 baseline, 코드 변경 0 → 회귀 0)
+  4. env-less `npm run build` — exit 0, **Middleware 32.5 kB** (INFRA-001 AC-4 기준선, Phase A.9 + Phase D — **6번째 회귀 0**)
+  5. `grep -i "password" onday-app/prisma/schema.prisma` — User 모델 0건 (DB-002 AC-6 일관) + SavedSearch 컬럼 0건 + ShareLink L48 `passwordHash` 별도 정상 필드 (DB-004 영역)
+- **타입 검증:** Phase A `tsc --noEmit` exit 0 — 코드 변경 0 → 회귀 0
+- **DB 검증:** ⏸ INFRA-002 swap 후 (AC-1 / AC-2 / AC-4 활성)
+- **CI 게이트 (본 ISSUE):** `prisma validate` + `prisma generate` + `tsc --noEmit` + env-less `npm run build` 통과 (Phase D)
 
 ---
 
-## 9. 🚧 Open Questions / Risks (보류 사항)
+## 9. 🚧 Open Questions / Risks (보류 사항 — Q1~Q8 follow-up 8종 + 보조)
 
-1. **search_params JSONB 스키마 진화:** search_params 내부 구조가 향후 필터 옵션 추가 시 변경될 수 있다. Zod 스키마를 `z.object().passthrough()`로 설정하여 하위 호환성을 유지할지, strict 모드로 갈지 CMD-SAVE-001 작업 시 확정.
-2. **SQLite JSONB 호환성:** SQLite에서는 `JSONB` 타입이 `TEXT`로 매핑된다. Prisma가 `@db.JsonB` 어노테이션 없이도 PostgreSQL에서 JSONB로 생성되는지 마이그레이션 SQL에서 확인 필요.
-3. **사용자당 1건 UPSERT vs 이력 보관:** 현재 SRS는 "사용자당 최신 1건"이지만, 향후 이력 보관 요구(Rev 2+)가 발생하면 PK를 `(user_id, saved_at)` 복합키로 변경해야 할 수 있다. — MVP에서는 단일 PK 유지.
+### §9.1 ★ Q1 PK 컨벤션 일관성 — 미래 모델 가이드
+- DB-001~004 + 본 ISSUE 전체 모델 `id String @id @default(uuid())` surrogate PK + 1:0..1 강제 시 다른 컬럼 `@unique`.
+- DB-007 (Supabase Auth USER 정렬) / Wave 2+ 모델 추가 시 동일 컨벤션 답습 가이드. 단일 비일관 방지.
+
+### §9.2 Q2 INFRA-002 후 Postgres `searchParams Json @db.JsonB` 전환 + 인덱싱 평가 (DB-003 §9.1 일관)
+- 현 `searchParams String JSON string` → INFRA-002 swap 시점에 Postgres `@db.JsonB` 전환.
+- JSONB 인덱싱 가능성 평가 (GIN index on searchParams).
+- DB-003 §9.1 (CandidateArea JSONB 정규화 재평가) 와 일관 — 미래 동시 트리거.
+
+### §9.3 ★ Q3 CMD-SAVE-001 Zod 추출 + 인라인 호출처 8행 통합 + strict/passthrough 확정 (명세 §9.1 직접 위임)
+- 명세 §9.1 인용: "Zod 스키마를 `z.object().passthrough()` 로 설정하여 하위 호환성을 유지할지, strict 모드로 갈지 **CMD-SAVE-001 작업 시 확정**."
+- 인라인 호출처 8행 (§2 표 참조) 을 CMD-SAVE-001 시점에 helper 호출로 리팩토링.
+- `searchParamsSchema` strict 정의 (명세 §3.7 가정) vs passthrough (`z.record` 현 변형) 최종 결정.
+- Server Action 전환 + best effort 패턴 (catch + Sentry.captureException) 추가.
+
+### §9.4 Q4 SavedSearch 시드 = INFRA-002 + tsx runner 결정
+- 현 seed.ts 가드 (DB-001~004 §3.9 일관) + tsx 부재 + 명세 §3 자체 시드 미정의.
+- 실 seed 실행 결정 = INFRA-002 (in-memory → 실 Prisma 전환) + seed runner 결정 (tsx 설치 / Prisma 7 자체 TS runner / .js 사전 컴파일).
+
+### §9.5 Q5 spec 작성 = TEST-*
+- vitest config 부재 + in-memory fake 검증 무의미 + 명세 §3.8 6 케이스 6/6 무의미 (Q1~Q3 결정 영향).
+- TEST-* 시점에 config + 모든 spec 일괄 작성 (DB-001~004 §3.10 일관).
+
+### §9.6 Q6 RLS SQL = INFRA-002 + DB-007 (DB-004 Q6 일관)
+- `prisma/migrations/manual/` 디렉토리 부재 + SQLite RLS 미지원 → INFRA-002 + DB-007 시점에 모든 테이블 RLS 일괄 작성.
+- 명세 §3.9 SQL 가정:
+  ```sql
+  ALTER TABLE public.saved_searches ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY "Users can manage own saved searches" ON public.saved_searches
+    FOR ALL USING (auth.uid() = user_id);
+  ```
+- DB-007 `auth.users` FK 정렬 + RLS 일괄 작성과 응집성 높음.
+
+### §9.7 ★ Q8 API-005 `SearchParams` interface + `SavedSearchDTO` 정의 (DB-003 Q6 / DB-004 Q7 경계 일관)
+- 명세 §7 자체가 API-005 매핑 직접 명시 ("API-005: DB-006이 제공하는 SavedSearchDTO/SearchParams 타입을 기반으로 API 계약 확장").
+- API-005 가 `src/lib/types/saved-search.ts` 신규 작성 (DB-001 패턴 — base type 부재로 처음부터 작성, DB-003 의 append 패턴과 다름):
+  ```typescript
+  import { ServiceModeType } from './user';   // DB-003 Q6 답습 — mode 재사용 (재정의 금지)
+
+  export interface SearchParams {
+    addressA?: string; addressB?: string;
+    coordA?: { lat: number; lng: number };
+    coordB?: { lat: number; lng: number };
+    filters?: { maxCommuteTime?, budgetMin?, budgetMax?, timeSlot? };
+    mode?: ServiceModeType;                    // user.ts 재사용
+    deadlineDate?: string | null;
+  }
+
+  export interface SavedSearchDTO {
+    userId: string;
+    searchParams: SearchParams;
+    savedAt: Date;
+  }
+  ```
+- DB-003 (DTO=API-002) ↔ DB-004 (DTO=API-003) ↔ DB-006 (DTO=API-005) 체인 일관.
+
+### §9.8 ★ Q1 PK 컨벤션 = 미래 모델 가이드 (재명시 — §9.1 보조)
+- DB-007 / Wave 2+ 모델 추가 시 surrogate PK + `@unique` 패턴 답습. 본 §9.1 참조.
+
+### 보조 follow-up
+
+- **SearchParams JSONB 스키마 진화 (명세 §9.1):** 향후 필터 옵션 추가 시 변경. strict vs passthrough = CMD-SAVE-001 작업 시 확정.
+- **SQLite JSONB 호환성:** SQLite TEXT → Postgres JSONB 마이그레이션 시 데이터 검증 = INFRA-002 영역.
+- **사용자당 1건 UPSERT vs 이력 보관:** 현 SRS Rev 1.5 단순화 = "사용자당 최신 1건". 향후 이력 보관 요구 (Rev 2+) 발생 시 PK 를 `(userId, savedAt)` 복합키로 변경 가능 — MVP 에서는 surrogate PK + `userId @unique` 유지.
+- **만료 자동 삭제:** SavedSearch 는 만료 개념 없음 (ShareLink 와 다름). UPSERT 패턴으로 항상 최신 1건만 유지.
+- **DB-007 / Wave 2+ 모델 패턴 예고 (DB-001~004 일관):** 모든 후속 데이터 모델은 `id String @id @default(uuid())` surrogate PK 컨벤션 답습 + SQLite/Postgres 환경 분기 (INFRA-002 위임) + RLS (DB-007 일괄).


### PR DESCRIPTION
## 산출물 (1 commit, 1 file — ★ 코드 변경 0건, DB-004 패턴 답습)

| 커밋 | 종류 | 파일 | 변경량 |
|---|---|---|---|
| `76a3b2a` | docs | `tasks/DB-006.md` (현실 동기화) | +346/-151 |

`main` (`0e846b2` PR #78 머지본) 대비 변경: **정확히 1 파일** (`git diff main --name-only` 검증). **코드 변경 0건** — Q7 결정 (좁힐 enum 컬럼 0건) + Q3 결정 (Zod = CMD-SAVE-001 위임) + Q8 결정 (DTO = API-005 위임) 누적 결과. DB-001 / DB-004 패턴 답습 (Phase B 생략).

★ **feat 커밋 없음 — 코드 변경 0건이라 정상** (DB-004 패턴 동일). "코드/문서 분리" 원칙은 분리할 코드가 없을 뿐. 억지로 dead file 만들지 않음.

## ✅ AC 검증 결과 표

| 검증 | 결과 |
|---|---|
| `npm run db:validate` (= `npx prisma validate`) | ✅ exit 0 — `"valid 🚀"` |
| `npx prisma generate` | ✅ exit 0 — Prisma Client 7.8.0 |
| `npx tsc --noEmit` | ✅ exit 0 (Phase A 기준선 유지, 코드 변경 0 → 회귀 0) |
| env-less `npm run build` | ✅ exit 0 — **Middleware 32.5 kB** (INFRA-001 AC-4 기준선 정확히 일치, **6번째 회귀 0** — INFRA-001/DB-001/002/003/004/006 누적 보존) |
| `grep -i "password"` | ✅ **User 모델 0건** (DB-002 AC-6 일관) + **SavedSearch 모델 0건** (도메인 분리) + ShareLink L48 `passwordHash` 별도 정상 필드 (DB-004 영역) |

### AC 표 (DB-002/003/004 ⏸ 패턴 일관)

| AC | 상태 |
|---|---|
| AC-1 신규 SavedSearch UPSERT | ⏸ CMD-SAVE-001 + INFRA-002 후 (schema valid 🚀 + UNIQUE INDEX `saved_searches_user_id_key` DB 레벨 강제) |
| AC-2 FK 위반 (nonexistent user_id) | ⏸ INFRA-002 후 (Migration FK CASCADE 보장) |
| AC-3 빈 객체 searchParams 저장 | ✅ Zod passthrough + `JSON.stringify({})` 충족 |
| AC-4 동일 user_id 재UPSERT 갱신 | ⏸ CMD-SAVE-001 + INFRA-002 후 (Q1 `userId @unique` 강제) |

## ★ Q1~Q8 mismatch 추적 표

| Q | 분기 | 명세 v1.0 | 현실 (4/29 schema) | 결정 | 후속 트리거 |
|---|---|---|---|---|---|
| **Q1** ★ | PK 구조 | `userId String @id @db.Uuid` (userId 자체 PK) | `id String @id @default(uuid())` + `userId @unique` (DB-001~004 surrogate PK 컨벤션 일관) | (C) 현실 추인 + §2 PK 컨벤션 명시 | DB-007 / Wave 2+ 미래 모델 가이드 (§9.1) |
| **Q2** | searchParams JSONB | `Json @db.JsonB` | `String + JSON.stringify` (SQLite 미지원) | (C) 현실 추인 + §9 INFRA-002 follow-up | INFRA-002 Postgres `@db.JsonB` + 인덱싱 (§9.2, DB-003 §9.1 일관) |
| **Q3** ★ | Zod validator | `searchParamsSchema` strict 정의 | 등가 인라인 8행 동작 중 | (A) CMD-SAVE-001 위임 (DB-004 Q3 패턴 + 명세 §9.1 직접 위임) | CMD-SAVE-001 Zod 추출 + strict/passthrough 확정 + 호출처 8행 통합 (§9.3) |
| **Q4** | seed.ts | 명세 §3 자체에 미정의 | 부재 (DB-001~004 가드 일관) | (A) seed.ts 가드 보존 | INFRA-002 + tsx runner (§9.4) |
| **Q5** | spec | 6 케이스 | vitest 부재 + 6/6 무의미 | (A) TEST-* 위임 (DB-001~004 일관) | TEST-* (§9.5) |
| **Q6** | RLS SQL | `manual/002_saved_search_rls.sql` | `manual/` 부재 + SQLite 미지원 | (A) INFRA-002 + DB-007 위임 (DB-004 Q6 일관) | INFRA-002 + DB-007 (§9.6) |
| **Q7** | TS 타입 신규 | 명세 §3.6 `SearchParams` + `SavedSearchDTO` | 좁힐 enum 컬럼 0건 | (A) 미작성 (DB-001 / DB-004 패턴) | API-005 가 처음 작성 (§9.7) |
| **Q8** ★ | DTO 정의 위치 | API-005 / MOCK 영역 | — (본 ISSUE 책임 외) | (A) API-005 위임 (DB-003 Q6 / DB-004 Q7 경계 일관 + 명세 §7 직접 명시) | API-005 + `mode = ServiceModeType` import (§9.7) |

## ★ §2 Q1 PK 컨벤션 일관성 (DB-001~004 + DB-006 답습)

| 모델 (ISSUE) | PK | UNIQUE 제약 | 카디널리티 |
|---|---|---|---|
| `User` (DB-002) | `id String @id @default(uuid())` | `email @unique` | — |
| `Diagnosis` (DB-003) | `id String @id @default(uuid())` | (없음) | 1:N |
| `ShareLink` (DB-004) | `id String @id @default(uuid())` | `diagnosisId @unique` + `uniqueUrl @unique` | 1:0..1 |
| **`SavedSearch` (DB-006 — 현실)** | `id String @id @default(uuid())` | `userId @unique` | 1:0..1 |

→ DB-001~004 + 본 ISSUE 전체 모델 surrogate PK 컨벤션 일관. **DB 효과 동일**: `userId @id` ↔ `id @id + userId @unique` 양쪽 사용자당 1건 강제, UPSERT `where: { userId }` 인터페이스 동일.

**미래 모델 (DB-007 / Wave 2+) 추가 시 동일 컨벤션 답습 가이드** (단일 비일관 방지).

## ★ §2 Q3 Zod 인라인 호출처 8행 (CMD-SAVE-001 통합 대상)

| # | 위치 | 인라인 로직 (현 동작) | 명세 §3.7 등가 | CMD-SAVE-001 통합 |
|---|---|---|---|---|
| 1 | `app/api/save/route.ts:3` | `import { z } from "zod"` | (validator 의존성) | `lib/validators/saved-search.ts` 로 이동 |
| 2 | `app/api/save/route.ts:5-7` | `saveSearchSchema = z.object({ searchParams: z.record(z.string(), z.unknown()) })` ★ passthrough | `searchParamsSchema` | strict 정의 + 명세 §9.1 최종 결정 |
| 3 | `app/api/save/route.ts:13` | `saveSearchSchema.safeParse(body)` | Zod 검증 | helper 추출 + 호출 |
| 4 | `app/api/save/route.ts:22-32` | `prisma.savedSearch.upsert({...})` | UPSERT 로직 | Server Action 전환 + best effort |
| 5 | `app/api/save/route.ts:26` | `JSON.stringify(parsed.data.searchParams)` (create) | JSON 직렬화 | helper / 인라인 결정 |
| 6 | `app/api/save/route.ts:29` | `JSON.stringify(...)` (update) | JSON 직렬화 | helper / 인라인 결정 |
| 7 | `app/api/save/route.ts:49` | `prisma.savedSearch.findUnique({ where: { userId } })` | 조회 | QRY-SAVE-001 영역 |
| 8 | `app/api/save/route.ts:58` | `JSON.parse(saved.searchParams)` | JSON 역직렬화 | helper / 인라인 결정 |

→ **8행 모두 본 PR 미수정** (가드에 포함). CMD-SAVE-001 시점 일괄 통합. **명세 §9.1 자체가 strict/passthrough 결정을 CMD-SAVE-001 로 직접 위임 명시** — 본 ISSUE 가 추출 시 §9.1 결정 시점 충돌.

## §9 follow-up 8종 (Q1~Q8)

| § | 항목 | 트리거 |
|---|---|---|
| **§9.1 ★** | Q1 PK 컨벤션 미래 모델 가이드 | DB-007 / Wave 2+ |
| §9.2 | Q2 INFRA-002 후 Postgres `@db.JsonB` + 인덱싱 (DB-003 §9.1 일관) | INFRA-002 |
| **§9.3 ★** | Q3 CMD-SAVE-001 Zod 추출 + strict/passthrough 확정 + 호출처 8행 통합 | CMD-SAVE-001 (명세 §9.1 직접 위임) |
| §9.4 | Q4 seed = INFRA-002 + tsx runner 결정 | INFRA-002 |
| §9.5 | Q5 spec + vitest config | TEST-* |
| §9.6 | Q6 RLS + auth.users 정렬 | INFRA-002 + DB-007 |
| **§9.7 ★** | Q7+Q8 API-005 `SearchParams` + `SavedSearchDTO` + `mode = ServiceModeType` import (DB-003 Q6 답습) | API-005 |
| §9.8 | Q1 PK 컨벤션 재명시 (§9.1 보조) | — |

## 가드 12종 + Q3 호출처 8행 (절대 불변, 본 PR 변경 0)

✅ 가드 5종 검증 (PR 내 `git diff main -- <file>` 으로 unchanged 재확인):

| 가드 | 상태 |
|---|---|
| `onday-app/prisma/schema.prisma` | ✅ unchanged |
| `onday-app/src/lib/db.ts` (in-memory) | ✅ unchanged |
| **`onday-app/src/lib/types/user.ts`** (DB-002 PR #76) | ✅ unchanged |
| **`onday-app/src/lib/types/diagnosis.ts`** (DB-003 PR #77) | ✅ unchanged |
| **`onday-app/src/app/api/save/route.ts`** (★ Q3 인라인 8행) | ✅ unchanged |

기타 가드: `prisma.config.ts` · `migrations(4/29)` · `seed.ts` · `errors/.gitkeep` · `tests/db/.gitkeep` · `package.json` · design 루트 · `06_TASK_LIST_v1.3.md` — 모두 변경 0건.

## 위임 (후속 ISSUE — §9 Open Q)

| 항목 | 위임 대상 |
|---|---|
| Q3 Zod 추출 + strict/passthrough 확정 (명세 §9.1) + 인라인 호출처 8행 통합 + Server Action 전환 + best effort | **CMD-SAVE-001** |
| Q7+Q8 `src/lib/types/saved-search.ts` 신규 + `SearchParams` + `SavedSearchDTO` + `mode = ServiceModeType` import (DB-003 Q6 답습) | **API-005** |
| 실 PrismaClient swap + `searchParams Json @db.JsonB` 전환 + 인덱싱 평가 + AC-1~AC-4 활성 | **INFRA-002** |
| Q6 RLS SQL + `auth.users` FK 정렬 | **INFRA-002 + DB-007** |
| Q5 spec + vitest config | **TEST-*** |
| Q4 SavedSearch 시드 + tsx runner | INFRA-002 + DB-001 §3.9 일관 |
| Q1 PK 컨벤션 미래 모델 가이드 | DB-007 / Wave 2+ |
| QRY-SAVE-001 (route.ts:49, 58 인라인 통합) | CMD-SAVE-001 + QRY-SAVE-001 |

## 상세 명세

[`tasks/DB-006.md`](./tasks/DB-006.md) — 현실 동기화 갱신본 (436줄, 497 line changed, +346/-151)

## 후행 ISSUE 현실 추인 패턴 예고

- **DB-007 (Supabase Auth USER 정렬)**: INFRA-002 + Q6 RLS SQL 일괄 작성 (본 ISSUE §9.6 트리거) + ★ Q1 PK 컨벤션 답습 가이드 (§9.1/§9.8)
- **API-005 (SavedSearch DTO)**: ★ Q7 + Q8 — `saved-search.ts` 신규 작성 + `SearchParams` + `SavedSearchDTO` + `import { ServiceModeType } from './user'` (DB-003 Q6 답습)
- **CMD-SAVE-001 (입력값 자동 저장)**: ★ Q3 — Zod 추출 + strict/passthrough 확정 + 인라인 호출처 8행 통합 + Server Action 전환

Refs #9