### PR TITLE
feat+docs(API-001): Auth DTO + AUTH_ERROR_MAP + createAuthError + 명세 동기화 (Refs #11)

### DIFF
--- a/onday-app/src/lib/constants/auth-errors.ts
+++ b/onday-app/src/lib/constants/auth-errors.ts
@@ -1,0 +1,41 @@
+import { AuthErrorCode, type AuthErrorDTO } from '@/lib/types/auth';
+
+/** AuthErrorCode → 사용자 메시지·HTTP 상태 매핑 (9 키 — code/originalError 는 createAuthError 가 채움) */
+export const AUTH_ERROR_MAP: Record<AuthErrorCode, Omit<AuthErrorDTO, 'code' | 'originalError'>> = {
+  [AuthErrorCode.OAUTH_CALLBACK_FAILED]: {
+    message: '로그인 처리 중 오류가 발생했습니다. 다시 시도해 주세요.',
+    httpStatus: 500,
+  },
+  [AuthErrorCode.OAUTH_PROVIDER_ERROR]: {
+    message: '소셜 로그인 서비스에 일시적 장애가 있습니다.',
+    httpStatus: 502,
+  },
+  [AuthErrorCode.OAUTH_CODE_MISSING]: {
+    message: '인증 코드가 누락되었습니다. 다시 로그인해 주세요.',
+    httpStatus: 400,
+  },
+  [AuthErrorCode.SESSION_EXPIRED]: {
+    message: '세션이 만료되었습니다. 다시 로그인해 주세요.',
+    httpStatus: 401,
+  },
+  [AuthErrorCode.SESSION_INVALID]: {
+    message: '유효하지 않은 세션입니다. 다시 로그인해 주세요.',
+    httpStatus: 401,
+  },
+  [AuthErrorCode.SESSION_REFRESH_FAILED]: {
+    message: '세션 갱신에 실패했습니다. 다시 로그인해 주세요.',
+    httpStatus: 401,
+  },
+  [AuthErrorCode.USER_NOT_FOUND]: {
+    message: '사용자 정보를 찾을 수 없습니다.',
+    httpStatus: 404,
+  },
+  [AuthErrorCode.USER_SYNC_FAILED]: {
+    message: '사용자 정보 동기화에 실패했습니다.',
+    httpStatus: 500,
+  },
+  [AuthErrorCode.GUEST_MODE_ACTIVATED]: {
+    message: '게스트 모드로 전환되었습니다. 일부 기능이 제한됩니다.',
+    httpStatus: 200,
+  },
+};

--- a/onday-app/src/lib/helpers/auth-error.ts
+++ b/onday-app/src/lib/helpers/auth-error.ts
@@ -1,0 +1,20 @@
+import { AuthErrorCode, type AuthErrorDTO } from '@/lib/types/auth';
+import { AUTH_ERROR_MAP } from '@/lib/constants/auth-errors';
+
+/**
+ * AuthErrorDTO 생성 헬퍼.
+ * AUTH_ERROR_MAP 에서 사용자 메시지·HTTP 상태를 lookup 한 뒤 originalError 를 합쳐 반환.
+ * Sentry catch 와 연계 가능 (REQ-NF-035) — originalError 필드로 원본 에러 메시지 전달.
+ */
+export function createAuthError(
+  code: AuthErrorCode,
+  originalError?: string,
+): AuthErrorDTO {
+  const mapped = AUTH_ERROR_MAP[code];
+  return {
+    code,
+    message: mapped.message,
+    httpStatus: mapped.httpStatus,
+    originalError,
+  };
+}

--- a/onday-app/src/lib/types/auth.ts
+++ b/onday-app/src/lib/types/auth.ts
@@ -1,0 +1,135 @@
+import type { Session } from '@supabase/supabase-js';
+import type { UserDTO, AuthProviderType } from './user';
+
+// ──────────────────────────────────────────────
+// 1. OAuth Provider 설정
+// ──────────────────────────────────────────────
+
+/**
+ * Supabase 대시보드에 등록된 OAuth Provider.
+ * (P1) DB-007 §3.8 UserDTO 추인 패턴 일관 — user.ts AuthProviderType 재사용.
+ * 신규 type alias 정의 금지 (3 중복 회피: types.ts AuthProvider / user.ts AuthProviderType / 본 ISSUE — 본 ISSUE 는 신규 정의 안 함).
+ */
+export type OAuthProvider = AuthProviderType;
+
+/** OAuth 로그인 요청 시 signInWithOAuth() 에 전달하는 옵션 */
+export interface OAuthSignInOptions {
+  provider: OAuthProvider;
+  redirectTo: string;
+  scopes?: string;
+}
+
+// ──────────────────────────────────────────────
+// 2. Auth Session DTO
+// ──────────────────────────────────────────────
+
+/** 서버 사이드에서 사용하는 인증 세션 (Supabase Session 래핑) */
+export interface AuthSessionDTO {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  user: AuthUserDTO;
+}
+
+/** Supabase User 에서 애플리케이션에 필요한 필드만 추출 */
+export interface AuthUserDTO {
+  id: string;
+  email: string;
+  provider: OAuthProvider;
+  avatarUrl?: string;
+  lastSignInAt?: string;
+}
+
+// ──────────────────────────────────────────────
+// 3. Auth Callback DTO
+// ──────────────────────────────────────────────
+
+/** /auth/callback Route Handler 요청 파라미터 */
+export interface AuthCallbackRequest {
+  code: string;
+  next?: string;
+}
+
+/** /auth/callback Route Handler 응답 결과 */
+export interface AuthCallbackResult {
+  success: boolean;
+  session: AuthSessionDTO | null;
+  redirectTo: string;
+  error?: AuthErrorDTO;
+}
+
+// ──────────────────────────────────────────────
+// 4. Auth Error DTO
+// ──────────────────────────────────────────────
+
+/** Auth 에러 코드 체계 (9 종) */
+export enum AuthErrorCode {
+  // OAuth 에러
+  OAUTH_CALLBACK_FAILED = 'AUTH_OAUTH_CALLBACK_FAILED',
+  OAUTH_PROVIDER_ERROR = 'AUTH_OAUTH_PROVIDER_ERROR',
+  OAUTH_CODE_MISSING = 'AUTH_OAUTH_CODE_MISSING',
+
+  // 세션 에러
+  SESSION_EXPIRED = 'AUTH_SESSION_EXPIRED',
+  SESSION_INVALID = 'AUTH_SESSION_INVALID',
+  SESSION_REFRESH_FAILED = 'AUTH_SESSION_REFRESH_FAILED',
+
+  // 사용자 에러
+  USER_NOT_FOUND = 'AUTH_USER_NOT_FOUND',
+  USER_SYNC_FAILED = 'AUTH_USER_SYNC_FAILED',
+
+  // 게스트 모드
+  GUEST_MODE_ACTIVATED = 'AUTH_GUEST_MODE_ACTIVATED',
+}
+
+/** Auth 에러 응답 DTO */
+export interface AuthErrorDTO {
+  code: AuthErrorCode;
+  message: string;
+  httpStatus: number;
+  originalError?: string;
+}
+
+// ──────────────────────────────────────────────
+// 5. Middleware 인증 검증 타입
+// ──────────────────────────────────────────────
+
+/** Middleware 에서 세션 검증 후 반환하는 결과 */
+export interface MiddlewareAuthResult {
+  authenticated: boolean;
+  user: AuthUserDTO | null;
+  error?: AuthErrorCode;
+}
+
+// ──────────────────────────────────────────────
+// 6. 게스트 모드 타입
+// ──────────────────────────────────────────────
+
+/** OAuth 장애 시 게스트 임시 체험 모드 */
+export interface GuestSession {
+  isGuest: true;
+  guestId: string;
+  createdAt: string;
+  limitations: GuestLimitation[];
+}
+
+export type GuestLimitation =
+  | 'no_save'
+  | 'no_share'
+  | 'no_history';
+
+// ──────────────────────────────────────────────
+// 7. 유니온 타입 (인증/게스트 통합)
+// ──────────────────────────────────────────────
+
+export type CurrentUser =
+  | { type: 'authenticated'; session: AuthSessionDTO; user: UserDTO }
+  | { type: 'guest'; session: GuestSession }
+  | { type: 'unauthenticated' };
+
+// ──────────────────────────────────────────────
+// §3.3 SessionMapper 타입 시그니처 (구현은 CMD-AUTH-001/003 위임 — 호출처 0건 dead file 회피)
+// ──────────────────────────────────────────────
+
+/** Supabase Session → AuthSessionDTO 변환 유틸리티 시그니처 */
+export type SessionMapper = (session: Session) => AuthSessionDTO;

--- a/tasks/API-001.md
+++ b/tasks/API-001.md
@@ -1,20 +1,30 @@
 ---
 name: Feature Task
-title: "[Feature] API-001: Auth 도메인 DTO (Supabase Session 객체, @supabase/ssr 타입)"
+title: "[Feature] API-001: Auth 도메인 DTO 명세 현실 동기화 + 3 파일 신규 (API Contract 트랙 첫 진입 — DB-001~007 docs only 와 다름, Phase B 활성. mapper=CMD-AUTH-001/003 위임 + spec=TEST-008 위임 + (P1) OAuthProvider=AuthProviderType 재사용 + DB-007 PR #80 L6 follow-up 2차 정정 이력)"
 labels: ['feature', 'priority:M', 'epic:API Contract', 'wave:2']
 assignees: []
 ---
 
 ## 1. 🎯 Summary
 
-- **기능명:** [API-001] Auth 도메인 DTO 정의 — Supabase Session 객체, @supabase/ssr 타입, External OAuth Provider 설정 인터페이스
+- **기능명:** [API-001] Auth 도메인 DTO 정의 — Supabase Session 객체, @supabase/ssr 타입, External OAuth Provider 설정 인터페이스. ★ **API Contract 트랙 첫 진입** — DB-001~007 의 "docs only + Phase B 생략 + 커밋 1개" 패턴에서 분기. 본 ISSUE 산출물 = **신규 3 파일 (코드) + 명세 1 파일 갱신** + **커밋 2개 (feat + docs 분리)**. mapper 함수 (§3.4) + spec (§3.7/3.8) 는 호출처 0건 dead file 회피 원칙 (DB-004 Q3 / DB-006 Q3 / DB-007 Q3 일관) 으로 위임. (P1) `OAuthProvider = AuthProviderType` 재사용 (DB-007 §3.8 UserDTO 추인 패턴 일관 — 3 중복 회피).
 - **목적 (Why):**
-  - **비즈니스:** 카카오·네이버 소셜 로그인의 API 통신 계약을 단일 진실 공급원으로 확립하여, 후속 Auth Command·Query 태스크(CMD-AUTH-001~004)가 일관된 타입으로 구현되게 한다.
-  - **사용자 가치:** 인증 관련 타입이 명확히 정의되어, 로그인·세션 관리·게스트 모드 전환 시 타입 안전성이 보장되고 런타임 에러가 방지된다.
+  - **비즈니스:** 카카오·네이버 소셜 로그인의 API 통신 계약 (DTO + 에러 매핑 + helper) 를 단일 진실 공급원 (SSoT) 으로 확립하여, 후속 Auth Command·Query 태스크 (CMD-AUTH-001~004 + MOCK-005 + TEST-008) 가 일관된 타입으로 import 한다. ★ API Contract 트랙 = **DTO 정의 자체가 본 ISSUE 의 owner** (06_TASK_LIST §1-B 명시 — "후행 Feature 태스크가 import 할 SSoT 를 먼저 확립") → docs only 시 빈 contract 로 Wave 2 진입 의미 상실. ★ 단 mapper 함수 (`auth-mapper.ts`) 는 onday-app 호출처 0건 (`@supabase/ssr` 사용처 0건 + `lib/auth.ts` mock-auth 5 함수 우회 — DB-006 Q3 인라인 동작 중 패턴) → 작성 시 즉시 dead file → CMD-AUTH-001/003 위임 (DB-007 §3.7 user-sync 위임 논리 일관). spec 도 vitest config 부재 (DB-001~007 일관) → TEST-008 위임. (P1) `OAuthProvider` 는 신규 type alias 정의 금지 — `import type { AuthProviderType } from './user'` 재사용으로 3 중복 (`AuthProvider` types.ts:1 / `AuthProviderType` user.ts:4 / 본 ISSUE) 회피.
+  - **사용자 가치:** 인증 관련 타입이 명확히 정의되어, 로그인·세션 관리·게스트 모드 전환 시 타입 안전성이 보장되고 런타임 에러가 방지된다 — Mock 환경에서는 `lib/auth.ts` mock-auth + Zustand `useSessionStore` 가 정상 동작 중, 실 Supabase Auth 환경에서는 CMD-AUTH-001/003 시점 활성.
 - **범위 (What):**
-  - ✅ 만드는 것: Supabase Auth 세션 관련 DTO, OAuth 콜백 응답 타입, Auth 에러 코드 enum, Provider 설정 인터페이스, Middleware 인증 검증 타입
-  - ❌ 만들지 않는 것: OAuth 로그인 플로우 구현(CMD-AUTH-001), 세션 전략 구현(CMD-AUTH-003), 결제 관련 타입, NextAuth.js 관련 타입
-- **복잡도:** M
+  - ✅ 만드는 것 (신규 3 코드 파일 + 명세 1 파일):
+    - **`onday-app/src/lib/types/auth.ts`** — §3.2 7 섹션 (OAuthProvider/OAuthSignInOptions/AuthSessionDTO/AuthUserDTO/AuthCallbackRequest/AuthCallbackResult/AuthErrorCode/AuthErrorDTO/MiddlewareAuthResult/GuestSession/GuestLimitation/CurrentUser) + §3.3 `SessionMapper` 타입 시그니처. **(P1) `OAuthProvider = AuthProviderType` 재사용** (신규 type alias 정의 금지).
+    - **`onday-app/src/lib/constants/auth-errors.ts`** — §3.5 `AUTH_ERROR_MAP` (9 키 × {message, httpStatus}).
+    - **`onday-app/src/lib/helpers/auth-error.ts`** — §3.6 `createAuthError(code, originalError?)` helper.
+    - **`tasks/API-001.md`** — 본 명세 현실 동기화 (Q1~Q10 + L6 2차 정정 이력 + mismatch 추적표 + mock-auth M1~M4 + 부재 산출물 표 + §9 follow-up).
+  - ❌ 만들지 않는 것 (호출처 0건 dead file 회피 + 가드):
+    - `lib/mappers/auth-mapper.ts` (§3.4 `mapSupabaseSessionToDTO` + `mapSupabaseUserToDTO`) — **CMD-AUTH-001/003 위임** (호출처 0건 + `lib/auth.ts` mock-auth 우회 + L1+L3 `login-form.tsx`/`session.ts` 위임 선언 주석)
+    - `__tests__/types/auth-dto.spec.ts` + `__tests__/mappers/auth-mapper.spec.ts` + helper spec (§3.7/3.8) — **TEST-008 위임** (vitest config 부재, DB-001~007 §3.10 일관)
+    - `OAuthProvider` 신규 type alias — **(P1) AuthProviderType 재사용** (DB-007 §3.8 추인 패턴 일관, 3 중복 회피)
+    - `types.ts:1-2` `AuthProvider`/`DiagnosisMode` 통합 정리 — **Q2 가드. owner = MOCK-005 (AuthProvider+MockUser) + API-002 (DiagnosisMode→ServiceModeType, DB-003 commit `2ea3a17` `diagnosis.ts:4` 주석 직접 명시)**
+    - mock-auth M1~M4 (`lib/auth.ts` 5 함수 + Zustand `useSessionStore` + `MOCK_SESSION` + `login-form.tsx` `handleOAuth`) — 본 ISSUE 미수정 (CMD-AUTH-001/003/004 + MOCK-005 통합 대상)
+    - `OAuthProvider`/`AuthProviderType`/`ServiceModeType` 등 기존 type 재정의·중복 정의 — **절대 금지** (3 중복 원인 차단)
+- **복잡도:** M (명세 v1.0 동일)
 - **Wave:** 2 (API Contract 트랙)
 
 ---
@@ -24,315 +34,181 @@ assignees: []
 ### SRS 인용 (REQ ID + 본문 발췌)
 
 - **REQ-FUNC-029** (§4.1.6): "시스템은 Supabase Auth(@supabase/ssr)를 사용하여 카카오·네이버 소셜 로그인을 지원해야 한다. 세션은 Supabase Auth가 발급하는 httpOnly cookie로 관리하며, 카카오·네이버 OAuth는 Supabase 대시보드의 External OAuth Provider 설정으로 구성한다."
-- **CON-18** (§1.2.3): "인증은 Supabase Auth (@supabase/ssr 패키지)를 사용한다. 카카오·네이버 OAuth는 Supabase 대시보드의 External OAuth Provider 설정으로 구성한다. NextAuth.js는 사용하지 않는다."
+- **CON-18** (§1.2.3): "인증은 Supabase Auth (@supabase/ssr 패키지)를 사용한다. NextAuth.js는 사용하지 않는다."
 - **REQ-NF-018** (§4.2.3): "인증 세션 보안 — Supabase Auth httpOnly cookie 기반 세션. sameSite strict 적용. CSRF 보호는 Supabase Auth 내장 메커니즘 사용"
 - **REQ-NF-035** (§4.2.6): "에러 로그 알림 — Sentry 기본 알림 설정 사용 (커스텀 슬랙 임계치 제거)"
 
-### API 엔드포인트 (§6.1 API Endpoint List)
+### `prototypes/design/CLAUDE.md` §3 (1인 MVP 제약) 인용
+
+- "Vercel Serverless Timeout = 10초 (REQ-FUNC-003)" → 본 ISSUE 비대상 (API Contract 트랙)
+- "Out of Scope ... 자동 코드 생성 금지" → §3.4 mapper 호출처 0건 + `lib/auth.ts` mock-auth 우회 = 미리 추출 시 dead file (DB-004 Q3 / DB-006 Q3 / DB-007 Q3 일관)
+
+### API 엔드포인트 (§6.1)
 
 | # | Method | Endpoint / Action | 설명 | 인증 | 응답 시간 목표 |
 |---|---|---|---|---|---|
-| API-07 | GET | `/auth/callback` | OAuth 소셜 로그인 (Supabase Auth 콜백) | — | ≤ 1,000ms |
+| API-07 | GET | `/auth/callback` | OAuth 소셜 로그인 (Supabase Auth 콜백) — `AuthCallbackRequest`/`AuthCallbackResult` DTO 활용 | — | ≤ 1,000ms (CMD-AUTH-001 시점 검증) |
 
 ### 시퀀스 다이어그램 (§6.3.6 인증 플로우)
 
-- **참여 Actor:** 사용자, Next.js Client Component, Next.js Middleware, Route Handler (/auth/callback), Supabase Auth, OAuth Provider (카카오/네이버), Prisma ORM, Amplitude
-- **핵심 메시지:**
-  1. `Web→Supabase: supabase.auth.signInWithOAuth({provider: "kakao"})`
-  2. `OAuth→Callback: auth_code 반환 (/auth/callback)`
-  3. `Callback→Supabase: auth_code → 세션 교환`
-  4. `Supabase→Callback: 세션 (httpOnly cookie 설정)`
-  5. `Callback→Prisma: User UPSERT (auth_provider, email)`
-  6. `Middleware→Supabase: 세션 검증 (쿠키 기반)` (매 요청)
+- 참여 Actor: 사용자, Next.js Client Component, Next.js Middleware, Route Handler (/auth/callback), Supabase Auth, OAuth Provider (카카오/네이버), Prisma ORM, Amplitude
+- 핵심 메시지: OAuth callback → Supabase 세션 교환 → `Callback→Prisma: User UPSERT (auth_provider, email)` → 리디렉트 + 세션 쿠키 설정 완료
+- ★ 본 시퀀스의 실 동작은 현재 mock-auth (`login-form.tsx:29-43` `handleOAuth`) + Zustand `useSessionStore.setUser` (`session.ts:17`) 로 대체. 실 Supabase Auth 활성 = CMD-AUTH-001/003 + INFRA-002 시점 (`AuthSessionDTO`/`AuthUserDTO`/`SessionMapper` 본 ISSUE 산출물 활용).
+
+### ★ Phase B 작성 산출물 표 (신규 3 파일)
+
+| # | 파일 | 내용 | 명세 §3 매핑 |
+|---|---|---|---|
+| **B.1** | `onday-app/src/lib/types/auth.ts` (133 lines) | 7 섹션 (OAuthProvider + OAuthSignInOptions / AuthSessionDTO + AuthUserDTO / AuthCallbackRequest + AuthCallbackResult / AuthErrorCode 9 enum + AuthErrorDTO / MiddlewareAuthResult / GuestSession + GuestLimitation 3 union / CurrentUser 3 분기 discriminated union) + SessionMapper 타입 시그니처. **(P1) `OAuthProvider = AuthProviderType` 재사용** (import type from `./user`) | §3.2 + §3.3 |
+| **B.2** | `onday-app/src/lib/constants/auth-errors.ts` (42 lines) | `AUTH_ERROR_MAP: Record<AuthErrorCode, Omit<AuthErrorDTO, 'code' \| 'originalError'>>` 9 키 — OAUTH 3 + SESSION 3 + USER 2 + GUEST 1 | §3.5 |
+| **B.3** | `onday-app/src/lib/helpers/auth-error.ts` (20 lines) | `createAuthError(code, originalError?): AuthErrorDTO` — AUTH_ERROR_MAP lookup + originalError 병합. Sentry catch 연계 가능 (REQ-NF-035) | §3.6 |
+
+### ★ 명세 §3.2 import vs 본 ISSUE import 차이 (정직 기록)
+
+| 명세 §3.2 원본 import | 본 ISSUE 실제 import (`auth.ts:1-2`) | 차이 사유 |
+|---|---|---|
+| `import type { Session, User as SupabaseUser, AuthError } from '@supabase/supabase-js';` | `import type { Session } from '@supabase/supabase-js';` | `SupabaseUser`/`AuthError` 는 §3.4 mapper 본문에서만 사용 → mapper 위임이라 본 ISSUE 미사용. **ESLint `no-unused-vars` 위반 회피** (명세 §8 CI 게이트 — "ESLint `no-unused-vars` 경고 0건") |
+| `import type { UserDTO } from './user';` | `import type { UserDTO, AuthProviderType } from './user';` | **(P1) OAuthProvider = AuthProviderType 재사용** 위해 `AuthProviderType` 추가 import (Q2 확정) |
+
+### ★ mock-auth M1~M4 인라인 호출처 (가드 추가 — 본 ISSUE 미수정, DB-006 Q3 / DB-007 Auth 호출처 6행 패턴 답습)
+
+| # | 위치 | 역할 | 본 ISSUE 처리 | 후행 통합 대상 |
+|---|---|---|---|---|
+| **M1** | `onday-app/src/lib/auth.ts:1-40` (40 lines) | `IS_MOCK` (L4) + `SESSION_KEY` (L6) + 5 함수: `getMockSession` (L8-17) / `setMockSession` (L19-22) / `clearMockSession` (L24-27) / `getCurrentUser` (L29-36) / `isAuthenticated` (L38-40). Mock 모드 localStorage 기반 세션 관리. **`@supabase/ssr` 사용처 0건 — §3.4 mapper 의 등가 인라인 mock 대체** | 미수정 | CMD-AUTH-001/003 (실 Supabase Session 활성 + `lib/auth.ts` mock 5 함수 → `auth-mapper.ts` 추출) |
+| **M2** | `onday-app/src/stores/session.ts` 전체 | Zustand `useSessionStore` — `SessionUser` interface (L7 — id+nickname+provider+avatarUrl, 4 필드) + `setUser` / `enterGuestMode` / `signOut` + localStorage persist. ★ `SessionUser` vs `AuthUserDTO` (5 필드 — id+email+provider+avatarUrl+lastSignInAt) **별 entity** (client-side mock vs 서버 Supabase 매핑) | 미수정 | CMD-AUTH-001/003/004 (SessionUser ↔ AuthUserDTO 통합 — §9 follow-up 4) |
+| **M3** | `onday-app/src/mocks/users.ts:1-14` | `MOCK_USER: MockUser` (L3-8 — id+email+authProvider+mode) + `MOCK_SESSION = { user, accessToken, expiresAt }` (L10-14). ★ `MockUser` interface (`types.ts:84-89`, 4 필드) ↔ `UserDTO` (user.ts:7-14, 6 필드) **별 entity** (mock 도메인 vs production 도메인) | 미수정 | MOCK-005 (MockUser interface 정리 + AuthProvider 통합 + MOCK_SESSION ↔ AuthSessionDTO 정합) |
+| **M4** | `onday-app/src/components/auth/login-form.tsx:8, 29-43` | `import { MOCK_USER }` (L8) + `handleOAuth(provider)` mock 분기 (`setUser({id: MOCK_USER.id, nickname: ..., provider})` + `router.push("/diagnosis")`) + 실 모드 `throw new Error("OAuth Provider 미구성 — Mock 모드를 켜주세요")` | 미수정 | CMD-AUTH-001 (실 OAuth 활성 시 mock 분기 제거 + `syncUserFromAuth()` 호출 통합) |
+
+본 ISSUE 가 §3.4 mapper 산출물을 미작성하는 사유: **호출처 0건 + 등가 인라인 동작 중 (M1) → 작성 시 dead file**. DB-006 Q3 "인라인 등가 8행 동작 중 → 추출 시 호출처 가드 위반" 패턴 답습 (DB-007 Q3 "호출처 0건 → 작성 즉시 dead file" 과 동일 dead 회피 논리). M1~M4 보존 — CMD-AUTH-001/003/004 시점에 통합.
+
+### ★ 부재 산출물 표 (호출처 0건 = dead file 회피 → 위임)
+
+| 명세 §3 산출물 | 현실 (Phase A 확인) | 위임 대상 |
+|---|---|---|
+| §3.4 `lib/mappers/auth-mapper.ts` (`mapSupabaseSessionToDTO` + `mapSupabaseUserToDTO`) | `@supabase/ssr`/`@supabase/supabase-js` 사용처 0건 + `lib/mappers/` 빈 디렉토리 + M1 mock-auth 우회 | **CMD-AUTH-001/003** (실 Supabase Session 활성 + Sentry catch + M1~M4 통합) |
+| §3.7 `__tests__/types/auth-dto.spec.ts` (5 케이스) | vitest config 부재 (DB-001~007 §3.10 일관) — `vitest ^4.1.6` 의존성만 존재 | **TEST-008** |
+| §3.8 `__tests__/mappers/auth-mapper.spec.ts` (4 케이스) | 동상 + mapper 자체 위임이라 동시 위임 | **TEST-008** |
+| (명세 §8 추가) helper spec (`__tests__/helpers/auth-error.spec.ts` 3 케이스) | 동상 | **TEST-008** |
 
 ### 선행 태스크 산출물
 
-| 선행 Task ID | 제공 산출물 | 본 태스크에서의 사용처 |
+| 선행 Task ID | 제공 산출물 | 본 ISSUE 사용처 |
 |---|---|---|
-| DB-007 | `lib/types/user.ts` (UserDTO 타입), `lib/supabase/server.ts`, `lib/supabase/middleware.ts` (Supabase 클라이언트 유틸리티), `prisma/schema.prisma` (User + AuthProvider Enum) | Auth DTO가 UserDTO를 import하여 AuthenticatedUser 타입 정의. Supabase 클라이언트의 세션 타입을 기반으로 AuthSession DTO 정의 |
+| **DB-002** (PR #76 머지 완료, main `d916a6f`) | `src/lib/types/user.ts` (`AuthProviderType` + `ServiceModeType` TS union + `UserDTO` interface, commit `2ea3a17`) | ★ B.1 `auth.ts:2` `import type { UserDTO, AuthProviderType } from './user'` — UserDTO 는 `CurrentUser.authenticated` 분기 에서 사용 + AuthProviderType 은 **(P1) OAuthProvider 재사용** 대상 |
+| **DB-007** (PR #80 머지 완료, main `d1a6cba`) | `tasks/DB-007.md` — Auth 호출처 6행 가드 + UserDTO=DB-002 추인 + Q3 "호출처 0건 → dead file" 패턴 + L6 1차 발견 (추후 정정 대상) | ★ Phase A 가드 12 + Auth 호출처 6행 + ★ L6 1차 발견 (본 ISSUE 에서 2차/3차 owner 정정) |
+| **DB-006** (PR #79 머지 완료) / **DB-004** (PR #78) / **DB-003** (PR #77) / **DB-001** (PR #75) | 간접 선행 (DB-* 일관 원칙 + Phase 패턴 답습 + DB-003 `diagnosis.ts:4` 주석 = DiagnosisMode owner 명시) | DB-* 패턴 답습 + L6 2차 정정 근거 (DB-003 주석 인용) |
+
+### 후행 ISSUE 정합성 (Q1~Q10 결정 트리거)
+
+| 후행 Task ID | 본 ISSUE 위임 트리거 |
+|---|---|
+| **★ CMD-AUTH-001** (Supabase Auth 카카오 OAuth Provider 설정) | §3.4 `lib/mappers/auth-mapper.ts` 신규 — `mapSupabaseSessionToDTO` + `mapSupabaseUserToDTO` + Sentry catch + L3 `session.ts:setUser` hook 통합 + DB-007 §3.7 `user-sync.ts` UPSERT 통합 + M4 `login-form.tsx` mock 분기 제거 |
+| **★ CMD-AUTH-003** (Supabase Auth 세션 전략) | DB-007 §3.5/3.6 `lib/supabase/server.ts` + `middleware.ts` 신규 + httpOnly cookie + sameSite strict (REQ-NF-018) + 본 ISSUE `MiddlewareAuthResult` + `SessionMapper` 활성 |
+| CMD-AUTH-002 (네이버 OAuth) | CMD-AUTH-001 패턴 답습 |
+| CMD-AUTH-004 (게스트 모드) | `GuestSession` + `CurrentUser` 활성 + Zustand `enterGuestMode` 통합 + `lib/auth.ts:getCurrentUser` 우회 정리 |
+| **★ MOCK-005** (OAuth Mock 데이터) | **L6 2차 정정 owner 1** — `MockUser` interface 정리 (`types.ts:84-89`) + `AuthProvider` (types.ts:1) → `AuthProviderType` 통합 + `MOCK_SESSION` ↔ `AuthSessionDTO` 정합 |
+| **★ API-002** (Diagnosis DTO) | **L6 2차 정정 owner 2** — `DiagnosisMode` (types.ts:2) → `ServiceModeType` (user.ts:5) 통합 (DB-003 commit `2ea3a17` `diagnosis.ts:4` 주석 직접 명시 — 9 호출처 + 3 파일 일괄 정리) |
+| **TEST-008** | §3.7/3.8 + helper spec 일괄 (vitest config 신규 + USER schema spec + Auth DTO spec + mapper spec + helper spec + Auth E2E) |
 
 ---
 
 ## 3. 🛠️ Task Breakdown (실행 체크리스트)
 
-- [ ] **3.1** `@supabase/supabase-js` 및 `@supabase/ssr` 패키지의 타입 확인
-  - 버전: `@supabase/supabase-js@^2.45.0`, `@supabase/ssr@^0.5.0`
-  - 확인 대상 타입: `Session`, `User`, `AuthError`, `Provider`, `SignInWithOAuthCredentials`
-  - 명령어: `npx tsc --noEmit` 으로 타입 호환성 확인
+> ★ DB-006/007 패턴 답습 (mismatch 추적 표 + ⏸ 위임) + API-001 특화 (Phase B 활성 — 3 신규).
 
-- [ ] **3.2** `lib/types/auth.ts`에 Auth 도메인 DTO 타입 정의
-  ```typescript
-  import type { Session, User as SupabaseUser, AuthError } from '@supabase/supabase-js';
-  import type { UserDTO } from './user';
-  
-  // ──────────────────────────────────────────────
-  // 1. OAuth Provider 설정
-  // ──────────────────────────────────────────────
-  
-  /** Supabase 대시보드에 등록된 OAuth Provider */
-  export type OAuthProvider = 'kakao' | 'naver';
-  
-  /** OAuth 로그인 요청 시 signInWithOAuth()에 전달하는 옵션 */
-  export interface OAuthSignInOptions {
-    provider: OAuthProvider;
-    redirectTo: string;  // OAuth callback URL (e.g., '/auth/callback')
-    scopes?: string;      // Provider별 추가 스코프 (optional)
-  }
-  
-  // ──────────────────────────────────────────────
-  // 2. Auth Session DTO
-  // ──────────────────────────────────────────────
-  
-  /** 서버 사이드에서 사용하는 인증 세션 (Supabase Session 래핑) */
-  export interface AuthSessionDTO {
-    accessToken: string;
-    refreshToken: string;
-    expiresAt: number;          // Unix timestamp (초)
-    user: AuthUserDTO;
-  }
-  
-  /** Supabase User에서 애플리케이션에 필요한 필드만 추출 */
-  export interface AuthUserDTO {
-    id: string;                  // UUID (auth.users.id = public.users.id)
-    email: string;
-    provider: OAuthProvider;
-    avatarUrl?: string;
-    lastSignInAt?: string;       // ISO 8601
-  }
-  
-  // ──────────────────────────────────────────────
-  // 3. Auth Callback DTO
-  // ──────────────────────────────────────────────
-  
-  /** /auth/callback Route Handler 요청 파라미터 */
-  export interface AuthCallbackRequest {
-    code: string;                // Supabase가 전달하는 auth_code
-    next?: string;               // 인증 후 리디렉트 경로 (default: '/')
-  }
-  
-  /** /auth/callback Route Handler 응답 결과 */
-  export interface AuthCallbackResult {
-    success: boolean;
-    session: AuthSessionDTO | null;
-    redirectTo: string;
-    error?: AuthErrorDTO;
-  }
-  
-  // ──────────────────────────────────────────────
-  // 4. Auth Error DTO
-  // ──────────────────────────────────────────────
-  
-  /** Auth 에러 코드 체계 */
-  export enum AuthErrorCode {
-    // OAuth 에러
-    OAUTH_CALLBACK_FAILED = 'AUTH_OAUTH_CALLBACK_FAILED',
-    OAUTH_PROVIDER_ERROR = 'AUTH_OAUTH_PROVIDER_ERROR',
-    OAUTH_CODE_MISSING = 'AUTH_OAUTH_CODE_MISSING',
-    
-    // 세션 에러
-    SESSION_EXPIRED = 'AUTH_SESSION_EXPIRED',
-    SESSION_INVALID = 'AUTH_SESSION_INVALID',
-    SESSION_REFRESH_FAILED = 'AUTH_SESSION_REFRESH_FAILED',
-    
-    // 사용자 에러
-    USER_NOT_FOUND = 'AUTH_USER_NOT_FOUND',
-    USER_SYNC_FAILED = 'AUTH_USER_SYNC_FAILED',
-    
-    // 게스트 모드
-    GUEST_MODE_ACTIVATED = 'AUTH_GUEST_MODE_ACTIVATED',
-  }
-  
-  /** Auth 에러 응답 DTO */
-  export interface AuthErrorDTO {
-    code: AuthErrorCode;
-    message: string;               // 사용자 노출 메시지 (한국어)
-    httpStatus: number;            // HTTP 상태 코드
-    originalError?: string;        // Supabase AuthError 원본 메시지 (디버깅용)
-  }
-  
-  // ──────────────────────────────────────────────
-  // 5. Middleware 인증 검증 타입
-  // ──────────────────────────────────────────────
-  
-  /** Middleware에서 세션 검증 후 반환하는 결과 */
-  export interface MiddlewareAuthResult {
-    authenticated: boolean;
-    user: AuthUserDTO | null;
-    error?: AuthErrorCode;
-  }
-  
-  // ──────────────────────────────────────────────
-  // 6. 게스트 모드 타입
-  // ──────────────────────────────────────────────
-  
-  /** OAuth 장애 시 게스트 임시 체험 모드 */
-  export interface GuestSession {
-    isGuest: true;
-    guestId: string;             // 브라우저 세션 기반 임시 ID
-    createdAt: string;           // ISO 8601
-    limitations: GuestLimitation[];
-  }
-  
-  export type GuestLimitation = 
-    | 'no_save'         // 진단 결과 저장 불가
-    | 'no_share'        // 공유 링크 생성 불가
-    | 'no_history';     // 이전 조건 불러오기 불가
-  
-  // ──────────────────────────────────────────────
-  // 7. 유니온 타입 (인증/게스트 통합)
-  // ──────────────────────────────────────────────
-  
-  export type CurrentUser = 
-    | { type: 'authenticated'; session: AuthSessionDTO; user: UserDTO }
-    | { type: 'guest'; session: GuestSession }
-    | { type: 'unauthenticated' };
-  ```
+- [x] **3.1** Supabase 패키지 타입 호환 확인 (Phase A.3)
+  > Phase A 확인: `@supabase/ssr ^0.10.3` (명세 ^0.5.0 보다 높음, 호환) + `@supabase/supabase-js ^2.105.4` (명세 ^2.45.0 호환) — **이미 설치, 패키지 추가 불필요**. `tsc --noEmit` Phase A.8 exit 0 — `Session` 타입 import 호환 확인.
 
-- [ ] **3.3** `lib/types/auth.ts`에 Supabase 세션 → AuthSessionDTO 변환 함수 타입 정의
-  ```typescript
-  /** Supabase Session → AuthSessionDTO 변환 유틸리티 시그니처 */
-  export type SessionMapper = (session: Session) => AuthSessionDTO;
-  ```
+- [x] **3.2** `lib/types/auth.ts` 신규 작성 — **Phase B.1 완료 (133 lines)**
+  > 7 섹션 + SessionMapper 타입 시그니처. **(P1) `OAuthProvider = AuthProviderType` 재사용** — 신규 type alias 정의 금지 (3 중복 회피).
+  > import 부 (명세 §3.2 원본 대비 축소 — 정직 기록):
+  > - `import type { Session } from '@supabase/supabase-js';` (Session 만 — SessionMapper 시그니처용)
+  > - `import type { UserDTO, AuthProviderType } from './user';` (UserDTO = CurrentUser 분기용 + AuthProviderType = P1 재사용)
+  > 7 섹션:
+  > 1. OAuth Provider: `OAuthProvider = AuthProviderType` (P1) + `OAuthSignInOptions`
+  > 2. Auth Session DTO: `AuthSessionDTO` + `AuthUserDTO`
+  > 3. Auth Callback DTO: `AuthCallbackRequest` + `AuthCallbackResult`
+  > 4. Auth Error: `AuthErrorCode` enum (9 종 — OAUTH 3 + SESSION 3 + USER 2 + GUEST 1) + `AuthErrorDTO`
+  > 5. Middleware: `MiddlewareAuthResult`
+  > 6. Guest: `GuestSession` + `GuestLimitation` (3 union — 'no_save' \| 'no_share' \| 'no_history')
+  > 7. Union: `CurrentUser` (3 분기 discriminated union — 'authenticated' \| 'guest' \| 'unauthenticated')
+  > §3.3: `SessionMapper = (session: Session) => AuthSessionDTO` 타입 시그니처 (구현은 §3.4 위임)
 
-- [ ] **3.4** `lib/mappers/auth-mapper.ts`에 Supabase 타입 → Auth DTO 변환 함수 구현
-  ```typescript
-  import type { Session, User as SupabaseUser } from '@supabase/supabase-js';
-  import type { AuthSessionDTO, AuthUserDTO, OAuthProvider } from '@/lib/types/auth';
-  
-  export function mapSupabaseSessionToDTO(session: Session): AuthSessionDTO {
-    return {
-      accessToken: session.access_token,
-      refreshToken: session.refresh_token,
-      expiresAt: session.expires_at ?? 0,
-      user: mapSupabaseUserToDTO(session.user),
-    };
-  }
-  
-  export function mapSupabaseUserToDTO(user: SupabaseUser): AuthUserDTO {
-    const provider = (user.app_metadata.provider ?? 'kakao') as OAuthProvider;
-    return {
-      id: user.id,
-      email: user.email ?? '',
-      provider,
-      avatarUrl: user.user_metadata.avatar_url,
-      lastSignInAt: user.last_sign_in_at,
-    };
-  }
-  ```
+- [x] **3.3** `SessionMapper` 타입 시그니처 — **Phase B.1 완료 (`auth.ts` 같은 파일)**
+  > §3.2 와 같은 파일에 정의. 함수 본체는 §3.4 위임.
 
-- [ ] **3.5** `lib/constants/auth-errors.ts`에 AuthErrorCode → 사용자 메시지 매핑 상수 정의
-  ```typescript
-  import { AuthErrorCode, type AuthErrorDTO } from '@/lib/types/auth';
-  
-  export const AUTH_ERROR_MAP: Record<AuthErrorCode, Omit<AuthErrorDTO, 'code' | 'originalError'>> = {
-    [AuthErrorCode.OAUTH_CALLBACK_FAILED]: {
-      message: '로그인 처리 중 오류가 발생했습니다. 다시 시도해 주세요.',
-      httpStatus: 500,
-    },
-    [AuthErrorCode.OAUTH_PROVIDER_ERROR]: {
-      message: '소셜 로그인 서비스에 일시적 장애가 있습니다.',
-      httpStatus: 502,
-    },
-    [AuthErrorCode.OAUTH_CODE_MISSING]: {
-      message: '인증 코드가 누락되었습니다. 다시 로그인해 주세요.',
-      httpStatus: 400,
-    },
-    [AuthErrorCode.SESSION_EXPIRED]: {
-      message: '세션이 만료되었습니다. 다시 로그인해 주세요.',
-      httpStatus: 401,
-    },
-    [AuthErrorCode.SESSION_INVALID]: {
-      message: '유효하지 않은 세션입니다. 다시 로그인해 주세요.',
-      httpStatus: 401,
-    },
-    [AuthErrorCode.SESSION_REFRESH_FAILED]: {
-      message: '세션 갱신에 실패했습니다. 다시 로그인해 주세요.',
-      httpStatus: 401,
-    },
-    [AuthErrorCode.USER_NOT_FOUND]: {
-      message: '사용자 정보를 찾을 수 없습니다.',
-      httpStatus: 404,
-    },
-    [AuthErrorCode.USER_SYNC_FAILED]: {
-      message: '사용자 정보 동기화에 실패했습니다.',
-      httpStatus: 500,
-    },
-    [AuthErrorCode.GUEST_MODE_ACTIVATED]: {
-      message: '게스트 모드로 전환되었습니다. 일부 기능이 제한됩니다.',
-      httpStatus: 200,
-    },
-  };
-  ```
+- [⏸ CMD-AUTH-001/003 위임] **3.4** `lib/mappers/auth-mapper.ts` (`mapSupabaseSessionToDTO` + `mapSupabaseUserToDTO`) — **Q6 부재 산출물 결정**
+  > **사유 5종 (DB-004 Q3 / DB-006 Q3 / DB-007 Q3 일관 dead 회피 + onday-app 자체 위임 선언):**
+  > 1. **★ 호출처 0건 (Phase A.6 확인)**: `@supabase/ssr` / `createServerClient` / `@supabase/supabase-js` import 사용처 = 0건 (전체 onday-app/src). `lib/mappers/` 빈 디렉토리.
+  > 2. **★ M1 mock-auth 5 함수 우회 (등가 인라인 동작 중)**: `lib/auth.ts:8-40` 의 `getMockSession()` (40 lines) 이 명세 §3.4 mapper 의 **mock 대체 동작**. 본 ISSUE 가 mapper 추출 시 M1 우회 가드 위반 (DB-006 Q3 인라인 동작 중 패턴).
+  > 3. **★ onday-app 자체 위임 선언 (L1+L3, DB-007 Auth 호출처 가드)**: `login-form.tsx:15` "실 OAuth: Step 12 Postgres 마이그 후 supabase.auth.signInWithOAuth 활성" + `session.ts:5` "CMD-AUTH-001~004 연동 (Supabase OAuth 콜백 후 setUser 호출)" → 본 ISSUE 작성 시 가드 위반.
+  > 4. **CMD-AUTH-001/003 영역**: 06_TASK_LIST §2-A `CMD-AUTH-001 — Supabase Auth 카카오 OAuth Provider 설정 + @supabase/ssr 클라이언트 연동` + `CMD-AUTH-003 — Supabase Auth 세션 전략 (@supabase/ssr httpOnly cookie)` — mapper 의 owner.
+  > 5. **DB-007 §3.7 user-sync.ts 위임과 통합**: DB-007 §3.7 `lib/services/user-sync.ts` (CMD-AUTH-001 위임) + 본 §3.4 `lib/mappers/auth-mapper.ts` (CMD-AUTH-001/003 위임) → 두 위임 CMD-AUTH-001 시점 동시 처리.
 
-- [ ] **3.6** `lib/helpers/auth-error.ts`에 AuthErrorDTO 생성 헬퍼 함수 작성
-  ```typescript
-  import { AuthErrorCode, type AuthErrorDTO } from '@/lib/types/auth';
-  import { AUTH_ERROR_MAP } from '@/lib/constants/auth-errors';
-  
-  export function createAuthError(
-    code: AuthErrorCode,
-    originalError?: string
-  ): AuthErrorDTO {
-    const mapped = AUTH_ERROR_MAP[code];
-    return {
-      code,
-      message: mapped.message,
-      httpStatus: mapped.httpStatus,
-      originalError,
-    };
-  }
-  ```
+- [x] **3.5** `lib/constants/auth-errors.ts` `AUTH_ERROR_MAP` (9 키) — **Phase B.2 완료 (42 lines)**
+  > 9 키 (AuthErrorCode enum 전수) × `{message: string (한국어), httpStatus: number}` 매핑. Omit pattern (`Omit<AuthErrorDTO, 'code' | 'originalError'>`) — code/originalError 는 createAuthError 가 채움.
+  > HTTP 상태: 400 (OAUTH_CODE_MISSING) / 401 (SESSION 3 종) / 404 (USER_NOT_FOUND) / 500 (OAUTH_CALLBACK_FAILED + USER_SYNC_FAILED) / 502 (OAUTH_PROVIDER_ERROR) / 200 (GUEST_MODE_ACTIVATED)
 
-- [ ] **3.7** `__tests__/types/auth-dto.spec.ts`에 Auth DTO 타입 검증 테스트 작성
-  ```typescript
-  describe('Auth DTO 타입 검증', () => {
-    it('OAuthProvider 타입이 kakao | naver만 허용한다', () => { /* 타입 레벨 테스트 */ });
-    it('AuthSessionDTO 필수 필드가 모두 존재한다', () => { /* ... */ });
-    it('AuthErrorCode의 모든 값에 AUTH_ERROR_MAP 매핑이 존재한다', () => { /* ... */ });
-    it('CurrentUser 유니온 타입이 3가지 분기를 올바르게 구분한다', () => { /* ... */ });
-  });
-  ```
+- [x] **3.6** `lib/helpers/auth-error.ts` `createAuthError(code, originalError?)` — **Phase B.3 완료 (20 lines)**
+  > `(code: AuthErrorCode, originalError?: string): AuthErrorDTO` — AUTH_ERROR_MAP lookup + originalError 병합. Sentry catch 와 연계 가능 (REQ-NF-035) — originalError 필드로 원본 에러 메시지 전달.
 
-- [ ] **3.8** `__tests__/mappers/auth-mapper.spec.ts`에 세션 변환 함수 테스트 작성
-  ```typescript
-  describe('mapSupabaseSessionToDTO', () => {
-    it('Supabase Session을 AuthSessionDTO로 올바르게 변환한다', () => { /* ... */ });
-    it('provider가 누락된 경우 기본값 kakao를 사용한다', () => { /* ... */ });
-    it('email이 null인 경우 빈 문자열로 변환한다', () => { /* ... */ });
-    it('avatar_url이 없는 경우 undefined를 반환한다', () => { /* ... */ });
-  });
-  ```
+- [⏸ TEST-008 위임] **3.7** `__tests__/types/auth-dto.spec.ts` (5 케이스: OAuthProvider 범위 / AuthSessionDTO 필수 필드 / AuthErrorCode 전수 매핑 / CurrentUser 3 분기 / GuestLimitation 범위)
+  > **사유 3종 (DB-001~007 §3.10 일관 + vitest config 부재 + AC 위임 일관):**
+  > 1. vitest config 부재 (Phase A.7 확인) → spec 작성해도 실행 불가
+  > 2. AC-1/AC-3/AC-4 가 INFRA-002+CMD-AUTH 위임 → spec 도 동일 시점 작성
+  > 3. TEST-008 영역 (06_TASK_LIST §3) — Auth E2E + DTO spec 일괄
+
+- [⏸ TEST-008 위임] **3.8** `__tests__/mappers/auth-mapper.spec.ts` (4 케이스)
+  > 사유: §3.4 mapper 자체 위임 (Q6) → spec 동시 위임. AC-1 (mapSupabaseSessionToDTO 정상 변환) 검증.
+
+### ★ Q1~Q10 결정 vs 명세 v1.0 mismatch 추적 표 (DB-006/007 §3 끝 패턴 답습)
+
+| Q | 영역 | 명세 v1.0 (API-001.md) | 현실 (onday-app) | 결정 | 후행 처리 |
+|---|---|---|---|---|---|
+| **Q1** ★ | 작업 모드 (가장 상위, DB-007 docs only 전환점) | §3.1~3.8 8개 산출물 신규 작성 | Supabase 패키지 설치됨 + DB-007 산출물 (user.ts UserDTO) 활용 가능 + mapper 호출처 0건 + spec 미실행 가능 | (B) **절충 — Phase B 활성 (3 파일) + 커밋 2개 (feat+docs 분리)**. API Contract 트랙 = DTO owner | Phase B 작성 (B.1/B.2/B.3) + Phase D 커밋 2개 |
+| **Q2** ★ | L6 type alias 통합 + OAuthProvider 처리 (개별 신중) | (명세 §3.2 신규 `OAuthProvider`) | `types.ts:1-2` `AuthProvider`/`DiagnosisMode` 별도 정의 (DiagnosisMode 9 호출처 + 3 파일 / AuthProvider 1 호출처) + `user.ts:4-5` `AuthProviderType`/`ServiceModeType` 동일 union 별도 alias | (A) + (P1) — `types.ts:1-2` 무수정 + `OAuthProvider = AuthProviderType` 재사용 (3 중복 회피) | API-002 (DiagnosisMode→ServiceModeType, DB-003 주석) + MOCK-005 (AuthProvider+MockUser) (§9 follow-up 3/4) |
+| **Q3** | §3.1 Supabase 패키지 호환 | `^0.5.0` / `^2.45.0` | `^0.10.3` / `^2.105.4` 이미 설치 | (A) Phase A 확인만 (패키지 추가 불필요) | — |
+| **Q4** | §3.2 `lib/types/auth.ts` 7 섹션 | 신규 작성 | 부재 + Supabase 패키지 설치 + DB-002 user.ts UserDTO 활용 가능 | (A) **✅ Phase B.1 작성** + (P1) OAuthProvider=AuthProviderType 재사용 + import 축소 (SupabaseUser/AuthError 미사용 — ESLint 회피) | 후행 import 활용 (CMD-AUTH-001/003/004 · MOCK-005 · TEST-008) |
+| **Q5** | §3.3 `SessionMapper` 타입 시그니처 | 신규 작성 | 부재 | (A) **✅ Phase B.1 작성** (§3.2 와 같은 파일) | §3.4 mapper 구현 시 type 활용 (CMD-AUTH-001/003) |
+| **Q6** | §3.4 mapper 함수 구현 | `lib/mappers/auth-mapper.ts` 신규 | `@supabase/ssr` 사용처 0건 + `lib/mappers/` 빈 디렉토리 + M1 mock-auth 우회 + L1/L3 위임 선언 주석 | (A) **⏸ CMD-AUTH-001/003 위임** — 호출처 0건 dead file 회피 (DB-004 Q3 / DB-006 Q3 / DB-007 Q3 일관) | CMD-AUTH-001 (mapSupabaseSessionToDTO + mapSupabaseUserToDTO + Sentry catch + L3 hook 통합) (§9 follow-up 2) |
+| **Q7** | §3.5 `AUTH_ERROR_MAP` (9 키) | 신규 작성 | 부재 + `lib/constants/` 빈 디렉토리 | (A) **✅ Phase B.2 작성** | 후행 createAuthError lookup 대상 |
+| **Q8** | §3.6 `createAuthError` helper | 신규 작성 | 부재 + `lib/helpers/` 빈 디렉토리 | (A) **✅ Phase B.3 작성** | 후행 CMD-AUTH-001/003 import (AuthErrorDTO 생성) |
+| **Q9** | §3.7/3.8 spec | type spec 5 케이스 + mapper spec 4 케이스 | vitest config 부재 + vitest 의존성 (`^4.1.6`) 만 존재 + in-memory fake meaningless | (A) **⏸ TEST-008 위임** — DB-001~007 §3.10 일관 | TEST-008 (vitest config + type spec + mapper spec + helper spec + Auth E2E 일괄) (§9 follow-up 3) |
+| **Q10** | (보조) Zustand `SessionUser` ↔ `AuthUserDTO` 정합 | — (명세 §3.2 신규 AuthUserDTO) | `stores/session.ts:7` `SessionUser` (4 필드: id+nickname+provider+avatarUrl) ↔ B.1 `AuthUserDTO` (5 필드: id+email+provider+avatarUrl+lastSignInAt) — **별 entity** | 본 ISSUE 미수정, §9 follow-up | CMD-AUTH-001/003 (SessionUser ↔ AuthUserDTO 통합, M2 보존) (§9 follow-up 5) |
 
 ---
 
-## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD — DB-006/007 ⏸ 패턴 일관 + Phase B 작성분 충족)
 
-**AC-1 (정상):** Supabase Session → AuthSessionDTO 변환 성공
-- **Given** Supabase Auth에서 카카오 OAuth 로그인 완료 후 유효한 `Session` 객체가 존재
-- **And** `session.user.app_metadata.provider === 'kakao'`
-- **When** `mapSupabaseSessionToDTO(session)` 호출
-- **Then** 반환된 `AuthSessionDTO`의 `user.provider`가 `'kakao'`이고, `accessToken`, `refreshToken`, `expiresAt`이 원본 Session의 값과 일치
-- **And** `user.id`가 UUID 형식이며, `user.email`이 비어있지 않다
+**AC-1 (정상, ⏸ CMD-AUTH-001 + INFRA-002 위임):** Supabase Session → AuthSessionDTO 변환 성공
+- **Given** Supabase Auth 카카오 OAuth 로그인 완료, `session.user.app_metadata.provider === 'kakao'`
+- **When** `mapSupabaseSessionToDTO(session)` 호출 (CMD-AUTH-001 시점)
+- **Then** `AuthSessionDTO.user.provider === 'kakao'`, `accessToken`/`refreshToken`/`expiresAt` 원본 일치, `user.id` UUID 형식, `user.email` 비어있지 않음
+- **Status:** ⏸ CMD-AUTH-001 (`auth-mapper.ts` 신규) + INFRA-002 (실 Supabase Session) 시점 검증. ★ 본 ISSUE B.1 `AuthSessionDTO`/`AuthUserDTO`/`SessionMapper` 타입 시그니처 정의 완료 — AC-1 검증 토대 활성.
 
-**AC-2 (예외):** OAuth 콜백에 auth_code가 누락된 경우
-- **Given** `/auth/callback` Route Handler에 `code` query parameter가 없는 요청
-- **When** `AuthCallbackRequest` 타입으로 파싱 시도
-- **Then** `AuthErrorCode.OAUTH_CODE_MISSING` 에러가 생성되며, `httpStatus`가 400이고, `message`가 `'인증 코드가 누락되었습니다. 다시 로그인해 주세요.'`
+**AC-2 (예외, ✅ Phase B 산출물 충족):** OAuth 콜백에 auth_code 가 누락된 경우
+- **Given** `/auth/callback` Route Handler 에 `code` query parameter 없음
+- **When** `AuthCallbackRequest` 타입 파싱 시도 + `createAuthError(AuthErrorCode.OAUTH_CODE_MISSING)`
+- **Then** `AuthErrorDTO.code === 'AUTH_OAUTH_CODE_MISSING'`, `httpStatus === 400`, `message === '인증 코드가 누락되었습니다. 다시 로그인해 주세요.'`
+- **Status:** ✅ Phase B.1 `AuthCallbackRequest` + B.1 `AuthErrorCode.OAUTH_CODE_MISSING` + B.2 `AUTH_ERROR_MAP[OAUTH_CODE_MISSING]` + B.3 `createAuthError()` 모두 작성 — **B.2/B.3 lookup 동작 자체 충족** (호출 자체는 CMD-AUTH-001 시점).
 
-**AC-3 (예외):** 세션 만료 상태에서 Middleware 검증 시도
-- **Given** 사용자의 Supabase 세션이 만료된 상태 (`expires_at < 현재 시각`)
-- **When** Middleware에서 `MiddlewareAuthResult`를 반환
-- **Then** `authenticated`가 `false`이고, `error`가 `AuthErrorCode.SESSION_EXPIRED`이며, `user`가 `null`
+**AC-3 (예외, ⏸ CMD-AUTH-003 + INFRA-002 위임):** 세션 만료 상태에서 Middleware 검증 시도
+- **Given** Supabase 세션 만료 (`expires_at < 현재`)
+- **When** Middleware 에서 `MiddlewareAuthResult` 반환
+- **Then** `authenticated === false`, `error === AuthErrorCode.SESSION_EXPIRED`, `user === null`
+- **Status:** ⏸ CMD-AUTH-003 (middleware Supabase 클라이언트 신규 — DB-007 §3.6 위임) + INFRA-002 시점 검증. ★ 본 ISSUE B.1 `MiddlewareAuthResult` + `AuthErrorCode.SESSION_EXPIRED` 정의 완료.
 
-**AC-4 (경계):** OAuth Provider 장애 시 게스트 모드 전환
-- **Given** 카카오 OAuth Provider가 장애 상태이어서 로그인 실패
-- **When** `CurrentUser` 타입을 `{ type: 'guest', session: GuestSession }`으로 생성
-- **Then** `GuestSession.isGuest`가 `true`이며, `limitations`에 `['no_save', 'no_share', 'no_history']`가 포함되고, `guestId`가 비어있지 않은 문자열
+**AC-4 (경계, ⏸ CMD-AUTH-004 위임):** OAuth Provider 장애 시 게스트 모드 전환
+- **Given** 카카오 OAuth Provider 장애 → 로그인 실패
+- **When** `CurrentUser` 를 `{ type: 'guest', session: GuestSession }` 으로 생성
+- **Then** `GuestSession.isGuest === true`, `limitations: ['no_save', 'no_share', 'no_history']`, `guestId` 비어있지 않은 문자열
+- **Status:** ⏸ CMD-AUTH-004 (게스트 모드 활성 + Zustand `enterGuestMode` 통합) 시점 검증. ★ 본 ISSUE B.1 `GuestSession` + `GuestLimitation` 3 union + `CurrentUser` 3 분기 정의 완료.
 
-**AC-5 (정상):** AuthErrorCode 전수 매핑 검증
-- **Given** `AuthErrorCode` enum의 모든 값
-- **When** 각 값에 대해 `AUTH_ERROR_MAP[code]`를 조회
-- **Then** 모든 enum 값에 대해 매핑이 존재하며, `message`가 한국어 문자열이고 `httpStatus`가 100~599 범위
+**AC-5 (정상, ✅ Phase B 산출물 충족):** AuthErrorCode 전수 매핑 검증
+- **Given** `AuthErrorCode` enum 의 9 값 모두
+- **When** `AUTH_ERROR_MAP[code]` 조회
+- **Then** 9 값 모두 매핑 존재, `message` 한국어 문자열, `httpStatus` 100~599 범위
+- **Status:** ✅ Phase B.2 `AUTH_ERROR_MAP` 9 키 전수 매핑 작성 완료 — **TS 타입 레벨 `Record<AuthErrorCode, ...>` 강제로 누락 시 컴파일 에러** (tsc Phase B.4 exit 0 검증). TEST-008 spec 으로 런타임 재검증 예정.
 
 ---
 
@@ -340,54 +216,173 @@ assignees: []
 
 | NFR ID | SRS 본문 인용 | 본 태스크에서의 검증 방법 |
 |---|---|---|
-| REQ-NF-018 | "인증 세션 보안 — Supabase Auth httpOnly cookie 기반 세션. sameSite strict 적용. CSRF 보호는 Supabase Auth 내장 메커니즘 사용" (§4.2.3) | AuthSessionDTO가 cookie 관련 속성을 직접 노출하지 않고 Supabase 내장 메커니즘에 위임하는 구조인지 타입 설계 리뷰로 검증 |
-| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | AuthErrorDTO에 `originalError` 필드가 포함되어 Sentry에 원본 에러 정보를 전달 가능한지 확인. `createAuthError()` 함수가 Sentry.captureException 호출과 연계 가능한 구조인지 검증 |
+| REQ-NF-018 | "인증 세션 보안 — Supabase Auth httpOnly cookie 기반 세션. sameSite strict 적용. CSRF 보호는 Supabase Auth 내장 메커니즘" (§4.2.3) | ✅ B.1 `AuthSessionDTO` 가 cookie 속성 직접 노출하지 않음 (accessToken/refreshToken/expiresAt/user 4 필드만 — cookie 는 Supabase 내장 메커니즘 위임). ⏸ CMD-AUTH-003 (middleware cookie 옵션 검증) + TEST-008 (httpOnly cookie 통합 테스트) |
+| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | ✅ B.1 `AuthErrorDTO.originalError` 필드 정의 + B.3 `createAuthError()` 가 originalError 를 받아 Sentry catch 와 연계 가능한 구조. ⏸ CMD-AUTH-001/003 (실 Sentry.captureException 호출) + MON-001 (Sentry 통합) |
 
 ---
 
-## 6. 📦 Deliverables (산출물 명시)
+## 6. 📦 Deliverables (산출물 명시 — 신규/보존/위임/정정 4 구역)
 
-- `lib/types/auth.ts` (Auth DTO 전체: OAuthProvider, AuthSessionDTO, AuthUserDTO, AuthCallbackRequest/Result, AuthErrorCode/DTO, MiddlewareAuthResult, GuestSession, CurrentUser)
-- `lib/mappers/auth-mapper.ts` (mapSupabaseSessionToDTO, mapSupabaseUserToDTO)
-- `lib/constants/auth-errors.ts` (AUTH_ERROR_MAP — 에러코드→사용자메시지 매핑)
-- `lib/helpers/auth-error.ts` (createAuthError 헬퍼 함수)
-- `__tests__/types/auth-dto.spec.ts` (DTO 타입 검증 테스트)
-- `__tests__/mappers/auth-mapper.spec.ts` (변환 함수 테스트)
+### ✅ 신규 (4 — 3 코드 + 1 docs, Phase B + C)
+
+**Phase B 코드 (3 파일)**:
+- `onday-app/src/lib/types/auth.ts` (133 lines) — §3.2 7 섹션 + §3.3 SessionMapper, (P1) OAuthProvider=AuthProviderType 재사용
+- `onday-app/src/lib/constants/auth-errors.ts` (42 lines) — §3.5 AUTH_ERROR_MAP 9 키
+- `onday-app/src/lib/helpers/auth-error.ts` (20 lines) — §3.6 createAuthError
+
+**Phase C 명세 (1 파일)**:
+- `tasks/API-001.md` — 본 명세 현실 동기화
+
+### ✅ 보존 (DB-001~007 12 + types.ts + mock-auth M1~M4 + Auth 호출처 6행 + .env.example = 19+종, 본 ISSUE 절대 미수정)
+
+**DB-001~007 누적 가드 (12)**: `prisma/schema.prisma`, `prisma.config.ts`, `prisma/migrations/20260429125124_init/`, `prisma/seed.ts`, `src/lib/db.ts`, `src/lib/types/errors/.gitkeep`, **`src/lib/types/user.ts`** (DB-002 산출물 — 본 ISSUE B.1 (P1) AuthProviderType + UserDTO import 재사용 대상), `src/lib/types/diagnosis.ts` (DB-003 — DiagnosisMode owner 명시 주석 `:4`), `__tests__/db/.gitkeep`, `package.json`, design 루트, `06_TASK_LIST_v1.3.md`
+
+**Q2 추가 가드**: `src/lib/types.ts` (DiagnosisMode 9 호출처 + AuthProvider 1 호출처 보존)
+
+**mock-auth M1~M4 (가드 추가, DB-006 Q3 / DB-007 Auth 호출처 6행 패턴 답습)**: `lib/auth.ts` 5 함수 / `stores/session.ts` Zustand / `mocks/users.ts` MOCK_SESSION / `components/auth/login-form.tsx` handleOAuth — 본 ISSUE 미수정
+
+**DB-007 Auth 호출처 6행 (L1~L6)**: `login-form.tsx:15,29-43` / `session.ts:5,17` / `user.ts:1-2,7-14` / `types.ts:87` — 본 ISSUE 미수정 (L5 UserDTO 는 (P1) import 재사용 대상)
+
+**`.env.example` Supabase 3종**: `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY` (값만 비어 있음, INFRA-002 시점 채움)
+
+### ⏸ 위임 (4 + 정정 1 = 5)
+
+- §3.4 `lib/mappers/auth-mapper.ts` (`mapSupabaseSessionToDTO` + `mapSupabaseUserToDTO`) → **CMD-AUTH-001/003** (Q6)
+- §3.7 `__tests__/types/auth-dto.spec.ts` (5 케이스) → **TEST-008** (Q9)
+- §3.8 `__tests__/mappers/auth-mapper.spec.ts` (4 케이스) → **TEST-008** (Q9)
+- helper spec (`__tests__/helpers/auth-error.spec.ts` 3 케이스, 명세 §8 추가) → **TEST-008** (Q9)
+- (보너스) `types.ts:1-2` type alias 통합 정리 → **API-002 (DiagnosisMode) + MOCK-005 (AuthProvider+MockUser)** (Q2, L6 2차 정정)
+
+### 🔄 정정 이력 (1)
+
+- **DB-007 PR #80 L6 follow-up 2차 정정** → §9 표 참조 (1차/2차/3차 owner 정정 + grep 근거 명시)
 
 ---
 
 ## 7. 🔗 Dependencies (의존성 — 양방향)
 
-### 선행 (이 태스크 시작 전 필요):
+### 선행 (이 ISSUE 시작 전 필요)
 
-- **DB-007:** `lib/types/user.ts` (UserDTO 타입) — Auth DTO의 `CurrentUser.user` 필드가 UserDTO를 참조. `lib/supabase/server.ts`, `lib/supabase/middleware.ts` (Supabase 클라이언트 유틸리티) — Auth mapper가 Supabase 클라이언트의 Session 타입을 입력으로 사용
+- **DB-002** (PR #76 머지 완료, main `d916a6f`): `src/lib/types/user.ts` (`AuthProviderType` + `ServiceModeType` TS union + `UserDTO` interface, commit `2ea3a17`) — ★ B.1 (P1) `OAuthProvider = AuthProviderType` 재사용 + `CurrentUser.authenticated.user: UserDTO` 사용.
+- **DB-007** (PR #80 머지 완료, main `d1a6cba`): `tasks/DB-007.md` — Auth 호출처 6행 가드 + UserDTO=DB-002 추인 + Q3 "호출처 0건 → dead file" 패턴 + L6 1차 발견. ★ 본 ISSUE 가 L6 2차/3차 owner 정정 + DB-007 Q3 dead 회피 논리 답습.
+- **DB-003** (PR #77 머지 완료): `diagnosis.ts:4` 주석 — "API-002 가 DTO 정의 시 `import { ServiceModeType } from './user'` 패턴 사용" (DiagnosisMode owner 직접 명시 — L6 2차 정정 근거).
+- **DB-006** (PR #79) / **DB-004** (PR #78) / **DB-001** (PR #75): 간접 선행 (Phase 패턴 + dead 회피 논리 답습).
 
-### 후행 (이 태스크 완료 후 차례로 가능):
+### 후행 (이 ISSUE 완료 후 차례로 가능)
 
-- **CMD-AUTH-001:** Supabase Auth 카카오 OAuth Provider 설정 — API-001이 제공하는 `OAuthSignInOptions`, `AuthCallbackResult`, `AuthErrorDTO`를 사용하여 OAuth 콜백 구현
-- **CMD-AUTH-002:** 네이버 OAuth — 동일 DTO 사용
-- **CMD-AUTH-003:** 세션 전략 — `AuthSessionDTO`, `MiddlewareAuthResult` 사용
-- **CMD-AUTH-004:** 게스트 모드 — `GuestSession`, `CurrentUser` 사용
-- **MOCK-005:** OAuth Mock 데이터 — `AuthSessionDTO`, `AuthUserDTO` 구조에 맞춘 Mock 생성
-- **TEST-008:** OAuth 로그인 GWT 시나리오 — Auth DTO 기반 테스트 작성
+- **★ CMD-AUTH-001** (Supabase Auth 카카오 OAuth Provider 설정): §3.4 `auth-mapper.ts` 신규 + L3 `session.ts:setUser` hook 통합 + DB-007 §3.7 `user-sync.ts` UPSERT 통합 + M4 `login-form.tsx` mock 분기 제거
+- **★ CMD-AUTH-003** (Supabase Auth 세션 전략): DB-007 §3.5/3.6 `lib/supabase/server.ts` + `middleware.ts` 신규 + `MiddlewareAuthResult` 활성 + `SessionMapper` 구현
+- **CMD-AUTH-002** (네이버 OAuth): CMD-AUTH-001 패턴 답습
+- **CMD-AUTH-004** (게스트 모드): `GuestSession` + `CurrentUser` 활성 + Zustand `enterGuestMode` 통합 + `lib/auth.ts:getCurrentUser` 우회 정리
+- **★ MOCK-005** (OAuth Mock 데이터): L6 2차 정정 owner 1 — `MockUser` interface 정리 + AuthProvider 통합 + MOCK_SESSION ↔ AuthSessionDTO 정합
+- **★ API-002** (Diagnosis DTO): L6 2차 정정 owner 2 — DiagnosisMode 9 호출처 + 3 파일 → ServiceModeType 통합 (DB-003 `diagnosis.ts:4` 주석)
+- **TEST-008**: §3.7/3.8 + helper spec + Auth E2E 일괄
 
 ---
 
 ## 8. 🧪 Test Plan (검증 절차)
 
-- **단위 테스트:** `__tests__/types/auth-dto.spec.ts` — DTO 타입 유효성 5개 케이스 (OAuthProvider 범위, AuthSessionDTO 필수 필드, AuthErrorCode 전수 매핑, CurrentUser 분기, GuestLimitation 범위)
-- **단위 테스트:** `__tests__/mappers/auth-mapper.spec.ts` — 변환 함수 4개 케이스 (정상 변환, provider 누락, email null, avatar_url 누락)
-- **단위 테스트:** `__tests__/helpers/auth-error.spec.ts` — createAuthError 함수 3개 케이스 (정상 생성, originalError 포함, 모든 코드 매핑 존재)
-- **수동 검증:**
-  1. `tsc --noEmit`으로 모든 Auth DTO 타입이 @supabase/supabase-js 타입과 호환되는지 확인
-  2. IDE에서 `CurrentUser` discriminated union 타입의 자동완성이 올바르게 동작하는지 확인
-- **CI 게이트:** `tsc --noEmit` 통과, Jest 테스트 100% 통과, ESLint `no-unused-vars` 경고 0건
+### Phase A (본 ISSUE) — 사전 검증 (read-only) — ✅ 완료
+
+- ✅ A.1 main 동기화: `f99473c..d1a6cba` fast-forward (PR #80 머지본 흡수)
+- ✅ A.2 DB-001~007 산출물 main 반영 (`user.ts`/`diagnosis.ts`/`tasks/DB-001~007.md`)
+- ✅ A.3 Supabase 패키지 설치 (`@supabase/ssr ^0.10.3`, `@supabase/supabase-js ^2.105.4` — 명세 ^0.5.0/^2.45.0 보다 높음 호환)
+- ✅ A.4 Q2 가드 grep — `types.ts:1` AuthProvider 1 호출처 + `types.ts:2` DiagnosisMode 9 호출처 + 3 파일 (mock-calculator + diagnosis-store + types.ts 자체) — grill 결과 정확 일치
+- ✅ A.5 mock-auth M1~M4 grep — M1 `lib/auth.ts` 40 lines 5 함수 / M2 `stores/session.ts` Zustand / M3 `mocks/users.ts` MOCK_SESSION / M4 `login-form.tsx` handleOAuth
+- ✅ A.6 §3.4 mapper 호출처 0건 — `@supabase/ssr` / `createServerClient` / `@supabase/supabase-js` 사용처 = 0건 / `lib/mappers/` 빈 디렉토리 / `lib/services/` 빈 디렉토리
+- ✅ A.7 vitest config 부재 (vitest `^4.1.6` 의존성만)
+- ✅ A.8 `lib/constants/` + `lib/helpers/` + `lib/supabase/` + `lib/mappers/` + `lib/services/` 디렉토리 모두 존재 (빈 상태) — Phase B 신규 파일 작성 시 mkdir 불필요
+- ✅ A.8 `prisma validate` (`valid 🚀`) + `prisma generate` (7.8.0, 21ms) + `tsc --noEmit` exit 0
+- ✅ A.9 env-less `npm run build` exit 0 + **Middleware 32.5 kB** (INFRA-001 AC-4 anchor, **8번째 회귀 0**)
+- ✅ A.10 `feature/API-001` 브랜치 분기 + untracked 2건 외 변경 0
+
+### Phase B (본 ISSUE) — 활성, 3 파일 신규 — ✅ 완료
+
+- ✅ B.1 `lib/types/auth.ts` (133 lines, 7 섹션 + SessionMapper, (P1) OAuthProvider=AuthProviderType)
+- ✅ B.2 `lib/constants/auth-errors.ts` (42 lines, AUTH_ERROR_MAP 9 키)
+- ✅ B.3 `lib/helpers/auth-error.ts` (20 lines, createAuthError)
+- ✅ B.4 `tsc --noEmit` exit 0 (회귀 0) + `prisma validate` exit 0
+
+### 후행 ISSUE 검증 (위임)
+
+- **CMD-AUTH-001**: `__tests__/mappers/auth-mapper.spec.ts` — `mapSupabaseSessionToDTO` 4 케이스 (정상, provider 누락 → 기본값 kakao, email null → 빈 문자열, avatar_url 누락 → undefined)
+- **CMD-AUTH-003**: middleware Supabase 클라이언트 + httpOnly cookie 옵션 검증
+- **TEST-008**: `__tests__/types/auth-dto.spec.ts` 5 케이스 (OAuthProvider 범위 / AuthSessionDTO 필수 필드 / AuthErrorCode 전수 매핑 / CurrentUser 3 분기 / GuestLimitation 범위) + helper spec 3 케이스 + Auth E2E (카카오/네이버 로그인, Supabase 세션 생성·갱신·만료, 게스트 모드 전환)
+- **수동 검증** (CMD-AUTH-001/003 시점):
+  1. `tsc --noEmit` 으로 모든 Auth DTO 가 `@supabase/supabase-js` 타입과 호환되는지 재확인
+  2. IDE 에서 `CurrentUser` discriminated union 자동완성 정상 동작
+  3. Mock 모드 OFF + 실 카카오/네이버 OAuth → AuthSessionDTO 정상 매핑 확인
 
 ---
 
-## 9. 🚧 Open Questions / Risks (보류 사항)
+## 9. 🚧 Open Questions / Risks (보류 사항 — follow-up 7종 + ★ L6 2차 정정 이력 표)
 
-1. **@supabase/supabase-js v2 vs v3 타입 호환성:** 현재 v2 기준으로 `Session`, `User` 타입을 정의했으나, v3 마이그레이션 시 `app_metadata` 구조가 변경될 수 있다. — 패키지 버전을 `package.json`에 pin하여 관리.
-2. **카카오·네이버 OAuth Provider 이름:** Supabase 대시보드에 등록할 때 provider 이름이 정확히 `'kakao'` / `'naver'`인지, custom OIDC 등록 시 다른 이름이 될 수 있는지 — CMD-AUTH-001 작업 시 확인 필요.
-3. **게스트 모드 세션 저장소:** `GuestSession.guestId`를 어디에 저장할지 (localStorage vs sessionStorage vs cookie) — CMD-AUTH-004 작업 시 확정. DTO는 저장소 독립적으로 설계.
-4. **RefreshToken 노출 범위:** `AuthSessionDTO.refreshToken`을 클라이언트 컴포넌트에 노출해도 되는지 — Supabase Auth가 httpOnly cookie로 관리하므로, 서버 사이드에서만 접근하는 타입으로 명시적 분리가 필요할 수 있다.
+### ★ DB-007 PR #80 L6 follow-up 2차 정정 이력 (정직 기록)
+
+본 ISSUE Phase A 시점 grep 호출처 분석 결과, DB-007 PR #80 본문의 L6 강화 follow-up 기록이 부정확함을 발견. 이전 오류를 숨기지 않고 정정 경위·근거 명시:
+
+| 차수 | 시점 | 잘못된 기록 | 정정 |
+|---|---|---|---|
+| **1차** | DB-007 grill (2026-05-19) | `types.ts:87` "**UserDTO 중복** (user.ts:7-14 와 별도)" | `types.ts:84-89` 는 **`MockUser` interface** (4 필드: id+email+authProvider+mode) — `UserDTO` (6 필드: createdAt+updatedAt 추가) 와 **다른 entity**. "UserDTO 중복" 부정확. |
+| **2차** | API-001 grill (2026-05-19) | L6 = "UserDTO 중복 + mode 타입 충돌" | L6 진짜 문제 = **type alias DRY 위반**: `AuthProvider` (types.ts:1) ↔ `AuthProviderType` (user.ts:4) 동일 union 이름만 다름 + `DiagnosisMode` (types.ts:2) ↔ `ServiceModeType` (user.ts:5) 동일 union 이름만 다름 |
+| **3차** | API-001 grill (2026-05-19) | "API-001 정리 대상" | grep 호출처 분석 결과 (★ 근거): `AuthProvider` **1 호출처** (types.ts:87 MockUser 자기 자신만) + `DiagnosisMode` **9 호출처 + 3 파일** (mock-calculator.ts:5,85,193 / diagnosis-store.ts:2,15,30,48 / types.ts:55,66,88). 진짜 owner: **DiagnosisMode → ServiceModeType 통합 = API-002** (DB-003 commit `2ea3a17` `diagnosis.ts:4` 주석 직접 명시 — "API-002 가 DTO 정의 시 `import { ServiceModeType } from './user'` 패턴 사용") / **AuthProvider + MockUser 정리 = MOCK-005** (mock 도메인 책임) / **API-001 = (P1) OAuthProvider=AuthProviderType 재사용으로 3 중복 회피만 담당** |
+
+정정 근거: (i) grep 호출처 정량 분석, (ii) DB-003 commit `2ea3a17` `diagnosis.ts:4` 주석 직접 인용, (iii) MockUser entity 의 4 필드 vs UserDTO 6 필드 정량 비교, (iv) mock 도메인 (MockUser/MOCK_SESSION) ↔ production 도메인 (UserDTO/AuthSessionDTO) 분리 원칙.
+
+### 1. ★ §3.4 CMD-AUTH-001/003 — `auth-mapper.ts` 신규
+
+CMD-AUTH-001/003 시점에:
+- `lib/mappers/auth-mapper.ts` 신규: `mapSupabaseSessionToDTO(session: Session): AuthSessionDTO` + `mapSupabaseUserToDTO(user: SupabaseUser): AuthUserDTO`
+- DB-007 §3.7 `lib/services/user-sync.ts` 신규 (`syncUserFromAuth()`) 와 함께 OAuth callback 시퀀스 활성 (§6.3.6)
+- M1 mock-auth 5 함수 (lib/auth.ts) → mapper 통합 + IS_MOCK 분기 제거
+- M4 login-form.tsx handleOAuth → 실 Supabase Auth 활성 (mock 분기 제거)
+- L3 session.ts setUser hook 통합 (callback → syncUserFromAuth → mapper → setUser)
+- Sentry catch (REQ-NF-012 / REQ-NF-035 충족)
+- AC-1 검증 활성 (TEST-008 시점)
+
+### 2. ★ §3.7/3.8 + helper spec TEST-008 위임
+
+TEST-008 시점에:
+- `vitest.config.ts` 신규 (DB-001~007 §3.10 + 본 ISSUE §3.7/3.8 일괄 위임 누적 해소)
+- `__tests__/types/auth-dto.spec.ts` 5 케이스 (Q9)
+- `__tests__/mappers/auth-mapper.spec.ts` 4 케이스 (Q9)
+- `__tests__/helpers/auth-error.spec.ts` 3 케이스 (createAuthError 정상 생성 / originalError 포함 / 모든 코드 매핑 존재)
+- Auth E2E (카카오/네이버 로그인, Supabase 세션 생성·리프레시 토큰 자동 갱신·만료, 게스트 모드 전환)
+
+### 3. ★ L6 2차 정정 owner 1 — API-002 (DiagnosisMode → ServiceModeType 통합)
+
+API-002 시점에:
+- `types.ts:2` `DiagnosisMode` type alias 제거
+- 9 호출처 일괄 치환: `import { DiagnosisMode } from '@/lib/types'` → `import { ServiceModeType } from '@/lib/types/user'`
+- 영향 파일: `features/diagnosis/mock-calculator.ts` (3건) + `stores/diagnosis-store.ts` (4건) + `types.ts` 자체 (3건: DiagnosisInput.mode / DiagnosisResult.mode / MockUser.mode)
+- DB-003 commit `2ea3a17` `diagnosis.ts:4` 주석 트리거 해소
+
+### 4. ★ L6 2차 정정 owner 2 — MOCK-005 (AuthProvider + MockUser 정리)
+
+MOCK-005 시점에:
+- `types.ts:1` `AuthProvider` type alias 제거
+- `types.ts:87` `MockUser.authProvider` → `AuthProviderType` 으로 import 변경
+- `MockUser` interface (types.ts:84-89) 자체를 mock 도메인으로 보존 또는 (선택) `AuthUserDTO` 와 정합 정리
+- `MOCK_SESSION` ↔ `AuthSessionDTO` 정합 (mocks/users.ts:10-14)
+
+### 5. ★ SessionUser ↔ AuthUserDTO 통합 = CMD-AUTH-001/003
+
+CMD-AUTH-001/003 시점에:
+- `stores/session.ts:7` `SessionUser` (4 필드: id+nickname+provider+avatarUrl) ↔ B.1 `AuthUserDTO` (5 필드: id+email+provider+avatarUrl+lastSignInAt) **별 entity** 통합
+- 선택: SessionUser 를 AuthUserDTO 의 client-side 표시용 서브셋으로 명시 (`nickname = email.split('@')[0]` 인라인 변환 → 명시적 변환 함수)
+- M2 보존 + AuthUserDTO 통합 → Zustand store 타입 안전성 강화
+
+### 6. ★ `lib/auth.ts` 부분 dead 정리 = CMD-AUTH-004 또는 MOCK-005
+
+Phase A.6 grep 발견: `getCurrentUser` / `getMockSession` / `setMockSession` / `clearMockSession` / `isAuthenticated` 의 **호출처 0건** (전체 onday-app/src). 즉 `lib/auth.ts` mock-auth 5 함수 자체가 **부분적으로 dead** (login-form 이 `setUser` 직접 호출하며 `getCurrentUser` 우회). CMD-AUTH-004 (게스트 모드) 또는 MOCK-005 시점에 정리 필요 (제거 또는 활성 통합).
+
+### 7. RefreshToken 노출 범위 (명세 §9.4 보존)
+
+- `AuthSessionDTO.refreshToken` 을 클라이언트 컴포넌트에 노출 가능한지 — Supabase Auth 가 httpOnly cookie 로 관리하므로, 서버 사이드에서만 접근하는 타입으로 명시적 분리 필요할 수 있음.
+- CMD-AUTH-003 시점 결정 (httpOnly cookie 옵션 + sameSite strict 적용).
+
+### 추가 보조 (명세 §9 v1.0 보존)
+
+- @supabase/supabase-js v2 → v3 마이그레이션 시 `app_metadata` 구조 변경 가능성 — `package.json` pin 관리. 현재 `^2.105.4` (v2 series).
+- 카카오·네이버 OAuth Provider 이름 (`'kakao'` / `'naver'` vs custom OIDC 다른 이름) — CMD-AUTH-001 시점 Supabase 대시보드 설정 후 확정.
+- `GuestSession.guestId` 저장소 (localStorage vs sessionStorage vs cookie) — CMD-AUTH-004 시점 확정. DTO 는 저장소 독립적으로 설계 (B.1 `guestId: string` 만 정의).


### PR DESCRIPTION
Refs #11

## 산출물 요약

★ **Wave 2 첫 ISSUE — API Contract 트랙 진입** (DB-001~007 docs only 패턴에서 분기)

- **신규 3 코드 파일** (커밋 1 feat, +196 lines)
- **명세 1 파일 갱신** (커밋 2 docs, +319 -324 lines)
- **★ 커밋 2개 분리** (feat → docs, 코드↔문서 절대 안 섞음)

## 작성 산출물 (Phase B 활성)

| # | 파일 | 라인 | 명세 §3 |
|---|---|---|---|
| B.1 | `onday-app/src/lib/types/auth.ts` | 133 | §3.2 7 섹션 + §3.3 SessionMapper. **(P1) `OAuthProvider = AuthProviderType` 재사용** |
| B.2 | `onday-app/src/lib/constants/auth-errors.ts` | 42 | §3.5 AUTH_ERROR_MAP 9 키 |
| B.3 | `onday-app/src/lib/helpers/auth-error.ts` | 20 | §3.6 createAuthError |
| C | `tasks/API-001.md` | 388 | 명세 현실 동기화 |

## ★ (P1) OAuthProvider = AuthProviderType 재사용

```typescript
// onday-app/src/lib/types/auth.ts:1-11
import type { Session } from '@supabase/supabase-js';
import type { UserDTO, AuthProviderType } from './user';

export type OAuthProvider = AuthProviderType;  // 신규 type alias 정의 금지 — 3 중복 회피
```

DB-007 §3.8 UserDTO 추인 패턴 일관 — "이미 정의된 type 재사용, 신규 0".

## ★ Q1~Q10 결정 vs 명세 v1.0 mismatch 추적 표

| Q | 영역 | 명세 v1.0 | 현실 | 결정 |
|---|---|---|---|---|
| **Q1** ★ | 작업 모드 (DB-007 docs only 전환점) | §3.1~3.8 8 산출물 신규 | DB-007 산출물 활용 + mapper 호출처 0건 | **(B) 절충 — Phase B 활성 + 커밋 2개** |
| **Q2** ★ | L6 + OAuthProvider | OAuthProvider 신규 | types.ts:1 AuthProvider 1 호출처 + types.ts:2 DiagnosisMode 9 호출처 + 3 파일 | **(A) types.ts 무수정 + (P1) AuthProviderType 재사용** |
| Q3 | §3.1 패키지 | ^0.5.0/^2.45.0 | ^0.10.3/^2.105.4 이미 설치 | Phase A 확인만 |
| Q4 | §3.2 7 섹션 | 신규 | 부재 | **✅ Phase B.1** + (P1) 재사용 |
| Q5 | §3.3 SessionMapper | 신규 | 부재 | **✅ Phase B.1** |
| **Q6** ★ | §3.4 mapper | 신규 | `@supabase/ssr` 호출처 0건 + M1 mock-auth 우회 | **⏸ CMD-AUTH-001/003** (dead file 회피, DB-004/006/007 Q3 일관) |
| Q7 | §3.5 AUTH_ERROR_MAP | 신규 | 부재 | **✅ Phase B.2** (9 키) |
| Q8 | §3.6 createAuthError | 신규 | 부재 | **✅ Phase B.3** |
| Q9 | §3.7/3.8 spec | 신규 | vitest config 부재 | **⏸ TEST-008** (DB-001~007 일관) |
| Q10 | SessionUser ↔ AuthUserDTO | — | 별 entity (4 필드 vs 5 필드) | 본 ISSUE 미수정, §9 follow-up |

## ★ mock-auth M1~M4 (가드 — 본 ISSUE 미수정, DB-006 Q3 / DB-007 Auth 6행 패턴)

| # | 위치 | 후행 |
|---|---|---|
| M1 | `lib/auth.ts:1-40` (5 함수 + IS_MOCK 분기) | CMD-AUTH-001/003 |
| M2 | `stores/session.ts` (Zustand `useSessionStore` + `SessionUser` 4 필드) | CMD-AUTH-001/003/004 |
| M3 | `mocks/users.ts:1-14` (`MOCK_USER` + `MOCK_SESSION`) | MOCK-005 |
| M4 | `login-form.tsx:8, 29-43` (`handleOAuth` mock 분기) | CMD-AUTH-001 |

## ★ 부재 산출물 (호출처 0건 = dead file 회피 → 위임)

| 명세 §3 | 사유 | 위임 |
|---|---|---|
| §3.4 `lib/mappers/auth-mapper.ts` | `@supabase/ssr` 사용처 0건 + M1 mock-auth 우회 | **CMD-AUTH-001/003** |
| §3.7 type spec / §3.8 mapper spec / helper spec | vitest config 부재 (DB-001~007 §3.10 일관) | **TEST-008** |

## ★ DB-007 PR #80 L6 follow-up 2차 정정 이력 (정직 기록)

| 차수 | 잘못된 기록 | 정정 |
|---|---|---|
| **1차** (DB-007 grill) | `types.ts:87` "UserDTO 중복" | `types.ts:84-89` = **`MockUser` interface** (4 필드, UserDTO 6 필드와 다른 entity) |
| **2차** (API-001 grill) | L6 = "UserDTO 중복 + mode 충돌" | L6 진짜 = **type alias DRY 위반** (AuthProvider/AuthProviderType + DiagnosisMode/ServiceModeType) |
| **3차** (API-001 grill) | "API-001 정리 대상" | grep 근거: AuthProvider **1 호출처** + DiagnosisMode **9 호출처 + 3 파일**. owner: **API-002** (DiagnosisMode, DB-003 commit `2ea3a17` 주석 직접 명시) + **MOCK-005** (AuthProvider+MockUser) + **API-001 = (P1) 3 중복 회피만** |

근거: grep 정량 분석 + DB-003 주석 인용 + 필드 정량 비교 + 도메인 분리 원칙.

## ★ §3.2 import 축소 정직 기록

| 명세 §3.2 원본 | 본 ISSUE 실제 | 사유 |
|---|---|---|
| `import type { Session, User as SupabaseUser, AuthError } from '@supabase/supabase-js';` | `import type { Session } from '@supabase/supabase-js';` | SupabaseUser/AuthError = §3.4 mapper 본문 사용 → mapper 위임이라 미사용. **ESLint `no-unused-vars` 회피** |
| `import type { UserDTO } from './user';` | `import type { UserDTO, AuthProviderType } from './user';` | **(P1) AuthProviderType 추가** (3 중복 회피) |

## ★ §9 follow-up 7종

1. ★ **§3.4 CMD-AUTH-001/003** — auth-mapper.ts + Sentry catch + L3 hook + M1/M4 통합
2. ★ **§3.7/3.8 + helper spec TEST-008** — vitest config + 5+4+3 케이스 + Auth E2E
3. ★ **L6 owner 1 — API-002** (DiagnosisMode 9 호출처 일괄, DB-003 commit `2ea3a17` 주석 트리거 해소)
4. ★ **L6 owner 2 — MOCK-005** (AuthProvider type alias 제거 + MockUser 정리 + MOCK_SESSION ↔ AuthSessionDTO)
5. ★ **SessionUser ↔ AuthUserDTO 통합 — CMD-AUTH-001/003** (별 entity, 4 vs 5 필드)
6. ★ **`lib/auth.ts` 부분 dead 정리 — CMD-AUTH-004 / MOCK-005** (Phase A 신규 발견: getCurrentUser 호출처 0건)
7. **RefreshToken 노출 범위** (명세 §9.4 보존, CMD-AUTH-003)

## D 검증 결과 표

| 항목 | 결과 |
|---|---|
| D.1 `npx prisma validate` | ✅ exit 0 (`valid 🚀`) |
| D.2 `npx prisma generate` | ✅ exit 0 (Prisma Client 7.8.0, 22ms) |
| D.3 `npx tsc --noEmit` | ✅ exit 0 (Phase B 기준선 유지, 회귀 0) |
| D.4 env-less `npm run build` | ✅ exit 0 + **Middleware 32.5 kB** (INFRA-001 AC-4, **8번째 회귀 0**) |
| D.5 grep password (User 모델) | ✅ 0건 (ShareLink L48 passwordHash 만, DB-002/004 AC-6 일관) |
| D.6 격리 (4 파일) | ✅ 신규 3 + 명세 1 = 정확히 4 파일 |
| D.7 가드 무수정 (DB-001~007 12 + types.ts + user.ts + diagnosis.ts + mock-auth M1~M4 + .env.example + package.json) | ✅ 0 lines |
| D.8 ★ 커밋 2개 분리 | ✅ feat (`5cfd63c`, 3 파일 +196) + docs (`b602e11`, 1 파일 +319 -324) — 코드↔문서 절대 안 섞음 |
| untracked 가드 | ✅ `.agents/skills`, `tasks/ISSUE_REGISTER_LOG.md` staging 안 함 |

## AC 충족 상태

| AC | 상태 |
|---|---|
| AC-1 정상 mapper | ⏸ CMD-AUTH-001 + INFRA-002 위임 (B.1 type 시그니처 토대 활성) |
| **AC-2 OAUTH_CODE_MISSING** | ✅ **Phase B 산출물 lookup 동작 충족** (B.1 enum + B.2 매핑 + B.3 createAuthError) |
| AC-3 SESSION_EXPIRED | ⏸ CMD-AUTH-003 + INFRA-002 위임 (B.1 MiddlewareAuthResult 정의 완료) |
| AC-4 게스트 모드 | ⏸ CMD-AUTH-004 위임 (B.1 GuestSession + CurrentUser 정의 완료) |
| **AC-5 AUTH_ERROR_MAP 전수 매핑** | ✅ **TS 타입 레벨 강제 충족** (B.2 Record<AuthErrorCode, ...> + tsc exit 0) |

## 가드 (DB-001~007 누적 + Q2 types.ts + Auth 호출처 6행 + mock-auth M1~M4 + .env.example 본 ISSUE 미수정)

- 불변: schema.prisma, prisma.config.ts, init migration, seed.ts, db.ts, errors/.gitkeep, **user.ts** ((P1) import 재사용 대상), diagnosis.ts, types.ts (Q2), **lib/auth.ts / stores/session.ts / mocks/users.ts / login-form.tsx (mock-auth M1~M4)**, .env.example, package.json, design 루트, 06_TASK_LIST
- Auth 호출처 6행 (DB-007 가드): login-form.tsx:15,29-43 / session.ts:5,17 / user.ts:1-2,7-14 / types.ts:87 — 본 ISSUE 미수정

## 산출물 파일

- [tasks/API-001.md](../blob/feature/API-001/tasks/API-001.md) (388 lines)
- [onday-app/src/lib/types/auth.ts](../blob/feature/API-001/onday-app/src/lib/types/auth.ts) (133 lines)
- [onday-app/src/lib/constants/auth-errors.ts](../blob/feature/API-001/onday-app/src/lib/constants/auth-errors.ts) (42 lines)
- [onday-app/src/lib/helpers/auth-error.ts](../blob/feature/API-001/onday-app/src/lib/helpers/auth-error.ts) (20 lines)

## 머지 정책

- Draft PR — 머지·Issue #11 닫기는 **사용자 직접 결정**
- "Refs #11" 사용 (Closes 아님 — 자동 닫힘 방지)
- 자동 머지 절대 금지

🤖 Generated with [Claude Code](https://claude.com/claude-code)