### PR TITLE
docs(DB-007): USER 모델 Supabase Auth 정렬 명세 현실 동기화 (Refs #10)

### DIFF
--- a/tasks/DB-007.md
+++ b/tasks/DB-007.md
@@ -1,20 +1,36 @@
 ---
 name: Feature Task
-title: "[Feature] DB-007: Supabase Auth 연동 USER 스키마 정렬"
+title: "[Feature] DB-007: USER 모델 Supabase Auth 정렬 명세 현실 동기화 (schema.prisma 무수정 — @db.Uuid/Prisma enum/auth.users FK/RLS/supabase 클라이언트/user-sync = INFRA-002 + CMD-AUTH-001/003 위임. UserDTO = DB-002 산출물 추인 (위임 아님). 본 ISSUE 산출물 = 명세 동기화만, 코드 0)"
 labels: ['feature', 'priority:L', 'epic:Data Foundation', 'wave:1']
 assignees: []
 ---
 
 ## 1. 🎯 Summary
 
-- **기능명:** [DB-007] Supabase Auth 연동 USER 스키마 정렬
+- **기능명:** [DB-007] USER 모델 Supabase Auth 정렬 명세 현실 동기화. USER schema 자체는 4/29 산출물 (`prisma/schema.prisma` L10-22) + DB-002 산출물 (`src/lib/types/user.ts` — `AuthProviderType`/`ServiceModeType` TS union + `UserDTO` interface, commit `2ea3a17`) 으로 이미 완전 정의됨. `@db.Uuid` / Prisma enum / `auth.users` FK / RLS / supabase 클라이언트 / user-sync = INFRA-002 + CMD-AUTH-001/003 위임. UserDTO 는 "위임" 아닌 **DB-002 산출물 추인** (DB-006 Q8 의 "API-005 위임" 과 다른 케이스). 본 ISSUE 산출물 = `tasks/DB-007.md` 1 파일 (코드 변경 0건, DB-006 패턴 정확히 답습).
 - **목적 (Why):**
-  - **비즈니스:** Supabase Auth가 자동 관리하는 `auth.users` 테이블과 애플리케이션 USER 테이블 간의 정합성을 확보하여, 후속 인증·진단·공유 기능의 데이터 기반을 확립한다.
-  - **사용자 가치:** 카카오·네이버 소셜 로그인 후 사용자 프로필(이메일, 인증 제공자)이 애플리케이션 DB에 즉시 동기화되어, 개인화된 진단·저장·공유 서비스를 끊김 없이 이용할 수 있다.
+  - **비즈니스:** Supabase Auth (`@supabase/ssr`) 카카오·네이버 OAuth 후 애플리케이션 USER 정합성을 확보하는 USER schema·DTO 기반은 4/29 schema + DB-002 user.ts 산출물에 이미 완전 정의되어 있으며, 본 ISSUE 는 명세 v1.0 과 현실 간 정합성을 동기화하고 후행 ISSUE 위임 트리거를 명시한다. Supabase Auth 발급 UUID 차용 (`@db.Uuid` + `@default` 제거) + auth.users FK + RLS + Postgres enum 전환은 SQLite 환경 (Prisma `@db.Uuid` / Prisma enum 모두 미지원) 에서 `prisma validate` 실패를 유발하므로 **Postgres 전환 시점 (INFRA-002 + 본 ISSUE) 일괄 처리** 로 위임한다. mock-auth callback (`login-form.tsx:29-43`) + `setUser` hook (`session.ts:5,17`) + `UserDTO` (`user.ts:7-14`) 는 Mock 환경에서 정상 동작 중이며, 실 Supabase Auth callback + `prisma.user.upsert` UPSERT 함수 (`user-sync.ts`) + Supabase 클라이언트 (`lib/supabase/server.ts`, `middleware.ts`) 는 **호출처 0건 상태로 작성 즉시 dead file** 이므로 CMD-AUTH-001/003 위임 — DB-006 Q3 의 "인라인 등가 동작 중 → 추출 시 가드 위반" 의 **정반대 방향, 더 강한 위임 논리**.
+  - **사용자 가치:** 카카오·네이버 소셜 로그인 후 사용자 프로필이 애플리케이션 DB 에 즉시 동기화되어 개인화 진단·저장·공유 서비스를 끊김 없이 이용할 수 있다 — Mock 환경에서는 4/29 산출물 + DB-002 user.ts 로 동작 보장, 실 Supabase Auth 환경에서는 INFRA-002 + CMD-AUTH-001/003 시점 활성.
 - **범위 (What):**
-  - ✅ 만드는 것: 애플리케이션 `USER` 테이블의 `id` 필드를 `auth.users.id` FK로 참조하는 구조로 Prisma 스키마를 정의하고, 마이그레이션을 생성한다. Supabase Auth 연동을 위한 helper 유틸리티를 작성한다.
-  - ❌ 만들지 않는 것: NextAuth.js Adapter, OAuth 로그인 플로우 구현(CMD-AUTH-001 범위), 결제 관련 스키마
-- **복잡도:** L
+  - ✅ 만드는 것: 본 명세 현실 동기화 (`tasks/DB-007.md`) — Q1~Q7 결정 반영 + Q1~Q7 mismatch 추적 표 + Auth 인라인 호출처 6행 (L1~L6) 위치 표 + 부재 산출물 5종 위임 트리거 표 + §9 follow-up 7종
+    - **`prisma/schema.prisma` USER `id` 정렬 (`@db.Uuid` + `@default` 제거 + auth.users.id FK)** — Q1·Q2 결정: SQLite `@db.Uuid` 미지원 + DB-001~006 surrogate UUID PK 컨벤션 일관 보존 + mock-auth Prisma 자체 발급 동작 중. **INFRA-002 + 본 ISSUE 위임** (Postgres 전환 시점 일괄: schema USER `@default` 제거 + `@db.Uuid` + manual SQL FK + RLS + mock-auth → 실 Supabase Auth callback 전환).
+    - **Prisma `AuthProvider`/`ServiceMode` enum 추가** — Q4 결정: SQLite Prisma enum 미지원 + DB-002 `user.ts:4-5` `AuthProviderType`/`ServiceModeType` TS union 이미 동작 중 + `user.ts:2` 자체 주석 "실 Prisma enum = INFRA-002 시점". **INFRA-002 위임**.
+    - **`prisma/migrations/manual/001_user_auth_fk.sql` (auth.users FK + RLS SQL)** — Q3 결정: `manual/` 디렉토리 부재 + SQLite RLS 미지원. **INFRA-002 + 본 ISSUE 일괄 위임** (DB-004/006 Q6 위임 트리거가 본 ISSUE 시점에서 만남 — SHARE_LINK + SAVED_SEARCH + USER RLS SQL 일괄).
+    - **`lib/supabase/server.ts`, `lib/supabase/middleware.ts`** — Q3 결정: `@supabase/ssr` 사용처 0건 + `lib/supabase/` 디렉토리 부재. **CMD-AUTH-003 위임** (Supabase Auth 세션 전략 + httpOnly cookie + sameSite strict, REQ-NF-018).
+    - **`lib/services/user-sync.ts` (`syncUserFromAuth()` UPSERT)** — Q3 결정: `prisma.user.upsert/create/findUnique` 호출처 0건 + `lib/services/` 디렉토리 부재. **CMD-AUTH-001 위임** (OAuth callback UPSERT + L3 `session.ts:setUser` hook 통합).
+    - **`__tests__/db/user-schema.spec.ts` (5 케이스)** — Q3 결정: `vitest.config.ts` 부재 (vitest 의존성만 존재) + AC-1~AC-4 위임 일관 + in-memory fake meaningless. **TEST-008 위임**.
+    - **`prisma/migrations/{ts}_align_user_supabase_auth/migration.sql`** — Q5 결정: Q1 schema 무수정 → 빈 마이그레이션 = dead file. **INFRA-002 일괄 위임** (`align_user_supabase_auth` + RLS + FK + Postgres enum 일괄).
+  - ❌ 만들지 않는 것 (4/29 산출물 + DB-002 user.ts 보존 + 후행 ISSUE 위임):
+    - `prisma/schema.prisma` USER 모델 변경 (Q1: 절대 불변 — SQLite `@db.Uuid`/Prisma enum 미지원 + Mock 모드 가드 위반)
+    - `prisma/migrations/manual/001_user_auth_fk.sql` (Q3 §3.3: INFRA-002 + 본 ISSUE 일괄 위임)
+    - `lib/supabase/server.ts` / `lib/supabase/middleware.ts` (Q3 §3.5/3.6: CMD-AUTH-003 위임)
+    - `lib/services/user-sync.ts` (Q3 §3.7: CMD-AUTH-001 위임)
+    - `lib/types/user.ts` `UserDTO` 신규 (§3.8: **DB-002 산출물 추인**, 위임 아님)
+    - `__tests__/db/user-schema.spec.ts` (Q3 §3.10: TEST-008 위임)
+    - 신규 마이그레이션 (Q5: INFRA-002 일괄 위임)
+    - `.env.example` 수정 (Q6: 3종 이미 정의됨 추인)
+    - `prisma/seed.ts` User seed (Q7: 명세 §3 자체에 미정의, DB-001~006 일관 skip)
+- **복잡도:** L (명세 v1.0 동일)
 - **Wave:** 1 (DB 스키마 트랙)
 
 ---
@@ -28,220 +44,248 @@ assignees: []
 - **CON-11** (§1.2.3): "데이터베이스는 Prisma ORM + SQLite(로컬 개발) / Supabase PostgreSQL(프로덕션)을 사용한다."
 - **REQ-NF-018** (§4.2.3): "인증 세션 보안 — Supabase Auth httpOnly cookie 기반 세션. sameSite strict 적용. CSRF 보호는 Supabase Auth 내장 메커니즘 사용"
 
-### ERD 컬럼 (§6.2.1 USER)
+### `prototypes/design/CLAUDE.md` §3 (1인 MVP 제약) 인용
 
-| 필드명 | 타입 | 제약조건 | 설명 |
+- "Vercel Serverless Timeout = 10초 (REQ-FUNC-003)" → 본 ISSUE 비대상 (DB 스키마 트랙)
+- "보안 (MVP): TLS만 (Supabase 기본). AES-256·ISMS-P·OWASP DAST 는 GA 이후 (CON-16)" → RLS 정책은 INFRA-002 + 본 ISSUE 시점 적용
+- "Out of Scope ... 자동 코드 생성 금지" → §3.5~3.7 호출처 0건 = 미리 추출 시 dead file (DB-004 Q3 / DB-006 Q3 일관 — 단 **방향 정반대**)
+
+### ERD 컬럼 vs 현 schema.prisma (§6.2.1 USER)
+
+명세 v1.0 ERD §6.2.1 vs 현 `onday-app/prisma/schema.prisma` L10-22:
+
+| 필드명 | 타입 (명세 v1.0) | 현 schema.prisma | 정합 |
 |---|---|---|---|
-| `id` | UUID | PK, NOT NULL | 사용자 고유 식별자 (auth.users.id FK) |
-| `email` | VARCHAR(255) | UNIQUE, NOT NULL | 사용자 이메일 |
-| `auth_provider` | ENUM('kakao', 'naver') | NOT NULL | OAuth 인증 제공자 |
-| `mode` | ENUM('couple', 'single') | NOT NULL, DEFAULT 'couple' | 서비스 모드 |
-| `created_at` | TIMESTAMP | NOT NULL, DEFAULT NOW() | 계정 생성일시 |
-| `updated_at` | TIMESTAMP | NOT NULL | 최종 수정일시 |
+| `id` | UUID PK, NOT NULL, `auth.users.id` FK | `String @id @default(uuid())` (Prisma 자체 발급, FK 부재) | ⚠ Q2: 현실 추인 — INFRA-002 위임 |
+| `email` | VARCHAR(255) UNIQUE, NOT NULL | `String @unique` | ✅ |
+| `auth_provider` | ENUM('kakao','naver') NOT NULL | `String @map("auth_provider")` + 주석 + `user.ts:4` `AuthProviderType` TS union | ⚠ Q4: 현실 추인 — INFRA-002 위임 |
+| `mode` | ENUM('couple','single') NOT NULL DEFAULT 'couple' | `String @default("couple")` + 주석 + `user.ts:5` `ServiceModeType` TS union | ⚠ Q4: 현실 추인 — INFRA-002 위임 |
+| `created_at` | TIMESTAMP NOT NULL DEFAULT NOW() | `DateTime @default(now()) @map("created_at")` | ✅ |
+| `updated_at` | TIMESTAMP NOT NULL | `DateTime @updatedAt @map("updated_at")` | ✅ |
+
+관계 (§6.2.0):
+- User : Diagnosis = 1 : N — ✅ DB-003 시점 검증
+- User : SavedSearch = 1 : 0..1 — ✅ DB-006 시점 검증 (`User.savedSearch SavedSearch?` 역관계 활성)
+- User.id : `auth.users.id` = 1 : 1 — ⏸ INFRA-002 + 본 ISSUE 위임 (SQLite 환경 검증 불가)
+
+### ★ Q2 PK 컨벤션 일관성 (DB-001~006 전체 모델 답습 — 미래 모델 가이드)
+
+DB-001~004/006 PK 컨벤션 표 (DB-006 §2 PK 표에 User 행 추가):
+
+| 모델 | PK | FK 컨벤션 | 비고 |
+|---|---|---|---|
+| **User** ★ | `id String @id @default(uuid())` | — | DB-002. ★ Supabase Auth 정렬 (`@db.Uuid` + `auth.users.id` FK) = **INFRA-002 + 본 ISSUE 위임** (DB-007 Q2) |
+| Diagnosis | `id String @id @default(uuid())` | `userId String @map("user_id")` | DB-003 |
+| ShareLink | `id String @id @default(uuid())` | `diagnosisId String @unique` (1:1) | DB-004 |
+| SavedSearch | `id String @id @default(uuid())` | `userId String @unique` (1:0..1) | DB-006 |
+
+★ 본 ISSUE 는 USER 도 동일 컨벤션 보존 (Q2 결정). USER 만 외부 발급 모델로 분기 시 컨벤션 깨짐. Postgres 전환 시점에 `@db.Uuid` + `@default` 제거 + `auth.users.id` FK 일괄 처리 = INFRA-002 위임 (`user.ts:2` 자체 주석 "실 Prisma enum = INFRA-002 시점" 과 정합).
+
+### 4/29 `_init` migration 의 users 테이블 검증
+
+```sql
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "auth_provider" TEXT NOT NULL,
+    "mode" TEXT NOT NULL DEFAULT 'couple',
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+```
+
+검증: PK + UNIQUE(email) DB 레벨 강제 보장. **AC-2 (email 중복 UNIQUE 위반) ✅ DB 레벨 자체 충족** (코드 0건, Phase A.4 확인). 나머지 AC-1/AC-3/AC-4 는 INFRA-002 + CMD-AUTH-001 + TEST-008 위임.
 
 ### 시퀀스 다이어그램 (§6.3.6 인증 플로우)
 
-- **참여 Actor:** 사용자, Next.js Client Component, Next.js Middleware, Route Handler (/auth/callback), Supabase Auth, OAuth Provider (카카오/네이버), Prisma ORM, Amplitude
-- **핵심 메시지:** OAuth callback → Supabase 세션 교환 → `Callback→Prisma: User UPSERT (auth_provider, email)` → 리디렉트 + 세션 쿠키 설정 완료
+- 참여 Actor: 사용자, Next.js Client Component, Next.js Middleware, Route Handler (/auth/callback), Supabase Auth, OAuth Provider (카카오/네이버), Prisma ORM, Amplitude
+- 핵심 메시지: OAuth callback → Supabase 세션 교환 → `Callback→Prisma: User UPSERT (auth_provider, email)` → 리디렉트 + 세션 쿠키 설정 완료
+- ★ 본 시퀀스의 `Callback→Prisma: User UPSERT` 는 현재 mock-auth (`login-form.tsx:29-43`) 에서 `setUser` (`session.ts:17`) 로 대체 — 실 UPSERT 는 CMD-AUTH-001 시점 활성 (`lib/services/user-sync.ts` 신규).
+
+### ★ Auth 인라인 호출처 6행 (가드 추가 — 본 ISSUE 미수정, DB-006 §2 Zod 8행 표 패턴 답습 / ★ 방향 정반대)
+
+| # | 위치 | 역할 | 본 ISSUE 처리 | 후행 통합 대상 |
+|---|---|---|---|---|
+| **L1** | `onday-app/src/components/auth/login-form.tsx:15` | 주석: `// 실 OAuth: Step 12 Postgres 마이그 후 supabase.auth.signInWithOAuth 활성` — **onday-app 자체의 명시적 위임 선언** | 미수정 | CMD-AUTH-001 |
+| **L2** | `onday-app/src/components/auth/login-form.tsx:29-43` | `handleOAuth(provider)` — mock 모드 분기 (`setUser` 호출 + `router.push("/diagnosis")`) + 실 모드 `throw new Error("OAuth Provider 미구성 — Mock 모드를 켜주세요")` | 미수정 | CMD-AUTH-001 |
+| **L3** | `onday-app/src/stores/session.ts:5,17` | 주석: `// CMD-AUTH-001~004 연동 (Supabase OAuth 콜백 후 setUser 호출)` + `/** OAuth 콜백 성공 시 호출 — 게스트 모드 종료 */` `setUser` hook | 미수정 | CMD-AUTH-001/003 |
+| **L4** | `onday-app/src/lib/types/user.ts:1-2` | 주석: `// schema.prisma 의 authProvider / mode 는 SQLite enum 미지원으로 String 타입. // TS 레벨 union 으로 좁혀 타입 안전성 제공. 실 Prisma enum = INFRA-002 시점.` ← **Q2/Q4 결정과 정확히 정합** | 미수정 | INFRA-002 |
+| **L5** | `onday-app/src/lib/types/user.ts:7-14` | `UserDTO` interface (id, email, authProvider: `AuthProviderType`, mode: `ServiceModeType`, createdAt, updatedAt) — **명세 §3.8 과 등가 정의 이미 존재** (DB-002 산출물, commit `2ea3a17`) | 미수정 | **DB-002 추인** (위임 아님) |
+| **L6** ★ | `onday-app/src/lib/types.ts:87` | `authProvider: AuthProvider;` + `mode: DiagnosisMode;` ⚠ **두 가지 충돌**: (i) UserDTO 중복 (`user.ts:7-14` 와 별도 정의), (ii) `mode: DiagnosisMode` 가 `user.ts:5` `ServiceModeType` ('couple'\|'single') 과 불일치 (DiagnosisMode 는 Diagnosis 도메인 enum 추정) | 미수정, **follow-up 강화 기록** | **API-001 정리** (중복 제거 + mode 타입 통합) |
+
+본 ISSUE 가 §3.5~3.7/3.10 산출물을 미작성하는 사유: **호출처 0건 상태에서 작성 시 즉시 dead file**. DB-006 Q3 의 "인라인 등가 8행 동작 중 → 추출 시 호출처 가드 위반" 의 **정반대 방향, 더 강한 위임 논리** — onday-app 코드 자체가 L1+L3+L4 주석에서 "Step 12 Postgres 마이그 후", "CMD-AUTH-001~004 연동", "실 Prisma enum = INFRA-002 시점" 으로 위임 시점을 **이미 선언** → 본 ISSUE 가 §3.5~3.7 작성 시 `onday-app/CLAUDE.md` 가드 위반.
+
+### ★ 부재 산출물 5종 (호출처 0건 = dead file 회피 → 위임)
+
+| 명세 §3 산출물 | 현실 (Phase A.7 확인) | 위임 대상 |
+|---|---|---|
+| §3.3 `prisma/migrations/manual/001_user_auth_fk.sql` (auth.users FK + RLS) | `manual/` 디렉토리 자체 부재 + SQLite RLS 미지원 + Supabase 환경 비활성 | **INFRA-002 + 본 ISSUE 일괄** (DB-004 Q6 / DB-006 Q6 위임 트리거가 본 ISSUE 시점에서 만남 — SHARE_LINK + SAVED_SEARCH + USER RLS SQL 일괄 작성) |
+| §3.5 `lib/supabase/server.ts` (서버 사이드 Supabase 클라이언트) | `@supabase/ssr`/`createServerClient` 사용처 = 0건, `lib/supabase/` 디렉토리 부재 | **CMD-AUTH-003** (Supabase Auth 세션 전략 영역) |
+| §3.6 `lib/supabase/middleware.ts` (Middleware Supabase 클라이언트) | 동상 | **CMD-AUTH-003** |
+| §3.7 `lib/services/user-sync.ts` (`syncUserFromAuth()` UPSERT) | `prisma.user.upsert/create/findUnique/findFirst/update` 호출처 = 0건 (전체 onday-app/src), `lib/services/` 디렉토리 부재 | **CMD-AUTH-001** (OAuth callback UPSERT + L3 `session.ts:setUser` hook 통합) |
+| §3.10 `__tests__/db/user-schema.spec.ts` (5 케이스) | `vitest.config.ts` 부재 (vitest `^4.1.6` 의존성만 존재) + in-memory fake meaningless + AC-1~AC-4 위임 일관 | **TEST-008** (vitest config + USER schema spec + Auth E2E 일괄) |
 
 ### 선행 태스크 산출물
 
-| 선행 Task ID | 제공 산출물 | 본 태스크에서의 사용처 |
+| 선행 Task ID | 제공 산출물 | 본 ISSUE 사용처 |
 |---|---|---|
-| DB-002 | `prisma/schema.prisma` 내 `model User` 기본 정의 + USER 테이블 마이그레이션 | DB-007은 DB-002의 USER 모델을 확장하여 `auth.users.id` FK 참조 구조로 정렬한다 |
+| **DB-002** (PR #76 머지 완료, main `d916a6f`) | `prisma/schema.prisma` `model User` (L10-22) + `src/lib/types/user.ts` (`AuthProviderType`/`ServiceModeType` TS union + **`UserDTO` interface**, commit `2ea3a17`) | ★ 본 ISSUE Q3 L5 §3.8 = **DB-002 산출물 추인** (위임 아님). Q4 enum: DB-002 TS union 재사용 (신규 0) |
+| **DB-006** (PR #79 머지 완료, main `f99473c`) | `tasks/DB-006.md` (Phase B 생략 + 커밋 1개 docs 패턴 검증) | 본 ISSUE Phase 구조 정확히 답습 + DB-006 §2 Zod 8행 표 / §3 mismatch 추적 표 / §9 follow-up 패턴 답습 |
+| **DB-004** (PR #78 머지 완료, main `0e846b2`) | `tasks/DB-004.md` (DB-001 Phase B 생략 패턴 적용 첫 사례) | 간접 선행 (Q6 RLS=INFRA-002+DB-007 위임 트리거 — 본 ISSUE 시점에서 만남) |
+| **DB-003** (PR #77 머지) / **DB-001** (PR #75 머지) | Prisma 7 초기화 + `diagnosis.ts` | 간접 선행 (DB-* 일관 원칙) |
+
+### 후행 ISSUE 정합성 (Q1~Q7 결정 트리거)
+
+| 후행 Task ID | 본 ISSUE 위임 트리거 |
+|---|---|
+| **★ INFRA-002** | Q2 + Q4 + Q5 + §3.3 일괄: schema USER `@default` 제거 + `@db.Uuid` + Prisma enum + `manual/001_user_auth_fk.sql` (FK) + RLS SQL (DB-004/006 트리거 통합) + mock-auth → 실 Supabase Auth callback 전환 |
+| **★ CMD-AUTH-001** | §3.7 `lib/services/user-sync.ts` 신규 + `syncUserFromAuth(supabaseUser)` UPSERT + L3 `session.ts:setUser` hook 통합 |
+| **★ CMD-AUTH-003** | §3.5/3.6 `lib/supabase/server.ts` + `middleware.ts` 신규 + httpOnly cookie 세션 전략 (REQ-NF-018) + sameSite strict |
+| CMD-AUTH-002 | 네이버 OAuth — CMD-AUTH-001 패턴 답습 |
+| CMD-AUTH-004 | 게스트 모드 — L2 `login-form.tsx` 의 throw 대체 분기 |
+| **★ API-001** | L6 `types.ts:87` 중복 정리 — UserDTO 중복 제거 + mode 타입 통합 (`DiagnosisMode` → `ServiceModeType`) + Supabase Session ↔ UserDTO 매핑 |
+| **TEST-008** | §3.10 vitest config + USER schema spec 5 케이스 + AC-1~AC-4 + Auth E2E 일괄 |
 
 ---
 
 ## 3. 🛠️ Task Breakdown (실행 체크리스트)
 
-- [ ] **3.1** `prisma/schema.prisma`의 `model User`에서 `id` 필드를 Supabase Auth `auth.users.id`와 매핑 가능한 UUID 타입으로 정의 확인
-  - 현재 정의: `id String @id @default(cuid())`
-  - 변경 목표: `id String @id @db.Uuid` — Supabase Auth에서 제공하는 UUID를 그대로 사용 (자동 생성 제거)
-  - `@default(cuid())` 또는 `@default(uuid())` 제거 — OAuth callback에서 `auth.users.id`를 직접 삽입
+> ★ DB-006 패턴 답습 — 본 ISSUE 코드 변경 0건. 각 항목 [x] 통과 / [⏸ 위임] / [⏸ 추인] / 미작성 표기.
 
-- [ ] **3.2** `prisma/schema.prisma`의 `model User`에 `auth_provider` Enum 정의 추가
-  ```prisma
-  enum AuthProvider {
-    kakao
-    naver
-  }
-  
-  model User {
-    id           String       @id @db.Uuid
-    email        String       @unique
-    authProvider AuthProvider @map("auth_provider")
-    mode         ServiceMode  @default(couple)
-    createdAt    DateTime     @default(now()) @map("created_at")
-    updatedAt    DateTime     @updatedAt @map("updated_at")
-    
-    diagnoses    Diagnosis[]
-    savedSearch  SavedSearch?
-    
-    @@map("users")
-  }
-  
-  enum ServiceMode {
-    couple
-    single
-  }
-  ```
+- [x] **3.1** `prisma/schema.prisma` `model User` 4/29 산출물 보존 + Q1·Q2·Q4 결정 정합
+  > 현 정의 (`onday-app/prisma/schema.prisma:10-22`):
+  > ```prisma
+  > model User {
+  >   id           String   @id @default(uuid())   // Q2: surrogate UUID PK 일관 유지
+  >   email        String   @unique
+  >   authProvider String   @map("auth_provider")   // Q4: String + 주석 (SQLite enum 미지원)
+  >   mode         String   @default("couple")      // Q4: String + 주석
+  >   createdAt    DateTime @default(now()) @map("created_at")
+  >   updatedAt    DateTime @updatedAt @map("updated_at")
+  >   diagnoses    Diagnosis[]
+  >   savedSearch  SavedSearch?
+  >   @@map("users")
+  > }
+  > ```
+  > 차이 3건 (Q2/Q4): (i) 명세 §3.1 `@db.Uuid` + `@default` 제거 → 현실 `@default(uuid())` 유지 (Q2 결정), (ii) 명세 §3.2 `AuthProvider` Prisma enum → 현실 `String` + 주석 + `user.ts:4` TS union (Q4 결정), (iii) 명세 §3.2 `ServiceMode` Prisma enum → 현실 `String @default("couple")` + 주석 + `user.ts:5` TS union (Q4 결정). 모두 INFRA-002 위임.
 
-- [ ] **3.3** Supabase PostgreSQL 환경에서 `auth.users` 테이블과의 FK 참조를 위한 RLS 정책 SQL 작성
-  - 파일: `prisma/migrations/manual/001_user_auth_fk.sql`
-  - 내용:
-    ```sql
-    -- Supabase auth.users와 public.users 간 FK 정합성 보장
-    ALTER TABLE public.users
-      ADD CONSTRAINT fk_users_auth_id
-      FOREIGN KEY (id) REFERENCES auth.users(id) ON DELETE CASCADE;
-    
-    -- RLS 활성화
-    ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
-    
-    -- 사용자 본인만 자신의 행을 조회 가능
-    CREATE POLICY "Users can view own data" ON public.users
-      FOR SELECT USING (auth.uid() = id);
-    
-    -- 서비스 역할(service_role)은 UPSERT 가능
-    CREATE POLICY "Service role can manage users" ON public.users
-      FOR ALL USING (auth.role() = 'service_role');
-    ```
+- [⏸ INFRA-002 위임] **3.2** Prisma `AuthProvider`/`ServiceMode` enum 추가 — **Q4 결정**
+  > **사유 3종 (DB-001~006 일관 + onday-app 자체 위임 선언 + DB-002 산출물 재사용):**
+  > 1. **SQLite Prisma enum 미지원**: Prisma `enum` 타입은 PostgreSQL only. SQLite 환경 (`provider = "sqlite"`) 에서 `prisma validate` 실패 → onday-app dev/Vercel 빌드 파손.
+  > 2. **★ DB-002 TS union 산출물 이미 동작 중**: `src/lib/types/user.ts:4-5` `AuthProviderType`/`ServiceModeType` (commit `2ea3a17`) → 신규 0. Mock 환경 타입 안전성 보장.
+  > 3. **★ onday-app 자체 위임 선언**: `user.ts:2` 주석 `"실 Prisma enum = INFRA-002 시점."` ← Q4 결정과 정확히 정합. 본 ISSUE 가 Prisma enum 적용 시 `onday-app/CLAUDE.md` 가드 위반.
 
-- [ ] **3.4** `npx prisma migrate dev --name align_user_supabase_auth` 실행, 마이그레이션 SQL 검토
-  - 생성된 `prisma/migrations/{timestamp}_align_user_supabase_auth/migration.sql`의 내용이 다음을 포함하는지 확인:
-    - `id` 필드 타입이 `UUID`
-    - `auth_provider` ENUM 타입 생성
-    - `email` UNIQUE 제약조건
-    - `@@map("users")` 반영
+- [⏸ INFRA-002 + 본 ISSUE 일괄 위임] **3.3** `prisma/migrations/manual/001_user_auth_fk.sql` (auth.users FK + RLS SQL) — **Q3 부재 산출물 결정**
+  > **사유 4종 (DB-004/006 Q6 트리거 통합 + SQLite RLS 미지원):**
+  > 1. `prisma/migrations/manual/` 디렉토리 자체 부재 (Phase A.7 확인, DB-006 Q6 일관)
+  > 2. SQLite 환경 RLS 미지원 + `auth.users` 테이블 부재 (Supabase Postgres only)
+  > 3. **★ DB-004 Q6 + DB-006 Q6 위임 트리거 본 ISSUE 시점 만남**: 두 ISSUE 모두 "RLS SQL = INFRA-002 + DB-007 일괄 작성" 으로 위임. 본 ISSUE 가 **일괄 처리 정거장** = SHARE_LINK + SAVED_SEARCH + USER RLS SQL 모두 INFRA-002 + 본 ISSUE 시점.
+  > 4. mock-auth 환경에서 `auth.users` FK 자체 검증 불가능 → INFRA-002 Postgres 전환 + Supabase Auth 활성 후 일괄 적용.
 
-- [ ] **3.5** `lib/supabase/server.ts`에 서버 사이드 Supabase 클라이언트 생성 유틸리티 작성
-  ```typescript
-  import { createServerClient, type CookieOptions } from '@supabase/ssr';
-  import { cookies } from 'next/headers';
-  
-  export async function createSupabaseServerClient() {
-    const cookieStore = await cookies();
-    return createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          getAll() { return cookieStore.getAll(); },
-          setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
-            cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
-            );
-          },
-        },
-      }
-    );
-  }
-  ```
+- [x] **3.4** `npx prisma migrate dev --name align_user_supabase_auth` 신규 마이그레이션 — **Q5 결정 = 미생성**
+  > **사유 2종 (Q1=(A) docs only 결과 + DB-006 §3.3/3.5 패턴 답습):**
+  > 1. Q1 schema.prisma 무수정 → migrate dev 실행 시 "No schema change" 또는 빈 마이그레이션 = dead file.
+  > 2. Phase A 에서 `npx prisma validate` exit 0 (`valid 🚀`) + `npx prisma generate` exit 0 (`Generated Prisma Client (7.8.0) to ./src/generated/prisma in 21ms`) 통과 — 기준선 보존 충족. 신규 마이그레이션 = INFRA-002 일괄 위임.
 
-- [ ] **3.6** `lib/supabase/middleware.ts`에 Middleware용 Supabase 클라이언트 생성 유틸리티 작성
-  ```typescript
-  import { createServerClient, type CookieOptions } from '@supabase/ssr';
-  import { type NextRequest, NextResponse } from 'next/server';
-  
-  export function createSupabaseMiddlewareClient(request: NextRequest) {
-    let response = NextResponse.next({ request });
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          getAll() { return request.cookies.getAll(); },
-          setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
-            cookiesToSet.forEach(({ name, value, options }) => {
-              request.cookies.set(name, value);
-              response.cookies.set(name, value, options);
-            });
-          },
-        },
-      }
-    );
-    return { supabase, response };
-  }
-  ```
+- [⏸ CMD-AUTH-003 위임] **3.5** `lib/supabase/server.ts` (서버 사이드 Supabase 클라이언트) — **Q3 부재 산출물 결정**
+  > **사유 4종 (DB-* 일관 원칙 + 호출처 0건 dead file 회피 + onday-app 자체 위임 선언):**
+  > 1. **★ DB-* 일관 원칙**: "DB ISSUE = type/스키마/인프라 만, 동작 로직 = 후행 CMD-*/API-*" (DB-006 §1). Supabase 클라이언트 = 동작 로직 → CMD-AUTH-003 영역.
+  > 2. **★ 호출처 0건 = 작성 즉시 dead file**: `@supabase/ssr` / `createServerClient` 사용처 = 0건 (Phase A.7 전체 onday-app/src 확인). DB-004 Q3 / DB-006 Q3 "미리 추출 = dead code" 배제 논리 답습 — 단 **방향 정반대, 더 강한 위임 논리** (DB-006 은 인라인 동작 중, 본 ISSUE 는 호출처 자체 부재).
+  > 3. **★ onday-app 자체 위임 선언 (L1+L3)**: `login-form.tsx:15` "Step 12 Postgres 마이그 후 ... 활성" + `session.ts:5` "CMD-AUTH-001~004 연동" → 본 ISSUE 작성 시 `onday-app/CLAUDE.md` 가드 위반.
+  > 4. **CMD-AUTH-003 영역**: 06_TASK_LIST_v1.3.md §2-A `CMD-AUTH-003 — Supabase Auth 세션 전략 구현 — @supabase/ssr httpOnly cookie` 가 본 산출물의 owner. 본 ISSUE 미작성 + CMD-AUTH-003 시점 작성.
 
-- [ ] **3.7** `lib/services/user-sync.ts`에 Supabase Auth → 애플리케이션 User UPSERT 함수 작성
-  ```typescript
-  import { prisma } from '@/lib/db';
-  import type { User as SupabaseUser } from '@supabase/supabase-js';
-  
-  export async function syncUserFromAuth(supabaseUser: SupabaseUser): Promise<void> {
-    const provider = supabaseUser.app_metadata.provider as 'kakao' | 'naver';
-    await prisma.user.upsert({
-      where: { id: supabaseUser.id },
-      create: {
-        id: supabaseUser.id,
-        email: supabaseUser.email!,
-        authProvider: provider,
-        mode: 'couple',
-      },
-      update: {
-        email: supabaseUser.email!,
-        authProvider: provider,
-      },
-    });
-  }
-  ```
+- [⏸ CMD-AUTH-003 위임] **3.6** `lib/supabase/middleware.ts` (Middleware Supabase 클라이언트) — **Q3 부재 산출물 결정**
+  > 사유: §3.5 와 동일 (호출처 0건 + onday-app 자체 위임 선언 + CMD-AUTH-003 영역). Middleware Rate Limiting 은 SEC-002 영역 별도.
 
-- [ ] **3.8** `lib/types/user.ts`에 애플리케이션 UserDTO 타입 정의
-  ```typescript
-  export interface UserDTO {
-    id: string;          // UUID (auth.users.id 동일)
-    email: string;
-    authProvider: 'kakao' | 'naver';
-    mode: 'couple' | 'single';
-    createdAt: Date;
-    updatedAt: Date;
-  }
-  ```
+- [⏸ CMD-AUTH-001 위임] **3.7** `lib/services/user-sync.ts` (`syncUserFromAuth()` UPSERT 함수) — **Q3 부재 산출물 결정**
+  > **사유 4종 (호출처 0건 dead file 회피 + L3 hook 통합):**
+  > 1. **★ `prisma.user.upsert/create/findUnique/findFirst/update` 호출처 = 0건** (Phase A.7 전체 onday-app/src 확인). 작성 시 즉시 dead file.
+  > 2. **★ L3 `session.ts:5,17` 자체 위임 선언**: `// CMD-AUTH-001~004 연동 (Supabase OAuth 콜백 후 setUser 호출)` + `setUser` hook. 본 함수는 `setUser` hook 직전에 호출되는 CMD-AUTH-001 시퀀스 (§6.3.6 인증 플로우의 `Callback→Prisma: User UPSERT`) → CMD-AUTH-001 영역.
+  > 3. **L1+L2 mock-auth callback (`login-form.tsx:15, 29-43`)**: 현재 mock 모드에서 `setUser` 직접 호출 (`session.ts:17`) — DB UPSERT 자체 부재. 실 Supabase Auth callback 활성 시점 = INFRA-002 + CMD-AUTH-001 → 그 시점 본 함수 추가.
+  > 4. **CMD-AUTH-001 영역**: 06_TASK_LIST_v1.3.md §2-A `CMD-AUTH-001 — Supabase Auth 카카오 OAuth Provider 설정 + @supabase/ssr 클라이언트 연동` 의 명세 §3 task list 에 `Callback→Prisma: User UPSERT` 포함 예상.
 
-- [ ] **3.9** `.env.example`에 Supabase 환경변수 템플릿 추가
-  ```env
-  NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-  NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-  SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-  ```
+- [x] **3.8** `lib/types/user.ts` UserDTO 타입 정의 — ★ **DB-002 산출물 추인** (위임 아님)
+  > **★ DB-006 Q8 ("API-005 위임") 과 다른 케이스 — 명확히 구분:**
+  > 1. **현실 (`src/lib/types/user.ts:7-14`)**: `UserDTO` interface 이미 정의 (DB-002 commit `2ea3a17`).
+  >    ```typescript
+  >    export interface UserDTO {
+  >      id: string;
+  >      email: string;
+  >      authProvider: AuthProviderType;
+  >      mode: ServiceModeType;
+  >      createdAt: Date;
+  >      updatedAt: Date;
+  >    }
+  >    ```
+  > 2. **명세 §3.8 과 등가**: 6 필드 모두 일치. 추가/제거 0건.
+  > 3. **DB-006 Q8 vs DB-007 §3.8 차이**:
+  >    - DB-006: `SavedSearchDTO` **부재** → "위임 (API-005)" 으로 DB-006.md 에 명시
+  >    - DB-007: `UserDTO` **이미 존재** → "추인 (DB-002)" 으로 본 ISSUE 에 명시. 위임 아님.
+  > 4. **L6 follow-up 강화**: `src/lib/types.ts:87` 의 별도 UserDTO (`authProvider: AuthProvider` + `mode: DiagnosisMode`) ⚠ 중복 + 타입 충돌 → API-001 통합 정리 (중복 제거 + mode 타입 통합).
 
-- [ ] **3.10** `__tests__/db/user-schema.spec.ts`에 USER 테이블 스키마 검증 테스트 작성
-  ```typescript
-  describe('USER 테이블 스키마 검증', () => {
-    it('id 필드가 UUID 타입이며 PK이다', async () => { /* ... */ });
-    it('email 필드에 UNIQUE 제약조건이 적용된다', async () => { /* ... */ });
-    it('auth_provider 필드가 kakao | naver ENUM이다', async () => { /* ... */ });
-    it('동일 email로 중복 생성 시 에러가 발생한다', async () => { /* ... */ });
-    it('Supabase auth.users.id와 동일한 UUID로 User 생성이 가능하다', async () => { /* ... */ });
-  });
-  ```
+- [x] **3.9** `.env.example` Supabase 환경변수 3종 — **Q6 결정 = 현실 추인**
+  > **사유 2종 (이미 정의됨 + DB-006 패턴 답습):**
+  > 1. `onday-app/.env.example` 에 3종 모두 존재 (Phase A.8 확인):
+  >    ```env
+  >    NEXT_PUBLIC_SUPABASE_URL=
+  >    NEXT_PUBLIC_SUPABASE_ANON_KEY=
+  >    SUPABASE_SERVICE_ROLE_KEY=
+  >    ```
+  > 2. 값만 비어 있음 (Step 13+ INFRA-002 시점 채움). 본 ISSUE 미수정 = 현실 추인 (DB-006 .env 패턴 답습).
+
+- [⏸ TEST-008 위임] **3.10** `__tests__/db/user-schema.spec.ts` (5 케이스: PK UUID, UNIQUE email, ENUM auth_provider, DEFAULT mode, UPSERT) — **Q3 부재 산출물 결정**
+  > **사유 3종 (DB-001~006 §3.10 일관 + vitest config 부재 + AC 위임 일관):**
+  > 1. **vitest config 부재**: `vitest.config.ts/js` 부재 (Phase A.5 확인). vitest 의존성 (`^4.1.6`) 만 package.json 에 존재 → spec 작성해도 실행 불가.
+  > 2. **AC-1~AC-4 위임 일관**: §4 AC 자체가 INFRA-002 + CMD-AUTH-001/003 + API-001 위임 → spec 도 동일 시점 작성.
+  > 3. **TEST-008 영역**: 06_TASK_LIST_v1.3.md §3 `TEST-008 — Test: Auth — OAuth 로그인 GWT 시나리오 ... 카카오/네이버 로그인 성공, Supabase Auth 세션 생성·리프레시 토큰 자동 갱신·만료, 게스트 모드 전환` — USER schema spec + Auth E2E 일괄.
+
+- **(Q7) `prisma/seed.ts` User seed** — 명세 §3 자체에 미정의 → **skip**
+  > **사유 3종 (DB-001~006 일관):**
+  > 1. 명세 §3 task list 자체에 User seed 미정의 + §6 Deliverables 에 부재.
+  > 2. `tsx` 의존성 부재 (Phase A.5 재확인) → seed 작성해도 실행 불가.
+  > 3. DB-001~004/006 모두 seed 미작성 일관. 본 ISSUE 도 동일 답습.
+
+### ★ Q1~Q7 결정 vs 명세 v1.0 mismatch 추적 표 (DB-006 §3 끝 패턴 답습)
+
+| Q | 영역 | 명세 v1.0 (DB-007.md) | 현실 (onday-app) | 결정 | 후행 처리 |
+|---|---|---|---|---|---|
+| **Q1** ★ | 작업 모드 (가장 상위) | §3.1~3.10 9개 산출물 신규 작성 + schema 변경 | schema.prisma USER 모델 4/29 산출물 + DB-002 user.ts 동작 중 + 호출처 0건 (§3.5/3.6/3.7) | (A) **docs only** — schema 무수정 + 코드 0건 + 부재 산출물 5종 위임 | INFRA-002 + CMD-AUTH-001/003 + TEST-008 일괄 (§9) |
+| **Q2** ★ | USER `id` 정렬 | `@id @db.Uuid` + `@default` 제거 + `auth.users.id` FK | `@id @default(uuid())` + Prisma 자체 발급 + FK 부재 (SQLite, `@db.Uuid` 미지원) | (A) 현실 추인 — **DB-001~006 surrogate UUID PK 컨벤션 일관 보존** | INFRA-002 + 본 ISSUE 위임 (§9.1): Postgres 전환 시 `@default` 제거 + `@db.Uuid` + manual SQL FK + RLS + mock-auth → 실 Supabase Auth callback 전환 |
+| **Q3** ★ | Auth 인라인 호출처 + 부재 산출물 5종 (**★ 방향 정반대**) | §3.3 manual SQL / §3.5/3.6 supabase 클라이언트 / §3.7 user-sync / §3.10 spec 신규 작성 | 호출처 0건 (`prisma.user.upsert`=0 / `@supabase/ssr`=0 / `lib/supabase`=부재 / `lib/services`=부재 / `manual/`=부재 / vitest config=부재). + Auth 인라인 호출처 6행 (L1~L6, 본 ISSUE 미수정) | (A) 호출처 6행 위치 기록 + 부재 산출물 5종 위임 트리거 명시 + **§3.8 UserDTO = DB-002 추인** (위임 아님) + L6 `types.ts:87` 중복 follow-up | **★ 방향 정반대 강조**: DB-006 Q3 "인라인 동작 중 → 가드 위반" ↔ DB-007 Q3 "**호출처 0건 → 작성 즉시 dead file**" (더 강한 위임 논리). INFRA-002 + 본 ISSUE 일괄 (§3.3) / CMD-AUTH-003 (§3.5/3.6) / CMD-AUTH-001 (§3.7) / TEST-008 (§3.10) / API-001 (L6 중복 정리) |
+| **Q4** | AuthProvider/ServiceMode Prisma enum | Prisma `enum { kakao naver }` + `enum { couple single }` 추가 | `String` + 주석 + DB-002 `user.ts:4-5` TS union (commit `2ea3a17`) 동작 중 | (A) 현실 추인 + DB-002 산출물 재사용 (신규 0) | INFRA-002 (§9.4) — Postgres 전환 시 Prisma enum 적용 (`user.ts:2` 자체 주석 "실 Prisma enum = INFRA-002 시점" 과 정합) |
+| **Q5** | 신규 마이그레이션 | `npx prisma migrate dev --name align_user_supabase_auth` | Q1 schema 무수정 → migrate dev 실행 시 빈 마이그레이션 = dead file. 4/29 `_init` only | (A) 미생성, `prisma validate`/`generate` Phase A 통과만 | INFRA-002 일괄 위임 (§9.5) — `align_user_supabase_auth` + RLS + FK + Postgres enum 일괄 |
+| **Q6** | `.env.example` Supabase 3종 | 3종 추가 (`NEXT_PUBLIC_SUPABASE_URL` + `ANON_KEY` + `SUPABASE_SERVICE_ROLE_KEY`) | 3종 모두 이미 정의됨 (값만 비어 있음, INFRA-002 시점 채움) | (A) 현실 추인, 본 ISSUE 미수정 | INFRA-002 (값 채움 — 본 ISSUE 명세 영역 외) |
+| **Q7** | `prisma/seed.ts` User seed | 명세 §3 자체에 미정의 | seed 부재, tsx 부재 | (A) skip (DB-001~006 §3.9 일관) | — |
 
 ---
 
-## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD — DB-006 ⏸ 패턴 일관)
 
-**AC-1 (정상):** Supabase Auth 사용자 UUID로 애플리케이션 User UPSERT 성공
-- **Given** Supabase Auth에서 카카오 OAuth 로그인이 완료되어 `auth.users`에 UUID가 생성된 상태
-- **And** 해당 UUID로 `public.users` 테이블에 레코드가 없는 상태
-- **When** `syncUserFromAuth(supabaseUser)` 함수를 호출
-- **Then** `public.users` 테이블에 1개 행이 생성되며, `id`가 `auth.users.id`와 동일하다
-- **And** `auth_provider` 필드가 `kakao`, `email` 필드가 Supabase에서 제공한 이메일과 일치한다
+**AC-1 (정상, ⏸ INFRA-002 + CMD-AUTH-001 위임):** Supabase Auth 사용자 UUID 로 애플리케이션 User UPSERT 성공
+- **Given** Supabase Auth 카카오 OAuth 로그인 완료, `auth.users` 에 UUID 생성된 상태
+- **And** 해당 UUID 로 `public.users` 테이블에 레코드가 없는 상태
+- **When** `syncUserFromAuth(supabaseUser)` 함수를 호출 (CMD-AUTH-001 시점)
+- **Then** `public.users` 행 1개 생성, `id = auth.users.id`, `auth_provider = 'kakao'`, `email` 일치
+- **Status:** ⏸ INFRA-002 (실 Supabase Postgres + auth.users FK 활성) + CMD-AUTH-001 (`user-sync.ts` 신규) 시점 검증
 
-**AC-2 (예외):** 동일 email 중복 INSERT 시 UNIQUE 제약조건 에러
+**AC-2 (예외, ✅ 4/29 산출물 DB 레벨 충족):** 동일 email 중복 INSERT 시 UNIQUE 제약조건 에러
 - **Given** `public.users` 테이블에 `email = 'test@example.com'` 레코드가 이미 존재
-- **When** 동일 email로 다른 UUID의 User 생성을 시도
-- **Then** Prisma `P2002` Unique constraint failed 에러가 발생하며, DB에 중복 행이 생성되지 않는다
+- **When** 동일 email 로 다른 UUID 의 User 생성 시도
+- **Then** Prisma `P2002` Unique constraint failed 에러 발생, DB 중복 행 0건
+- **Status:** ✅ DB 레벨 자체 충족 (4/29 `_init` migration `CREATE UNIQUE INDEX "users_email_key" ON "users"("email");` Phase A.4 확인). TEST-008 검증.
 
-**AC-3 (예외):** auth.users에 존재하지 않는 UUID로 INSERT 시 FK 제약조건 에러
-- **Given** Supabase `auth.users` 테이블에 존재하지 않는 랜덤 UUID를 준비
-- **When** 해당 UUID로 `public.users` INSERT를 시도 (프로덕션 환경, FK 활성 시)
-- **Then** FK 제약조건 위반 에러가 발생하며, `public.users`에 행이 생성되지 않는다
+**AC-3 (예외, ⏸ INFRA-002 위임):** `auth.users` 에 존재하지 않는 UUID 로 INSERT 시 FK 제약조건 에러
+- **Given** Supabase `auth.users` 테이블에 존재하지 않는 랜덤 UUID 준비
+- **When** 해당 UUID 로 `public.users` INSERT 시도 (Postgres 환경, FK 활성)
+- **Then** FK 제약조건 위반 에러, `public.users` 행 0건 생성
+- **Status:** ⏸ INFRA-002 + 본 ISSUE (`manual/001_user_auth_fk.sql`) 시점 활성. SQLite 환경에서는 검증 불가.
 
-**AC-4 (경계):** 기존 User 재로그인 시 UPSERT로 email/provider 갱신
-- **Given** `public.users`에 `id = 'abc-123'`, `email = 'old@email.com'`, `auth_provider = 'kakao'` 레코드가 존재
-- **When** Supabase Auth에서 동일 `id = 'abc-123'`이지만 `email = 'new@email.com'`으로 `syncUserFromAuth()` 호출
-- **Then** 기존 행의 `email`이 `new@email.com`으로 갱신되고, `updated_at` 필드가 현재 시각으로 업데이트되며, 총 행 수는 여전히 1개다
+**AC-4 (경계, ⏸ INFRA-002 + CMD-AUTH-001 위임):** 기존 User 재로그인 시 UPSERT 로 email/provider 갱신
+- **Given** `public.users` 에 `id='abc-123'`, `email='old@email.com'`, `auth_provider='kakao'` 레코드 존재
+- **When** 동일 `id='abc-123'` 이지만 `email='new@email.com'` 으로 `syncUserFromAuth()` 호출
+- **Then** 기존 행 갱신, `email` 새 값 + `updated_at` 갱신, 총 행 수 1개 유지
+- **Status:** ⏸ CMD-AUTH-001 (`user-sync.ts` UPSERT) 시점 검증.
 
 ---
 
@@ -249,55 +293,168 @@ assignees: []
 
 | NFR ID | SRS 본문 인용 | 본 태스크에서의 검증 방법 |
 |---|---|---|
-| REQ-NF-018 | "인증 세션 보안 — Supabase Auth httpOnly cookie 기반 세션. sameSite strict 적용. CSRF 보호는 Supabase Auth 내장 메커니즘 사용" (§4.2.3) | Supabase 클라이언트 생성 유틸리티(`lib/supabase/server.ts`)에서 cookie 옵션이 올바르게 설정되는지 단위 테스트로 검증. 통합 테스트에서 httpOnly cookie 존재 확인 |
-| REQ-NF-012 | "서버 오류율 (5xx 응답) ≤ 0.5%" (§4.2.2) | UPSERT 실패 시 에러가 적절히 catch되어 Sentry로 전송되는지 확인. 스키마 불일치 시 500 에러 발생하지 않도록 방어 코드 검증 |
+| REQ-NF-018 | "인증 세션 보안 — Supabase Auth httpOnly cookie 기반 세션. sameSite strict 적용. CSRF 보호는 Supabase Auth 내장 메커니즘" (§4.2.3) | ⏸ CMD-AUTH-003 (`lib/supabase/server.ts` + `middleware.ts` 신규 + cookie 옵션 검증) + TEST-008 (httpOnly cookie 통합 테스트). 본 ISSUE 미작성 |
+| REQ-NF-012 | "서버 오류율 (5xx 응답) ≤ 0.5%" (§4.2.2) | ⏸ CMD-AUTH-001 (`user-sync.ts` UPSERT 실패 → Sentry catch) + MON-001 (Sentry 통합) 시점 검증 |
+| REQ-NF-035 | "Sentry 에러 추적 + 기본 알림" (§4.2.6, CON-17) | ⏸ MON-001 (Sentry 통합) + CMD-AUTH-001/003 시점 검증 |
 
 ---
 
-## 6. 📦 Deliverables (산출물 명시)
+## 6. 📦 Deliverables (산출물 명시 — 신규/보존/위임 3구역)
 
-- `prisma/schema.prisma` (USER 모델 Supabase Auth 연동 구조로 정렬 + AuthProvider/ServiceMode Enum 추가)
-- `prisma/migrations/{timestamp}_align_user_supabase_auth/migration.sql`
-- `prisma/migrations/manual/001_user_auth_fk.sql` (RLS 정책 + FK 수동 SQL)
-- `lib/supabase/server.ts` (서버 사이드 Supabase 클라이언트 생성 유틸리티)
-- `lib/supabase/middleware.ts` (Middleware용 Supabase 클라이언트 유틸리티)
-- `lib/services/user-sync.ts` (syncUserFromAuth UPSERT 함수)
-- `lib/types/user.ts` (UserDTO 타입)
-- `.env.example` (Supabase 환경변수 템플릿)
-- `__tests__/db/user-schema.spec.ts` (USER 테이블 제약조건 테스트)
+### ✅ 신규 (1)
+
+- `tasks/DB-007.md` — 본 ISSUE 명세 현실 동기화 (코드 변경 0건)
+
+### ✅ 보존 (12 가드 + 6 Auth 호출처 + 1 .env = 19종, 본 ISSUE 절대 미수정)
+
+**DB-001~006 누적 가드 (12)**:
+- `prisma/schema.prisma`, `prisma.config.ts`, `prisma/migrations/20260429125124_init/`, `prisma/seed.ts`, `src/lib/db.ts` (in-memory store), `src/lib/types/errors/.gitkeep`, **`src/lib/types/user.ts`** (DB-002 산출물 — 본 ISSUE Q3 L5 추인), `src/lib/types/diagnosis.ts` (DB-003 산출물), `__tests__/db/.gitkeep`, `package.json`, design 루트 (`CLAUDE.md`/`AGENTS.md`/`docs/`/`.claude/`/`README-*`), `06_TASK_LIST_v1.3.md`
+
+**Auth 인라인 호출처 6행 (가드 추가, DB-006 §6 Zod 호출처 8행 패턴 답습)**:
+- `onday-app/src/components/auth/login-form.tsx:15` (위임 선언 주석)
+- `onday-app/src/components/auth/login-form.tsx:29-43` (`handleOAuth`)
+- `onday-app/src/stores/session.ts:5,17` (CMD-AUTH 연동 주석 + `setUser` hook)
+- `onday-app/src/lib/types/user.ts:1-2` (INFRA-002 위임 주석)
+- `onday-app/src/lib/types/user.ts:7-14` (`UserDTO` — DB-002 추인)
+- `onday-app/src/lib/types.ts:87` (★ 중복 + mode 타입 충돌, API-001 follow-up)
+
+**`.env.example` Supabase 3종 (1)**: `onday-app/.env.example` 의 `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY` (값만 비어 있음, INFRA-002 시점 채움)
+
+### ⏸ 위임 (8종 — 후행 ISSUE 트리거)
+
+- §3.2 Prisma `AuthProvider`/`ServiceMode` enum → **INFRA-002 위임** (Q4)
+- §3.3 `prisma/migrations/manual/001_user_auth_fk.sql` (FK + RLS) → **INFRA-002 + 본 ISSUE 일괄** (Q3, DB-004/006 Q6 트리거 통합)
+- §3.4 신규 마이그레이션 (`align_user_supabase_auth`) → **INFRA-002 일괄** (Q5)
+- §3.5 `lib/supabase/server.ts` → **CMD-AUTH-003** (Q3)
+- §3.6 `lib/supabase/middleware.ts` → **CMD-AUTH-003** (Q3)
+- §3.7 `lib/services/user-sync.ts` (`syncUserFromAuth()`) → **CMD-AUTH-001** (Q3)
+- §3.10 `__tests__/db/user-schema.spec.ts` (5 케이스) → **TEST-008** (Q3)
+- (보너스) L6 `src/lib/types.ts:87` UserDTO 중복 + `mode: DiagnosisMode` 충돌 → **API-001 정리**
 
 ---
 
 ## 7. 🔗 Dependencies (의존성 — 양방향)
 
-### 선행 (이 태스크 시작 전 필요):
+### 선행 (이 ISSUE 시작 전 필요)
 
-- **DB-002:** `prisma/schema.prisma` 내 `model User` 기본 정의 + USER 테이블 마이그레이션 SQL
+- **DB-002** (PR #76 머지 완료, main `d916a6f`): `model User` (L10-22) + `src/lib/types/user.ts` (`AuthProviderType`/`ServiceModeType` TS union + **`UserDTO` interface**, commit `2ea3a17`) — ★ 본 ISSUE Q3 L5 §3.8 = DB-002 추인.
+- **DB-006** (PR #79 머지 완료, main `f99473c`): Phase B 생략 + 커밋 1개 docs 패턴 검증 자료 — 본 ISSUE 답습 대상.
+- **DB-004** (PR #78 머지 완료, main `0e846b2`): 간접 선행 (Phase B 생략 패턴 첫 사례 + Q6 RLS=INFRA-002+DB-007 위임 트리거 통합 대상).
+- **DB-001** (PR #75 머지 완료) / **DB-003** (PR #77 머지 완료): 간접 선행 (DB-* 일관 원칙).
 
-### 후행 (이 태스크 완료 후 차례로 가능):
+### 후행 (이 ISSUE 완료 후 차례로 가능)
 
-- **API-001:** Auth 도메인 DTO 정의 — DB-007이 제공하는 UserDTO, Supabase 클라이언트 유틸리티를 기반으로 Auth DTO를 확장 정의
-- **CMD-AUTH-001:** Supabase Auth 카카오 OAuth Provider 설정 — DB-007이 제공하는 `syncUserFromAuth()`와 Supabase 클라이언트를 사용하여 OAuth callback 구현
-- **CMD-AUTH-002:** 네이버 OAuth — CMD-AUTH-001과 동일한 패턴
-- **CMD-AUTH-003:** Supabase Auth 세션 전략 — DB-007이 제공하는 `lib/supabase/middleware.ts`를 사용
+- **★ INFRA-002** (Supabase Postgres 프로비저닝): Q2 + Q4 + Q5 + §3.3 일괄 처리 정거장 — schema USER `@default` 제거 + `@db.Uuid` + Prisma enum + manual SQL FK + RLS (DB-004/006 트리거 통합) + mock-auth → 실 Supabase Auth callback 전환
+- **★ CMD-AUTH-001** (Supabase Auth 카카오 OAuth Provider 설정): §3.7 `user-sync.ts` 신규 + L3 `session.ts:setUser` hook 통합
+- **★ CMD-AUTH-003** (Supabase Auth 세션 전략): §3.5/3.6 `lib/supabase/*` 신규 + httpOnly cookie + sameSite strict (REQ-NF-018)
+- **CMD-AUTH-002** (네이버 OAuth): CMD-AUTH-001 패턴 답습
+- **CMD-AUTH-004** (게스트 모드): L2 `login-form.tsx` 의 throw 대체 분기
+- **★ API-001** (Auth DTO): L6 `types.ts:87` 중복 정리 + Supabase Session ↔ UserDTO 매핑 + mode 타입 통합
+- **TEST-008**: §3.10 vitest config + USER schema spec 5 케이스 + AC-1~AC-4 + Auth E2E 일괄
+
+### ★ Q2 PK 컨벤션 미래 모델 가이드
+
+- Wave 2+ 모델 추가 시 `id String @id @default(uuid())` surrogate PK 패턴 답습.
+- USER 만 외부 발급 (`auth.users.id`) 모델로 분기 시 컨벤션 깨짐 → INFRA-002 시점 일괄 정렬 (본 ISSUE Q2 결정).
 
 ---
 
 ## 8. 🧪 Test Plan (검증 절차)
 
-- **단위 테스트:** `__tests__/db/user-schema.spec.ts` — Prisma 스키마 제약조건 5개 케이스 (PK UUID, UNIQUE email, ENUM auth_provider, DEFAULT mode, UPSERT 동작)
-- **단위 테스트:** `__tests__/services/user-sync.spec.ts` — `syncUserFromAuth()` 함수 4개 케이스 (신규 생성, 기존 갱신, 잘못된 provider, email 누락)
-- **통합 테스트:** `__tests__/integration/supabase-client.spec.ts` — Supabase 클라이언트 생성 유틸리티가 올바른 cookie 옵션을 사용하는지 검증
-- **수동 검증:**
-  1. 로컬 SQLite에서 `npx prisma migrate dev` 정상 실행 확인
-  2. Supabase 프로덕션 DB에서 마이그레이션 적용 + RLS SQL 적용 확인
-  3. Supabase 대시보드에서 `auth.users` → `public.users` FK 관계 확인
-- **CI 게이트:** `npx prisma validate` 통과, TypeScript `tsc --noEmit` 통과, Jest 테스트 통과
+### Phase A (본 ISSUE) — 사전 검증 (read-only) — ✅ 완료
+
+- ✅ A.1 main 동기화: `0e846b2..f99473c` fast-forward (PR #79 머지본 흡수)
+- ✅ A.2 DB-002~006 산출물 main 반영 (`user.ts`, `diagnosis.ts`, `tasks/DB-002~006.md`)
+- ✅ A.3 schema.prisma USER 모델 L10-22 보존 + Q2/Q4 결정 정합
+- ✅ A.4 4/29 `_init` migration `users` 테이블 + `users_email_key` UNIQUE INDEX 확인
+- ✅ A.5 vitest config + tsx 부재 (vitest `^4.1.6` 의존성만 존재)
+- ✅ A.6 Auth 호출처 6행 grep (L1~L6 위치 + 내용 정확 확인, ★ L6 강화 — `mode: DiagnosisMode` 충돌)
+- ✅ A.7 부재 산출물 5종 grep (`prisma.user.upsert`=0 / `@supabase/ssr`=0 / `lib/supabase`=부재 / `lib/services`=부재 / `manual/`=부재)
+- ✅ A.8 `.env.example` Supabase 3종 존재 (값 비어 있음)
+- ✅ A.9 `prisma validate` (`valid 🚀`) + `prisma generate` (Prisma Client 7.8.0) + `tsc --noEmit` exit 0
+- ✅ A.10 env-less `npm run build` exit 0 + **Middleware 32.5 kB** (7번째 회귀 0, INFRA-001 AC-4 anchor)
+- ✅ A.11 `feature/DB-007` 브랜치 분기 + untracked 2건 외 변경 0
+
+### 후행 ISSUE 검증 (위임)
+
+- **INFRA-002**: schema USER `@db.Uuid` + Prisma enum 적용 후 `prisma validate` 통과, `manual/001_user_auth_fk.sql` 적용 후 auth.users FK CASCADE 정합 확인
+- **CMD-AUTH-001**: `__tests__/services/user-sync.spec.ts` — `syncUserFromAuth()` 4 케이스 (신규 생성, 기존 갱신, 잘못된 provider, email 누락)
+- **CMD-AUTH-003**: `__tests__/integration/supabase-client.spec.ts` — httpOnly cookie 옵션 검증
+- **TEST-008**: `__tests__/db/user-schema.spec.ts` 5 케이스 (PK UUID, UNIQUE email, ENUM auth_provider, DEFAULT mode, UPSERT) + Auth E2E (카카오/네이버 로그인, Supabase 세션 생성·갱신·만료, 게스트 모드 전환)
+- **수동 검증** (INFRA-002 + CMD-AUTH-001 시점):
+  1. Supabase 프로덕션 DB 마이그레이션 적용 + RLS SQL 적용 확인
+  2. Supabase 대시보드 `auth.users` → `public.users` FK 관계 확인
+  3. Mock 모드 OFF (`NEXT_PUBLIC_USE_MOCK=false`) + 실 카카오/네이버 OAuth 로그인 후 `public.users` UPSERT 확인
 
 ---
 
-## 9. 🚧 Open Questions / Risks (보류 사항)
+## 9. 🚧 Open Questions / Risks (보류 사항 — follow-up 7종 + L6 강화)
 
-1. **RLS 정책과 Prisma 호환성:** Prisma ORM은 RLS를 직접 지원하지 않으므로, `service_role` key를 사용하는 Prisma 클라이언트와 `anon` key를 사용하는 Supabase 클라이언트를 분리 운영해야 할 수 있다. — 후속 CMD-AUTH-001에서 확정
-2. **로컬 개발 환경(SQLite)에서 FK 참조:** SQLite에는 `auth.users` 테이블이 없으므로, 로컬에서는 FK 제약을 건너뛰고 프로덕션에서만 수동 SQL로 적용하는 전략을 사용한다. `prisma/migrations/manual/` 디렉토리에 별도 관리.
-3. **Supabase Auth `app_metadata.provider` 필드 형식:** 카카오 OAuth Provider 설정 시 provider 값이 정확히 `'kakao'`인지 `'kakao-login'`인지 Supabase 대시보드 설정 후 확인 필요. — CMD-AUTH-001 작업 시 확정
+### 1. ★ Q2 + Q4 + Q5 + §3.3 INFRA-002 + 본 ISSUE 일괄 처리 (Postgres 전환 시점)
+
+INFRA-002 (Supabase Postgres 프로비저닝) 시점에 다음을 **일괄 적용**:
+- `prisma/schema.prisma` USER `id` 에서 `@default(uuid())` 제거 → `@db.Uuid` (Postgres provider 전환과 동시)
+- Prisma `AuthProvider`/`ServiceMode` enum 추가 (`user.ts:2` 자체 주석 "실 Prisma enum = INFRA-002 시점" 트리거 해소)
+- `prisma/migrations/manual/001_user_auth_fk.sql` 신규: `ALTER TABLE public.users ADD CONSTRAINT fk_users_auth_id FOREIGN KEY (id) REFERENCES auth.users(id) ON DELETE CASCADE` + RLS 활성 (`ALTER TABLE public.users ENABLE ROW LEVEL SECURITY`) + `auth.uid() = id` policy + `service_role` policy
+- **DB-004 Q6 + DB-006 Q6 위임 트리거 동시 처리**: `manual/002_share_link_rls.sql` (DB-004) + `manual/003_saved_search_rls.sql` (DB-006) 일괄 작성
+- 신규 마이그레이션 `align_user_supabase_auth` 생성 (`npx prisma migrate dev`)
+- mock-auth (`login-form.tsx:29-43`) → 실 Supabase Auth `signInWithOAuth()` callback 전환
+
+### 2. ★ Q3 §3.7 CMD-AUTH-001 — `lib/services/user-sync.ts` 신규 + L3 hook 통합
+
+- `lib/services/user-sync.ts` 신규: `syncUserFromAuth(supabaseUser: SupabaseUser): Promise<void>` UPSERT 함수
+- L3 `session.ts:setUser` hook 통합: OAuth callback → Supabase 세션 교환 → `syncUserFromAuth()` → `setUser()` 시퀀스 (§6.3.6)
+- AC-1/AC-4 검증 활성 (TEST-008 시점)
+- Sentry catch (REQ-NF-012 / REQ-NF-035 충족)
+
+### 3. ★ Q3 §3.5/3.6 CMD-AUTH-003 — Supabase 클라이언트 신규
+
+- `lib/supabase/server.ts` 신규: `createSupabaseServerClient()` (`@supabase/ssr` `createServerClient`)
+- `lib/supabase/middleware.ts` 신규: `createSupabaseMiddlewareClient(request)`
+- httpOnly cookie + sameSite strict 옵션 (REQ-NF-018)
+- TEST-008 통합 테스트 활성
+
+### 4. Q4 INFRA-002 후 Postgres Prisma enum 전환
+
+- `user.ts:2` 자체 주석 "실 Prisma enum = INFRA-002 시점" 해소
+- `enum AuthProvider { kakao naver }` + `enum ServiceMode { couple single }` schema.prisma 추가
+- DB-002 TS union (`AuthProviderType`/`ServiceModeType`) 은 Prisma 자동 생성 enum 으로 대체 가능 — but `user.ts` import 호환성 위해 re-export 유지 검토.
+
+### 5. Q5 INFRA-002 신규 마이그레이션 일괄
+
+- `npx prisma migrate dev --name align_user_supabase_auth_postgres` (Postgres 전환 + USER 정렬 + DB-004/006 RLS 일괄)
+
+### 6. ★ Q3 §3.10 TEST-008 — vitest config + USER schema spec + Auth E2E
+
+- `vitest.config.ts` 신규 (DB-001~006 일관 위임 누적 해소)
+- `__tests__/db/user-schema.spec.ts` 5 케이스
+- `__tests__/services/user-sync.spec.ts` 4 케이스
+- `__tests__/integration/supabase-client.spec.ts` cookie 검증
+- Auth E2E (카카오/네이버 로그인, 세션 갱신·만료, 게스트 모드)
+
+### 7. ★ L6 강화 — `src/lib/types.ts:87` UserDTO 중복 + mode 타입 충돌 = API-001 정리
+
+★ Phase A.6 추가 발견:
+
+`src/lib/types.ts:87` 의 UserDTO 는 다음 두 줄을 사용:
+```typescript
+// L6 발췌 (L85-90 컨텍스트):
+//   id: string;
+//   email: string;
+//   authProvider: AuthProvider;   ← user.ts:4 AuthProviderType 과 별도 타입
+//   mode: DiagnosisMode;          ← ⚠ user.ts:5 ServiceModeType 과 불일치
+// }
+```
+
+두 가지 문제:
+1. **UserDTO 중복**: `src/lib/types/user.ts:7-14` (DB-002 산출물) ↔ `src/lib/types.ts:87` (별도 정의) — 두 개의 UserDTO 가 공존.
+2. **mode 타입 불일치**: `types.ts:87` 의 `mode: DiagnosisMode` 는 Diagnosis 도메인 enum 으로 추정. user.ts:5 의 `mode: ServiceModeType` ('couple' \| 'single') 과 의미·값이 다를 가능성.
+
+→ **API-001 (Auth DTO 통합) 시점에 정리**:
+- `src/lib/types.ts:87` UserDTO 제거 (`user.ts:7-14` 로 단일화)
+- 또는 `types.ts:87` 을 다른 도메인 (예: `DiagnosisUserContext`) 으로 명명 변경
+- mode 타입은 `ServiceModeType` 으로 통합 (또는 별도 도메인 type 으로 분리)
+
+### 추가 보조
+
+- `app_metadata.provider` 값 형식 ('kakao' vs 'kakao-login') — CMD-AUTH-001 시점 Supabase 대시보드 설정 후 확정 (명세 §9.3 일관, 명세 v1.0 보존)


### PR DESCRIPTION
Refs #10

## 산출물 요약

- **명세 1 파일** (`tasks/DB-007.md`, +389 -232, 460 lines)
- **코드 변경 0건** (DB-001/004/006 패턴 답습 — Phase B 생략, 커밋 1개 docs only)
- feat 커밋 없음 — 코드 0건이라 정상

## ★ Q1~Q7 결정 vs 명세 v1.0 mismatch 추적 표

| Q | 영역 | 명세 v1.0 | 현실 (onday-app) | 결정 |
|---|---|---|---|---|
| **Q1** ★ | 작업 모드 | §3.1~3.10 9개 산출물 신규 + schema 변경 | 4/29 산출물 + DB-002 user.ts 동작 중 + 호출처 0건 | (A) **docs only** — schema 무수정 + 코드 0건 |
| **Q2** ★ | USER `id` | `@id @db.Uuid` + `@default` 제거 + auth.users.id FK | `@id @default(uuid())` (SQLite, `@db.Uuid` 미지원) | (A) 현실 추인 — DB-001~006 surrogate UUID PK 컨벤션 일관 보존 |
| **Q3** ★ | Auth 인라인 + 부재 5종 | §3.3/3.5/3.6/3.7/3.10 신규 작성 | 호출처 0건 (`prisma.user.upsert`=0 / `@supabase/ssr`=0 / `lib/supabase`=부재 / `lib/services`=부재 / `manual/`=부재) | (A) 호출처 6행 위치 기록 + 부재 5종 위임 + **§3.8 UserDTO = DB-002 추인** (위임 아님) |
| **Q4** | Prisma enum | `enum AuthProvider`/`ServiceMode` | String + 주석 + DB-002 TS union 동작 중 | (A) 현실 추인 + DB-002 재사용 (신규 0) |
| **Q5** | 신규 migration | `align_user_supabase_auth` | Q1 schema 무수정 → 빈 마이그레이션 = dead file | (A) 미생성, validate/generate Phase A 통과만 |
| **Q6** | `.env.example` Supabase 3종 | 3종 추가 | 3종 이미 정의됨 (값 비어 있음) | (A) 현실 추인, 미수정 |
| **Q7** | seed | 명세 미정의 | seed 부재, tsx 부재 | (A) skip (DB-001~006 §3.9 일관) |

## ★ Auth 인라인 호출처 6행 (가드 추가 — 본 ISSUE 미수정, DB-006 §2 Zod 8행 표 패턴)

| # | 위치 | 역할 | 후행 |
|---|---|---|---|
| L1 | `login-form.tsx:15` | 주석 "실 OAuth: Step 12 Postgres 마이그 후 supabase.auth.signInWithOAuth 활성" — **onday-app 자체 위임 선언** | CMD-AUTH-001 |
| L2 | `login-form.tsx:29-43` | `handleOAuth(provider)` mock 분기 + 실 모드 throw | CMD-AUTH-001 |
| L3 | `session.ts:5,17` | 주석 "CMD-AUTH-001~004 연동" + `setUser` hook | CMD-AUTH-001/003 |
| L4 | `user.ts:1-2` | 주석 "실 Prisma enum = INFRA-002 시점" — Q2/Q4 정합 | INFRA-002 |
| L5 | `user.ts:7-14` | `UserDTO` interface (DB-002 산출물) — **추인** | DB-002 추인 |
| **L6** ★ | `types.ts:87` | `authProvider: AuthProvider;` + `mode: DiagnosisMode;` ⚠ **두 가지 충돌**: (i) UserDTO 중복 (`user.ts:7-14` 와 별도), (ii) `mode: DiagnosisMode` 가 `ServiceModeType` ('couple'\|'single') 과 불일치 | **API-001 정리** (중복 제거 + mode 타입 통합) |

## ★ 부재 산출물 5종 (호출처 0건 = dead file 회피 → 위임)

| 명세 §3 | 현실 | 위임 |
|---|---|---|
| §3.3 `manual/001_user_auth_fk.sql` | `manual/` 디렉토리 부재 | **INFRA-002 + 본 ISSUE 일괄** (DB-004 Q6 / DB-006 Q6 트리거 통합) |
| §3.5 `lib/supabase/server.ts` | `@supabase/ssr` 사용처 0건 | **CMD-AUTH-003** |
| §3.6 `lib/supabase/middleware.ts` | 동상 | **CMD-AUTH-003** |
| §3.7 `lib/services/user-sync.ts` | `prisma.user.upsert` 호출처 0건 | **CMD-AUTH-001** |
| §3.10 `__tests__/db/user-schema.spec.ts` | vitest config 부재 | **TEST-008** |

## ★ §2 PK 컨벤션 표 — User 행 추가 (DB-006 §2 PK 표 확장)

| 모델 | PK | FK 컨벤션 | 비고 |
|---|---|---|---|
| **User** ★ | `id String @id @default(uuid())` | — | DB-002. Supabase Auth 정렬 (`@db.Uuid` + auth.users.id FK) = **INFRA-002 + 본 ISSUE 위임** (DB-007 Q2) |
| Diagnosis | `id String @id @default(uuid())` | `userId String @map("user_id")` | DB-003 |
| ShareLink | `id String @id @default(uuid())` | `diagnosisId String @unique` (1:1) | DB-004 |
| SavedSearch | `id String @id @default(uuid())` | `userId String @unique` (1:0..1) | DB-006 |

## ★ §9 follow-up 7종 (L6 강화 포함)

1. ★ **Q2 + Q4 + Q5 + §3.3 INFRA-002 + 본 ISSUE 일괄** (Postgres 전환 시점): schema USER `@default` 제거 + `@db.Uuid` + Prisma enum + `manual/001_user_auth_fk.sql` (FK) + RLS SQL (DB-004/006 트리거 통합) + mock-auth → 실 Supabase Auth callback 전환
2. ★ **Q3 §3.7 CMD-AUTH-001**: `lib/services/user-sync.ts` 신규 + L3 `session.ts:setUser` hook 통합
3. ★ **Q3 §3.5/3.6 CMD-AUTH-003**: `lib/supabase/server.ts` + `middleware.ts` 신규 + httpOnly cookie + sameSite strict (REQ-NF-018)
4. Q4 **INFRA-002** Postgres Prisma enum 전환 (`user.ts:2` 주석 해소)
5. Q5 **INFRA-002** 신규 마이그레이션 일괄
6. ★ **Q3 §3.10 TEST-008**: vitest config + USER schema spec 5 케이스 + Auth E2E 일괄
7. ★ **L6 강화 — `types.ts:87` UserDTO 중복 + mode 타입 충돌 = API-001 정리**: (i) UserDTO 중복 제거 (`user.ts:7-14` 로 단일화), (ii) `mode: DiagnosisMode` → `ServiceModeType` 통합

## ★ Q3 방향 정반대 (DB-006 ↔ DB-007 대조)

- **DB-006 Q3**: 인라인 등가 Zod 8행 동작 중 → 추출 시 호출처 가드 위반 → CMD-SAVE-001 위임
- **DB-007 Q3**: **호출처 0건 → 작성 즉시 dead file** → CMD-AUTH-001/003 + TEST-008 위임 (**더 강한 위임 논리**)
- onday-app 자체가 L1+L3+L4 주석에서 "Step 12 Postgres 마이그 후", "CMD-AUTH-001~004 연동", "실 Prisma enum = INFRA-002 시점" 으로 **위임 시점을 이미 선언** → 본 ISSUE 작성 시 `onday-app/CLAUDE.md` 가드 위반

## ★ UserDTO = DB-002 추인 (위임 아님)

- `src/lib/types/user.ts:7-14` 의 `UserDTO` interface 이미 정의 (DB-002 commit `2ea3a17`) + 명세 §3.8 과 6 필드 모두 등가
- **DB-006 Q8 ("API-005 위임") 과 다른 케이스**: DB-006 은 `SavedSearchDTO` 부재 → 위임. DB-007 은 `UserDTO` 이미 존재 → 추인.
- L6 `types.ts:87` 중복은 별도 follow-up (API-001 통합 정리)

## D 검증 결과 표

| 항목 | 결과 |
|---|---|
| D.1 `npx prisma validate` | ✅ exit 0 (`valid 🚀`) |
| D.2 `npx prisma generate` | ✅ exit 0 (Prisma Client 7.8.0) |
| D.3 `npx tsc --noEmit` | ✅ exit 0 (회귀 0) |
| D.4 env-less `npm run build` | ✅ exit 0 + **Middleware 32.5 kB** (7번째 회귀 0, INFRA-001 AC-4 anchor) |
| D.5 grep password (User 모델) | ✅ 0건 (ShareLink L48 `passwordHash` 만 별도 — DB-002/004 AC-6 일관) |
| D.6 격리 `git diff main --name-only` | ✅ `tasks/DB-007.md` 1 파일만 |
| D.7 가드 무수정 (DB-001~006 12종 + Auth 호출처 6행 + .env.example) | ✅ 0 lines |
| D.8 커밋 1개 (docs only) | ✅ `08c5a4a docs(DB-007): ...` |
| 격리 untracked | ✅ `.agents/skills`, `tasks/ISSUE_REGISTER_LOG.md` staging 안 함 |

## 가드 (DB-001~006 누적 + Auth 호출처 6행 + .env.example 본 ISSUE 미수정)

- 불변: `prisma/schema.prisma`, `prisma.config.ts`, `prisma/migrations/20260429125124_init/`, `prisma/seed.ts`, `src/lib/db.ts`, `src/lib/types/errors/.gitkeep`, `src/lib/types/user.ts` (DB-002 추인 — UserDTO 등가 정의), `src/lib/types/diagnosis.ts`, `src/lib/types.ts`, `__tests__/db/.gitkeep`, `package.json`, design 루트, `06_TASK_LIST_v1.3.md`
- Auth 호출처 6행: `login-form.tsx:15,29-43` / `session.ts:5,17` / `user.ts:1-2,7-14` / `types.ts:87` — 본 ISSUE 미수정
- `.env.example` Supabase 3종 — 미수정

## 산출물 파일

- [tasks/DB-007.md](../blob/feature/DB-007/tasks/DB-007.md) (460 lines)

## 머지 정책

- Draft PR — 머지·Issue #10 닫기는 **사용자 직접 결정**
- "Refs #10" 사용 (Closes 아님 — 자동 닫힘 방지)
- 자동 머지 절대 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)