### PR TITLE
[Feature] API-002: Diagnosis DTO 명세 현실 동기화 + 3 파일 신규 (Q2 9칸 가드 사수 첫 성공 + L6 3차 cleanup 트리거)

### DIFF
--- a/onday-app/src/lib/constants/diagnosis-errors.ts
+++ b/onday-app/src/lib/constants/diagnosis-errors.ts
@@ -1,0 +1,37 @@
+import { DiagnosisErrorCode, type DiagnosisErrorDTO } from '@/lib/types/diagnosis';
+
+/** DiagnosisErrorCode → 사용자 메시지·HTTP 상태 매핑 (8 키 — code/originalError 는 createDiagnosisError 가 채움) */
+export const DIAG_ERROR_MAP: Record<DiagnosisErrorCode, Omit<DiagnosisErrorDTO, 'code' | 'originalError'>> = {
+  [DiagnosisErrorCode.ADDRESS_MISSING]: {
+    message: '출발지 주소를 입력해 주세요.',
+    httpStatus: 400,
+  },
+  [DiagnosisErrorCode.ADDRESS_OUT_OF_COVERAGE]: {
+    message: '현재는 수도권(서울·경기·인천) 만 서비스하고 있어요. 다른 동네 추가는 곧 열려요.',
+    httpStatus: 400,
+  },
+  [DiagnosisErrorCode.DEADLINE_DATE_PAST]: {
+    message: '데드라인 날짜는 오늘 이후로 설정해 주세요.',
+    httpStatus: 400,
+  },
+  [DiagnosisErrorCode.NO_CANDIDATES_FOUND]: {
+    message: '조건에 맞는 동네를 찾지 못했어요. 통근 시간이나 예산을 조정해 보세요.',
+    httpStatus: 404,
+  },
+  [DiagnosisErrorCode.TRANSPORT_API_TIMEOUT]: {
+    message: '교통 정보를 불러오는 데 시간이 너무 걸렸어요. 잠시 후 다시 시도해 주세요.',
+    httpStatus: 504,
+  },
+  [DiagnosisErrorCode.TRANSPORT_API_RETRY_FAILED]: {
+    message: '교통 정보 조회에 반복 실패했어요. 잠시 후 다시 시도해 주세요.',
+    httpStatus: 502,
+  },
+  [DiagnosisErrorCode.DIAGNOSIS_NOT_FOUND]: {
+    message: '진단 결과를 찾을 수 없어요. 링크가 만료됐을 수 있어요.',
+    httpStatus: 404,
+  },
+  [DiagnosisErrorCode.DIAGNOSIS_FORBIDDEN]: {
+    message: '이 진단 결과를 볼 권한이 없어요.',
+    httpStatus: 403,
+  },
+};

--- a/onday-app/src/lib/helpers/diagnosis-error.ts
+++ b/onday-app/src/lib/helpers/diagnosis-error.ts
@@ -1,0 +1,20 @@
+import { DiagnosisErrorCode, type DiagnosisErrorDTO } from '@/lib/types/diagnosis';
+import { DIAG_ERROR_MAP } from '@/lib/constants/diagnosis-errors';
+
+/**
+ * DiagnosisErrorDTO 생성 헬퍼.
+ * DIAG_ERROR_MAP 에서 사용자 메시지·HTTP 상태를 lookup 한 뒤 originalError 를 합쳐 반환.
+ * Sentry catch 와 연계 가능 (REQ-NF-035) — originalError 필드로 원본 에러 메시지 전달.
+ */
+export function createDiagnosisError(
+  code: DiagnosisErrorCode,
+  originalError?: string,
+): DiagnosisErrorDTO {
+  const mapped = DIAG_ERROR_MAP[code];
+  return {
+    code,
+    message: mapped.message,
+    httpStatus: mapped.httpStatus,
+    originalError,
+  };
+}

--- a/onday-app/src/lib/types/diagnosis.ts
+++ b/onday-app/src/lib/types/diagnosis.ts
@@ -4,3 +4,118 @@
 // mode 는 user.ts 의 ServiceModeType 재사용 — diagnosis.ts 에서 재정의 금지. API-002 가 DTO 정의 시 `import { ServiceModeType } from './user'` 패턴 사용.
 
 export type DiagnosisStatusType = 'processing' | 'completed' | 'expired';
+
+// ──────────────────────────────────────────────
+// API-002 append (Q2 (b) types.ts 9칸 가드 보존 — DiagnosisMode 11/DiagnosisStatus 1 호출처 미수정,
+//   Q3 (D) re-export 패턴 — 신규 type alias 정의 금지, Q5 §3.2 ErrorCode 8 종)
+// ──────────────────────────────────────────────
+
+import type { ServiceModeType } from './user';
+import type {
+  CandidateArea,
+  CommuteInfo,
+  DiagnosisFilters,
+  DiagnosisInput,
+} from '../types';
+
+// ──────────────────────────────────────────────
+// 1. (P1) re-export — 신규 type alias 정의 금지, 현실 entity 재사용
+//    API-001 OAuthProvider=AuthProviderType 패턴 답습 (3 중복 회피)
+// ──────────────────────────────────────────────
+
+/** 후보 동네 — Step 10.5 풍부 필드 (lines/listingsCount/avgArea) 까지 노출 */
+export type CandidateAreaDTO = CandidateArea;
+
+/** 통근 정보 — 시간·수단·환승 */
+export type CommuteInfoDTO = CommuteInfo;
+
+/** 진단 생성 요청 — Figma 비전 leisure 4 필드 superset 노출 */
+export type CreateDiagnosisRequest = DiagnosisInput;
+
+// ──────────────────────────────────────────────
+// 2. Diagnosis DTO 본체
+// ──────────────────────────────────────────────
+
+/**
+ * 진단 결과 DTO.
+ * mode: Q2 (b) — types.ts DiagnosisMode 가 아니라 user.ts ServiceModeType 사용 (11 호출처 일괄 치환은 cleanup ISSUE 위임).
+ * status: DB-003 commit `2ea3a17` 산출물 DiagnosisStatusType 첫 활성 사용처.
+ */
+export interface DiagnosisDTO {
+  id: string;
+  userId: string;
+  addressA: string;
+  addressB?: string;
+  filters: DiagnosisFilters;
+  mode: ServiceModeType;
+  deadlineMode: boolean;
+  deadline?: string;
+  status: DiagnosisStatusType;
+  createdAt: string;
+}
+
+// ──────────────────────────────────────────────
+// 3. Request / Response DTO (부재 신규)
+// ──────────────────────────────────────────────
+
+/** POST /api/diagnosis 응답 */
+export interface CreateDiagnosisResponse {
+  diagnosisId: string;
+  candidates: CandidateAreaDTO[];
+  timeline: TimelineDTO | null;
+  status: DiagnosisStatusType;
+}
+
+/** GET /api/diagnosis/[id] 응답 */
+export interface GetDiagnosisResponse {
+  diagnosis: DiagnosisDTO;
+  candidates: CandidateAreaDTO[];
+}
+
+// ──────────────────────────────────────────────
+// 4. Timeline DTO (Deadline mode — 부재 신규)
+// ──────────────────────────────────────────────
+
+export interface TimelineDTO {
+  steps: TimelineStepDTO[];
+  deadlineDate: string;
+}
+
+export interface TimelineStepDTO {
+  order: number;
+  title: string;
+  description: string;
+  dueDate: string;
+  completed: boolean;
+}
+
+// ──────────────────────────────────────────────
+// 5. Diagnosis Error DTO (§3.2 — 8 종, API-001 AuthErrorCode 패턴 답습)
+// ──────────────────────────────────────────────
+
+/** 진단 도메인 에러 코드 (8 종) */
+export enum DiagnosisErrorCode {
+  // 입력 검증
+  ADDRESS_MISSING = 'DIAG_ADDRESS_MISSING',
+  ADDRESS_OUT_OF_COVERAGE = 'DIAG_ADDRESS_OUT_OF_COVERAGE',
+  DEADLINE_DATE_PAST = 'DIAG_DEADLINE_DATE_PAST',
+
+  // 결과 처리
+  NO_CANDIDATES_FOUND = 'DIAG_NO_CANDIDATES_FOUND',
+
+  // 외부 API
+  TRANSPORT_API_TIMEOUT = 'DIAG_TRANSPORT_API_TIMEOUT',
+  TRANSPORT_API_RETRY_FAILED = 'DIAG_TRANSPORT_API_RETRY_FAILED',
+
+  // 조회·권한
+  DIAGNOSIS_NOT_FOUND = 'DIAG_NOT_FOUND',
+  DIAGNOSIS_FORBIDDEN = 'DIAG_FORBIDDEN',
+}
+
+/** 진단 도메인 에러 응답 DTO */
+export interface DiagnosisErrorDTO {
+  code: DiagnosisErrorCode;
+  message: string;
+  httpStatus: number;
+  originalError?: string;
+}

--- a/tasks/API-002.md
+++ b/tasks/API-002.md
@@ -1,20 +1,35 @@
 ---
 name: Feature Task
-title: "[Feature] API-002: Diagnosis 도메인 Request/Response DTO"
+title: "[Feature] API-002: Diagnosis 도메인 DTO 명세 현실 동기화 + 3 파일 신규 (API Contract 트랙 두 번째, API-001 (B) 절충 패턴 답습 + ★ Q2 9칸 가드 보존 첫 성공 사례 — types.ts 미수정 + cleanup ISSUE 신설 트리거 + Q3 (D) re-export 3 + DB-003 commit `2ea3a17` 주석 트리거 완전 해소 + DiagnosisStatusType 첫 활성 + L6 단계적 해소 체인 3차)"
 labels: ['feature', 'priority:M', 'epic:API Contract', 'wave:2']
 assignees: []
 ---
 
 ## 1. 🎯 Summary
 
-- **기능명:** [API-002] Diagnosis 도메인 Request/Response DTO 정의 — createDiagnosis(), GET /api/diagnosis/[id]
+- **기능명:** [API-002] Diagnosis 도메인 Request/Response DTO 정의 — createDiagnosis() / GET /api/diagnosis/[id] 의 통신 계약 + DiagnosisErrorCode (8 종) + DIAG_ERROR_MAP + createDiagnosisError helper. ★ **API Contract 트랙 두 번째 진입** (Wave 2 — API-001 PR #81 직후). 본 ISSUE 산출물 = **신규 1 + 수정 1 + 신규 1 (코드) + 명세 1 파일 갱신** + **커밋 2개 (feat + docs 분리, API-001 패턴 답습)**. Zod (§3.3) + mapper (§3.5) + spec (§3.6/3.7/3.8) 는 호출처 인라인 동작 중 / 0건 dead file 회피 원칙 (DB-004 Q3 / DB-006 Q3 / DB-007 Q3 / API-001 Q6/Q9 일관) 으로 위임. **(P1) `CandidateAreaDTO = CandidateArea` / `CommuteInfoDTO = CommuteInfo` / `CreateDiagnosisRequest = DiagnosisInput` 3 re-export** (API-001 OAuthProvider=AuthProviderType 패턴 답습 — 신규 type alias 정의 금지, 현실 entity superset 노출). ★ **Q2 (b) 9칸 가드 보존 첫 성공 사례** — `types.ts:1-3` (`AuthProvider` + `DiagnosisMode` + `DiagnosisStatus`) 무수정 + 11 호출처 (DiagnosisMode) + 1 호출처 (DiagnosisStatus) 본 ISSUE 미치환 + cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계) 신설 트리거 §9 명시. ★ **DB-003 commit `2ea3a17` `diagnosis.ts:3-4` 주석 트리거 완전 해소** — Q3 (D) 채택으로 `import { ServiceModeType } from './user'` + `DiagnosisStatusType` 첫 활성. ★ **L6 단계적 해소 체인 3차** (DB-007 1차 → API-001 2차 → API-002 3차).
 - **목적 (Why):**
-  - **비즈니스:** 두 동선 교차 진단의 API 통신 계약을 확립하여, 프론트엔드·백엔드·테스트 코드가 동일한 타입으로 개발된다.
-  - **사용자 가치:** 진단 입력·결과 응답의 타입 안전성이 보장되어 런타임 에러 없이 안정적인 진단 경험을 제공한다.
+  - **비즈니스:** 두 동선 교차 진단의 API 통신 계약 (Request/Response DTO + 에러 매핑 + helper) 을 단일 진실 공급원 (SSoT) 으로 확립하여, 후속 진단 Command·Query 태스크 (CMD-DIAG-001~007 + QRY-DIAG-001 + MOCK-001 + TEST-001) 가 일관된 타입으로 import 한다. ★ API Contract 트랙 = **DTO 정의 자체가 본 ISSUE 의 owner** (06_TASK_LIST §1-B 명시 — "후행 Feature 태스크가 import 할 SSoT 를 먼저 확립") → docs only 시 빈 contract 로 Wave 2 진입 의미 상실. ★ 단 Zod (`createDiagnosisSchema`) + mapper (`mapDiagnosisToDTO`) 는 현재 인라인 동작 중 (`validators/diagnosis.ts:8-30` `diagnosisInputSchema` 23 lines + `app/api/diagnosis/route.ts:12` safeParse 호출처 활성 / `app/api/diagnosis/[id]/route.ts:19-34` JSON.parse + NextResponse 인라인 mapper) → 본 ISSUE 가 추출 시 동작 중 인라인 가드 위반 (DB-006 Q3 인라인 동작 중 패턴 답습). spec 도 vitest config 부재 (DB-001~007 + API-001 일관) → TEST-001 위임. ★ (P1) `CandidateAreaDTO` / `CommuteInfoDTO` / `CreateDiagnosisRequest` 는 신규 type alias 정의 금지 — `import type { CandidateArea, CommuteInfo, DiagnosisInput } from '../types'` 재사용으로 명세 v1.0 의 단순 모델 vs 현실 Step 10.5 풍부 entity (15 필드, leisure superset) 불일치 회피. ★ Q2 (b) — `types.ts:1-3` 가드 보존이 9칸 통틀어 가장 위험한 판단 (cleanup ISSUE 신설 트리거 채택으로 가드 사수 + DB-003 주석 의도 충족).
+  - **사용자 가치:** 진단 입력·결과 응답의 타입 안전성이 보장되어 런타임 에러 없이 안정적인 진단 경험을 제공한다 — Mock 환경에서는 `validators/diagnosis.ts` Zod + `mock-calculator.ts` Haversine + `api/diagnosis/[id]/route.ts` 인라인 mapper 가 정상 동작 중, 실 환경에서는 CMD-DIAG-001~007 + QRY-DIAG-001 시점 활성.
 - **범위 (What):**
-  - ✅ 만드는 것: createDiagnosis Request/Response DTO, GET /api/diagnosis/[id] Response DTO, CandidateArea 타입, DiagnosisFilter 타입, Zod 유효성 스키마
-  - ❌ 만들지 않는 것: 진단 로직 구현(CMD-DIAG 범위), 결제 관련 타입, 시나리오 비교 타입(제거됨)
-- **복잡도:** M
+  - ✅ 만드는 것 (수정 1 + 신규 2 코드 파일 + 명세 1 파일):
+    - **`onday-app/src/lib/types/diagnosis.ts`** (DB-003 산출물 확장 — L1-7 보존 + L8~ append, 총 121 lines) — §3.1 (P1) re-export 3 + 부재 4 신규 (CreateDiagnosisResponse / GetDiagnosisResponse / TimelineDTO / TimelineStepDTO) + DiagnosisDTO 신규 (mode: ServiceModeType, status: DiagnosisStatusType — DB-003 산출물 첫 활성) + §3.2 DiagnosisErrorCode enum 8 종 + DiagnosisErrorDTO interface.
+    - **`onday-app/src/lib/constants/diagnosis-errors.ts`** — §3.4 `DIAG_ERROR_MAP` (8 키 × {message, httpStatus}).
+    - **`onday-app/src/lib/helpers/diagnosis-error.ts`** — `createDiagnosisError(code, originalError?)` helper (API-001 §3.6 createAuthError 패턴 일관).
+    - **`tasks/API-002.md`** — 본 명세 현실 동기화 (Q1~Q10 + L6 3차 정정 이력 + cleanup ISSUE 신설 트리거 + mismatch 추적표 + N1~N6 인라인 호출처 표 + 부재 산출물 표 + §9 follow-up 8종).
+  - ❌ 만들지 않는 것 (인라인 동작 중 dead 회피 + Q2 가드 + 호출처 0건 회피):
+    - `lib/validators/diagnosis.ts` 수정 (§3.3 `createDiagnosisSchema` 명세 vs 현실 `diagnosisInputSchema`) — **CMD-DIAG-001~007 위임** (N1 인라인 동작 중 + Route Handler L12 safeParse 호출처 활성, DB-006 Q3 인라인 보존 패턴 답습)
+    - `lib/mappers/diagnosis-mapper.ts` (§3.5 `mapDiagnosisToDTO`) — **QRY-DIAG-001 위임** (N3 `[id]/route.ts:19-34` 인라인 동작 중 — JSON.parse + NextResponse mapper, DB-006 Q3 / API-001 Q6 일관)
+    - `__tests__/types/diagnosis-dto.spec.ts` + `__tests__/validators/diagnosis.spec.ts` + `__tests__/mappers/diagnosis-mapper.spec.ts` — **TEST-001 위임** (vitest config 부재, DB-001~007 + API-001 §3.7/3.8 일관)
+    - `types.ts:1-3` `AuthProvider`/`DiagnosisMode`/`DiagnosisStatus` 통합 정리 — **Q2 가드 (b). owner = 별도 cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계) 신설 트리거 §9.4** (11 호출처 DiagnosisMode + 1 호출처 DiagnosisStatus + MockUser.mode 동시 — 분리 불가)
+    - `DiagnosisMode` 11 호출처 일괄 치환 (mock-calculator 3 + diagnosis-store 4 + types.ts 4) — Q2 cleanup ISSUE 위임
+    - `DiagnosisStatus` 1 호출처 일괄 치환 (types.ts:69 DiagnosisResult.status) — Q2 cleanup ISSUE 위임
+    - N1~N6 인라인 호출처 (`validators/diagnosis.ts` / `api/diagnosis/route.ts` POST / `api/diagnosis/[id]/route.ts` GET / `mock-calculator.ts` / `diagnosis-store.ts` / `detail-mapper.ts`) — 본 ISSUE 미수정 (후행 CMD-DIAG / QRY-DIAG-001 / cleanup ISSUE 통합 대상)
+    - mock-auth M1~M4 (API-001 산출물 가드 — `lib/auth.ts` 5 함수 + Zustand `useSessionStore` + `MOCK_SESSION` + `login-form.tsx` `handleOAuth`) — 본 ISSUE 무관여
+    - API-001 산출물 (`lib/types/auth.ts` + `lib/constants/auth-errors.ts` + `lib/helpers/auth-error.ts`) — 본 ISSUE 미수정
+    - `CandidateAreaDTO` / `CommuteInfoDTO` / `CreateDiagnosisRequest` 신규 type 정의 — **(P1) re-export 만 사용** (현실 entity superset 노출, 명세 v1.0 단순 모델 폐기)
+    - `DiagnosisMode` / `ServiceModeType` / `DiagnosisStatusType` 재정의·중복 정의 — **절대 금지** (3 중복 원인 차단, DB-007 §3.8 UserDTO 추인 + API-001 (P1) OAuthProvider=AuthProviderType 패턴 일관)
+- **복잡도:** M (명세 v1.0 동일)
 - **Wave:** 2 (API Contract 트랙)
 
 ---
@@ -28,12 +43,18 @@ assignees: []
 - **REQ-FUNC-004** (§4.1.1): "시스템은 각 후보 동네를 탭했을 때 양쪽 직장까지의 예상 출퇴근 시간(대중교통·자차)을 표시해야 한다. 카카오맵 API 대비 시간 오차는 ±10% 이내여야 한다."
 - **REQ-FUNC-006** (§4.1.1): "시스템은 조건 필터(최대 통근 시간, 예산)를 적용했을 때 조건에 맞지 않는 후보를 실시간 필터링하고 지도를 갱신해야 한다."
 - **REQ-NF-001** (§4.2.1): "두 동선 교차 계산 응답 시간 — p95 ≤ 8,000ms (클라이언트 API 콜 기준)"
+- **REQ-NF-035** (§4.2.6): "에러 로그 알림 — Sentry 기본 알림 설정 사용"
+
+### `prototypes/design/CLAUDE.md` §3 (1인 MVP 제약) 인용
+
+- "Vercel Serverless Timeout = 10초 (REQ-FUNC-003)" → 본 ISSUE 비대상 (API Contract 트랙, DTO only). 실 외부 API 반복 호출 = CMD-DIAG-001~007 영역.
+- "Out of Scope ... 자동 코드 생성 금지" → §3.3 Zod 인라인 동작 중 + §3.5 mapper 인라인 동작 중 = 미리 추출 시 dead 또는 중복 (DB-006 Q3 / API-001 Q6 일관)
 
 ### API 엔드포인트 (§6.1)
 
 | # | Method | Endpoint / Action | 요청 Body (주요 필드) | 응답 Body (주요 필드) | 응답 시간 목표 |
 |---|---|---|---|---|---|
-| API-01 | POST | `createDiagnosis()` | `address_a`, `address_b`, `filters`, `mode`, `deadline_date` | `diagnosis_id`, `candidates[]`, `timeline` | p95 ≤ 3,000ms |
+| API-01 | POST | `/api/diagnosis` (createDiagnosis) | `addressA`, `addressB?`, `coordinateA`, `coordinateB?`, `leisureA?`, `leisureCoordA?`, `leisureB?`, `leisureCoordB?`, `filters`, `mode`, `deadlineDate?` | `diagnosisId`, `candidates[]`, `timeline?` | p95 ≤ 3,000ms |
 | API-02 | GET | `/api/diagnosis/[id]` | — | `diagnosis`, `candidates[]` | p95 ≤ 1,500ms |
 
 ### ERD 컬럼 (§6.2.2 DIAGNOSIS)
@@ -49,158 +70,191 @@ assignees: []
 | `deadline_mode` | BOOLEAN | NOT NULL, DEFAULT FALSE | 데드라인 모드 여부 |
 | `created_at` | TIMESTAMP | NOT NULL, DEFAULT NOW() | 생성일시 |
 
+### ★ Phase B 작성 산출물 표 (수정 1 + 신규 2 파일)
+
+| # | 파일 | 내용 | 명세 §3 매핑 |
+|---|---|---|---|
+| **B.1** | `onday-app/src/lib/types/diagnosis.ts` (121 lines, **DB-003 L1-7 보존 + L8~ append 115 lines**) | (P1) re-export 3 (CandidateAreaDTO=CandidateArea / CommuteInfoDTO=CommuteInfo / CreateDiagnosisRequest=DiagnosisInput) + 부재 4 신규 (CreateDiagnosisResponse / GetDiagnosisResponse / TimelineDTO / TimelineStepDTO) + DiagnosisDTO 신규 (mode: ServiceModeType, status: DiagnosisStatusType) + DiagnosisErrorCode enum 8 종 + DiagnosisErrorDTO. **import 부 (명세 §3 원본 대비 축소 — 정직 기록): `import type { ServiceModeType } from './user'` + `import type { CandidateArea, CommuteInfo, DiagnosisFilters, DiagnosisInput } from '../types'` — DiagnosisMode / DiagnosisStatus import 0 (Q2 가드)** | §3.1 + §3.2 |
+| **B.2** | `onday-app/src/lib/constants/diagnosis-errors.ts` (37 lines) | `DIAG_ERROR_MAP: Record<DiagnosisErrorCode, Omit<DiagnosisErrorDTO, 'code' \| 'originalError'>>` 8 키 — 입력검증 3 (ADDRESS_MISSING/OUT_OF_COVERAGE/DEADLINE_PAST) + 결과 1 (NO_CANDIDATES_FOUND) + 외부 API 2 (TRANSPORT_TIMEOUT/RETRY_FAILED) + 조회·권한 2 (NOT_FOUND/FORBIDDEN) | §3.4 |
+| **B.3** | `onday-app/src/lib/helpers/diagnosis-error.ts` (20 lines) | `createDiagnosisError(code, originalError?): DiagnosisErrorDTO` — DIAG_ERROR_MAP lookup + originalError 병합. Sentry catch 연계 가능 (REQ-NF-035). API-001 §3.6 createAuthError 패턴 일관 | (API-001 §3.6 패턴) |
+
+### ★ Q2 가드 사수 표 — DiagnosisMode 11 + DiagnosisStatus 1 호출처 모두 본 ISSUE 미치환 (Q2 (b) 채택, cleanup ISSUE 위임 매핑)
+
+본 ISSUE Phase A 시점 grep 결과 (코드 호출처만, 주석 텍스트 제외):
+
+| # | 위치 | 라인 | 역할 | 본 ISSUE 처리 | cleanup ISSUE 통합 대상 |
+|---|---|---|---|---|---|
+| DM1 | `src/lib/types.ts` | L2 | `export type DiagnosisMode = "couple" \| "single"` 정의 | 미수정 (가드) | cleanup ISSUE — 제거 |
+| DM2 | `src/lib/types.ts` | L55 | `DiagnosisInput.mode: DiagnosisMode` | 미수정 (가드) | cleanup ISSUE — `ServiceModeType` 으로 치환 |
+| DM3 | `src/lib/types.ts` | L66 | `DiagnosisResult.mode: DiagnosisMode` | 미수정 (가드) | cleanup ISSUE — `ServiceModeType` 으로 치환 |
+| DM4 | `src/lib/types.ts` | L88 | `MockUser.mode: DiagnosisMode` | 미수정 (가드) | cleanup ISSUE — `ServiceModeType` (MOCK-005 동시 처리 — 분리 불가) |
+| DM5 | `src/features/diagnosis/mock-calculator.ts` | L5 | `import type { ..., DiagnosisMode } from "@/lib/types"` | 미수정 (가드) | cleanup ISSUE — `import { ServiceModeType } from "@/lib/types/user"` |
+| DM6 | `src/features/diagnosis/mock-calculator.ts` | L85 | `mode: DiagnosisMode` (parameter type) | 미수정 (가드) | cleanup ISSUE |
+| DM7 | `src/features/diagnosis/mock-calculator.ts` | L193 | `mode: DiagnosisMode` (parameter type) | 미수정 (가드) | cleanup ISSUE |
+| DM8 | `src/stores/diagnosis-store.ts` | L2 | `import type { ..., DiagnosisMode } from "@/lib/types"` | 미수정 (가드) | cleanup ISSUE |
+| DM9 | `src/stores/diagnosis-store.ts` | L15 | `mode: DiagnosisMode` (state) | 미수정 (가드) | cleanup ISSUE |
+| DM10 | `src/stores/diagnosis-store.ts` | L30 | `setMode: (mode: DiagnosisMode) => void` (action) | 미수정 (가드) | cleanup ISSUE |
+| DM11 | `src/stores/diagnosis-store.ts` | L48 | `mode: "couple" as DiagnosisMode` (initial state) | 미수정 (가드) | cleanup ISSUE |
+| **DS1** | `src/lib/types.ts` | L3 | `export type DiagnosisStatus = "processing" \| "completed" \| "expired"` 정의 | 미수정 (가드) | cleanup ISSUE — 제거 |
+| **DS2** | `src/lib/types.ts` | L69 | `DiagnosisResult.status: DiagnosisStatus` | 미수정 (가드) | cleanup ISSUE — `DiagnosisStatusType` 으로 치환 |
+
+**합계: DiagnosisMode 11 호출처 (정의 1 + 사용 10) + DiagnosisStatus 2 호출처 (정의 1 + 사용 1) — 본 ISSUE 0 치환.**
+
+본 ISSUE 가 위 11+2 호출처를 정리하지 않는 사유 (Q2 (b) 채택):
+1. **9칸 가드 보존 첫 성공 사례**: INFRA-001 / DB-001~007 / API-001 누적 9 ISSUE 동안 `types.ts` 무수정 가드 유지. 본 ISSUE 가 가드 푸는 첫 위험 후보였으나 (b) 채택으로 보존.
+2. **DB-003 주석 의도 충족**: `diagnosis.ts:3-4` 주석 = "DTO 정의 시 `import { ServiceModeType } from './user'`" → Q3 (D) 채택 (`DiagnosisDTO.mode = ServiceModeType`) 으로 주석 의도 정확 충족, types.ts 일괄 치환은 별도 영역.
+3. **분리 불가 의존**: `types.ts:88 MockUser.mode` 는 MOCK-005 영역 (mock 도메인 책임). types.ts:2 제거 시 L88 동시 깨짐 — 분리 불가 → cleanup ISSUE 신설 트리거 §9.4 일괄 처리.
+4. **DB-006 Q3 / API-001 mock-auth M1~M4 패턴 답습**: 인라인 동작 중 → 본 ISSUE 가 추출 시 가드 위반 + 호출처 동시 영향.
+
+### ★ N1~N6 인라인 호출처 표 (위치/역할/본 ISSUE 미수정/후행 통합 — DB-006 Q3 / API-001 mock-auth M1~M4 패턴 답습)
+
+| # | 위치 | 역할 | 본 ISSUE 처리 | 후행 통합 대상 |
+|---|---|---|---|---|
+| **N1** | `onday-app/src/lib/validators/diagnosis.ts:8-30` (`diagnosisInputSchema` 23 lines — 파일 전체 47 lines 중 본체 23 lines, 나머지 24 lines = shareLinkInputSchema + shareAccessSchema + z.infer 2 종) | 명세 §3.3 `createDiagnosisSchema` 의 **현실 등가 인라인 동작 중**. addressA min(1) + coordinate Korea lat/lng range + filters.maxCommuteTime 10~120 (명세 1~180 차이) + budget {min, max} 객체 (명세 budgetMin/Max 차이) + timeRange enum (명세 timeSlot 차이) + priorities z.array(string) (명세 부재) + mode enum + deadlineDate optional | 미수정 | **CMD-DIAG-001~007** (validators/diagnosis.ts:8-30 N1 통합 + 명세 §3.3 createDiagnosisSchema 정합 검증 + Filters 차이 정리) |
+| **N2** | `onday-app/src/app/api/diagnosis/route.ts:12, 34-46` (POST) | L12 `diagnosisInputSchema.safeParse(body)` 호출처 활성 + L34-46 `prisma.diagnosis.create` 인라인 (filters JSON.stringify + candidates JSON.stringify + status:"completed" + deadlineMode/deadline 변환) | 미수정 | **CMD-DIAG-004** (POST /api/diagnosis 인라인 → saveDiagnosisResult Server Action 추출, N2 통합) |
+| **N3** | `onday-app/src/app/api/diagnosis/[id]/route.ts:13, 19-34` (GET) | L13 `prisma.diagnosis.findUnique` + L19 `JSON.parse(diagnosis.candidates)` + L20 `JSON.parse(diagnosis.filters)` + L22-33 NextResponse.json 인라인 mapper (명세 §3.5 `mapDiagnosisToDTO` 의 현실 등가) | 미수정 | **QRY-DIAG-001** (`mapDiagnosisToDTO(diagnosis, candidates): GetDiagnosisResponse` 신규 + N3 통합) |
+| **N4** | `onday-app/src/features/diagnosis/mock-calculator.ts` (L5/85/193) | DiagnosisMode 3 호출처 (import + parameter type 2) | 미수정 | **cleanup ISSUE** (DM5/DM6/DM7 — types.ts:2 제거와 동시) |
+| **N5** | `onday-app/src/stores/diagnosis-store.ts` (L2/15/30/48) | DiagnosisMode 4 호출처 (import + state + action + initial) | 미수정 | **cleanup ISSUE** (DM8/DM9/DM10/DM11 — types.ts:2 제거와 동시) |
+| **N6** | `onday-app/src/features/diagnosis/detail-mapper.ts` (96 lines) | UI 표시용 매퍼 (CandidateArea → CardProps 등). §3.5 API mapper 와 별 영역 (UI 표시 vs API 응답 직렬화) | 미수정 (본 ISSUE 무관여) | — (DiagnosisMode 미사용 — cleanup ISSUE 영향 X) |
+
+본 ISSUE 가 N1~N3 추출 산출물을 미작성하는 사유 (DB-006 Q3 / API-001 Q6/Q9 일관 dead 회피):
+- N1 Zod: `validators/diagnosis.ts:8-30` 23 lines 인라인 동작 중 + Route Handler L12 safeParse 호출처 활성 → 본 ISSUE 추출 시 N1 우회 가드 위반
+- N3 mapper: `[id]/route.ts:19-34` JSON.parse + NextResponse 인라인 동작 중 → 본 ISSUE 추출 시 N3 우회 가드 위반
+- 두 위임 모두 **CMD-DIAG-001~007 + QRY-DIAG-001 시점에 통합** (N1/N3 인라인 → 추출 + 본 ISSUE B.1 DTO import + Sentry catch + createDiagnosisError 활용)
+
+### ★ 부재 산출물 표 (인라인 동작 중 또는 호출처 0건 → 위임)
+
+| 명세 §3 산출물 | 현실 (Phase A 확인) | 위임 대상 |
+|---|---|---|
+| §3.3 `lib/validators/diagnosis.ts` `createDiagnosisSchema` 신규 | `diagnosisInputSchema` 23 lines (N1) 인라인 동작 중 + Route Handler L12 safeParse 호출처 활성 + filters 필드 차이 (budget object vs budgetMin/Max / timeRange enum vs timeSlot string / priorities 추가) | **CMD-DIAG-001~007** (N1 통합 + 명세 §3.3 정합 검증 + Filters 차이 정리) |
+| §3.5 `lib/mappers/diagnosis-mapper.ts` `mapDiagnosisToDTO` | `[id]/route.ts:19-34` 인라인 mapper (N3) 동작 중 + `lib/mappers/` 빈 디렉토리 (API-001 시점 빈, 본 ISSUE 도 작성 안 함) | **QRY-DIAG-001** (mapDiagnosisToDTO 추출 + N3 통합) |
+| §3.6 `__tests__/types/diagnosis-dto.spec.ts` (4 케이스) | vitest config 부재 (DB-001~007 + API-001 §3.7/3.8 일관) — `vitest ^4.1.6` 의존성만 존재 | **TEST-001** |
+| §3.7 `__tests__/validators/diagnosis.spec.ts` (6 케이스) | 동상 | **TEST-001** |
+| §3.8 `__tests__/mappers/diagnosis-mapper.spec.ts` (3 케이스) | 동상 + mapper 자체 위임이라 동시 위임 | **TEST-001** |
+
 ### 선행 태스크 산출물
 
-| 선행 Task ID | 제공 산출물 | 본 태스크에서의 사용처 |
+| 선행 Task ID | 제공 산출물 | 본 ISSUE 사용처 |
 |---|---|---|
-| DB-003 | `prisma/schema.prisma` 내 `model Diagnosis` + `DiagnosisStatus`/`ServiceMode` Enum | DTO가 Prisma 모델의 타입을 래핑하여 API 응답 구조로 변환 |
+| **DB-002** (PR #76 머지 완료, main `d916a6f`) | `src/lib/types/user.ts` (`AuthProviderType` + `ServiceModeType` TS union + `UserDTO` interface, commit `2ea3a17`) | ★ B.1 `diagnosis.ts:13` `import type { ServiceModeType } from './user'` — `DiagnosisDTO.mode` 에 사용 (Q2 (b) 핵심 — DiagnosisMode 미사용) |
+| **DB-003** (PR #77 머지 완료) | `src/lib/types/diagnosis.ts` (7 lines, `DiagnosisStatusType` TS union + ★ L3-4 주석 "DTO 정의 시 `import { ServiceModeType } from './user'` 패턴 사용") | ★ B.1 base — **L1-7 보존 + L8~ append** (DB-003 산출물 확장, 덮어쓰기 0). `DiagnosisStatusType` 첫 활성 (DiagnosisDTO.status + CreateDiagnosisResponse.status) |
+| **API-001** (PR #81 머지 완료, main `ee83429`) | `lib/types/auth.ts` (133 lines) + `lib/constants/auth-errors.ts` (42 lines) + `lib/helpers/auth-error.ts` (20 lines) + `tasks/API-001.md` (Q1~Q10 + L6 2차 정정 + (P1) OAuthProvider=AuthProviderType 패턴) | ★ 본 ISSUE 답습 기준: (B) 절충 패턴 + Phase B 활성 + 커밋 2개 (feat+docs) + (P1) re-export 3 + L6 2차 정정 → 3차 cleanup 트리거 |
+| DB-006 / DB-004 / DB-001 / DB-007 | 간접 선행 (Phase 패턴 + dead 회피 논리 답습 + DB-007 L6 1차 발견) | DB-* 패턴 답습 + L6 3차 정정 근거 |
+
+### 후행 ISSUE 정합성 (Q1~Q10 결정 트리거)
+
+| 후행 Task ID | 본 ISSUE 위임 트리거 |
+|---|---|
+| **★ CMD-DIAG-001~007** | §3.3 `createDiagnosisSchema` — N1 `validators/diagnosis.ts:8-30` 통합 + 명세 §3.3 정합 검증 (addressA min(1) + maxCommuteTime 범위 + budget/timeRange/priorities 정리) + DiagnosisErrorCode 활용 |
+| **★ CMD-DIAG-004** (진단 결과 서버 저장) | N2 `api/diagnosis/route.ts:12, 34-46` POST 인라인 → `saveDiagnosisResult` Server Action 추출 + B.1 `CreateDiagnosisRequest` / `CreateDiagnosisResponse` import |
+| **★ QRY-DIAG-001** (진단 조회) | §3.5 `mapDiagnosisToDTO` 신규 + N3 `[id]/route.ts:19-34` 통합 + B.1 `GetDiagnosisResponse` / `DiagnosisDTO` / `CandidateAreaDTO` import |
+| **★ MOCK-001** (Diagnosis Mock 데이터) | B.1 `CandidateAreaDTO` 3곳+ Mock + `GetDiagnosisResponse` Mock + `TimelineDTO` Mock |
+| **★ TEST-001** | §3.6/3.7/3.8 일괄 (vitest config + type spec 4 + validator spec 6 + mapper spec 3 + 교차 진단 GWT E2E) |
+| **★ cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계)** | **L6 3차 정정 owner** — types.ts:2 `DiagnosisMode` 제거 + 11 호출처 → ServiceModeType / types.ts:3 `DiagnosisStatus` 제거 + 1 호출처 → DiagnosisStatusType / types.ts:88 MockUser.mode (MOCK-005 동시) / DiagnosisInput·DiagnosisResult 의존 파일 (use-diagnosis.ts + Zod schema + result page) 동시 §9.4 일괄 처리 |
 
 ---
 
 ## 3. 🛠️ Task Breakdown (실행 체크리스트)
 
-- [ ] **3.1** `lib/types/diagnosis.ts`에 Diagnosis 도메인 DTO 타입 전체 정의
-  ```typescript
-  // === Request DTOs ===
-  export interface CreateDiagnosisRequest {
-    addressA: string;
-    addressB: string;
-    coordA?: { lat: number; lng: number };
-    coordB?: { lat: number; lng: number };
-    filters: DiagnosisFilters;
-    mode: 'couple' | 'single';
-    deadlineDate?: string | null; // ISO date
-  }
+> ★ API-001 패턴 답습 (Phase A 사전 검증 + Phase B 활성 3 파일 + Phase C 명세 동기화 + Phase D 커밋 2개) + (B) 절충 + (P1) re-export 3 + Q2 (b) cleanup 위임.
 
-  export interface DiagnosisFilters {
-    maxCommuteTime?: number;  // 분
-    budgetMin?: number;
-    budgetMax?: number;
-    timeSlot?: string;        // "07:00"~"09:00"
-  }
+- [x] **3.1** `lib/types/diagnosis.ts` (DB-003 산출물 확장 — L1-7 보존 + L8~ append) — **Phase B.1 완료 (121 lines = DB-003 보존 7 + 빈줄 1 + append 113)**
+  > **★ DB-003 산출물 L1-7 절대 보존** (덮어쓰기 0, git diff +115/-0). Edit anchor = L6 `export type DiagnosisStatusType = ...` 의 다음 줄에 append.
+  > import 부 (명세 §3.1 원본 대비 — 정직 기록):
+  > - `import type { ServiceModeType } from './user';` (DiagnosisDTO.mode 사용, **DiagnosisMode 미사용 — Q2 가드**)
+  > - `import type { CandidateArea, CommuteInfo, DiagnosisFilters, DiagnosisInput } from '../types';` (P1 re-export 3 + DiagnosisFilters import only — DiagnosisMode / DiagnosisStatus import 0)
+  > 5 섹션:
+  > 1. (P1) re-export — `CandidateAreaDTO = CandidateArea` / `CommuteInfoDTO = CommuteInfo` / `CreateDiagnosisRequest = DiagnosisInput` (3 re-export, 신규 type alias 정의 금지)
+  > 2. DiagnosisDTO 본체 — mode: ServiceModeType (Q2 b — DiagnosisMode 아님), status: DiagnosisStatusType (DB-003 산출물 첫 활성), 10 필드 (id+userId+addressA+addressB?+filters+mode+deadlineMode+deadline?+status+createdAt)
+  > 3. Request / Response DTO — CreateDiagnosisResponse (4 필드) + GetDiagnosisResponse (2 필드)
+  > 4. Timeline DTO — TimelineDTO + TimelineStepDTO (Deadline mode)
+  > 5. Diagnosis Error — `DiagnosisErrorCode` enum 8 종 (입력검증 3 + 결과 1 + 외부 API 2 + 조회·권한 2) + `DiagnosisErrorDTO`
 
-  // === Response DTOs ===
-  export interface CreateDiagnosisResponse {
-    diagnosisId: string;
-    candidates: CandidateAreaDTO[];
-    timeline: TimelineDTO | null;
-    status: DiagnosisStatusType;
-  }
+- [x] **3.2** `lib/types/diagnosis.ts` `DiagnosisErrorCode` enum 8 종 — **Phase B.1 완료 (같은 파일 §5 섹션)**
+  > 입력 검증 3 (ADDRESS_MISSING/ADDRESS_OUT_OF_COVERAGE/DEADLINE_DATE_PAST) + 결과 처리 1 (NO_CANDIDATES_FOUND) + 외부 API 2 (TRANSPORT_API_TIMEOUT/RETRY_FAILED) + 조회·권한 2 (DIAGNOSIS_NOT_FOUND/FORBIDDEN). API-001 §3.2 AuthErrorCode 패턴 답습.
 
-  export interface GetDiagnosisResponse {
-    diagnosis: DiagnosisDTO;
-    candidates: CandidateAreaDTO[];
-  }
+- [⏸ CMD-DIAG-001~007 위임] **3.3** `lib/validators/diagnosis.ts` `createDiagnosisSchema` — **Q5 부재 산출물 결정**
+  > **사유 4종 (DB-006 Q3 / API-001 Q6/Q9 일관 dead 회피 + 인라인 동작 중):**
+  > 1. **★ N1 인라인 동작 중 (Phase A.5 확인)**: `validators/diagnosis.ts:8-30` `diagnosisInputSchema` 23 lines (Zod) 정상 동작 중. 파일 전체 47 lines (shareLinkInputSchema + shareAccessSchema 포함).
+  > 2. **★ Route Handler 호출처 활성**: `api/diagnosis/route.ts:12` `diagnosisInputSchema.safeParse(body)` 호출처 활성 + L34-46 prisma.diagnosis.create 실 사용.
+  > 3. **★ Filters 필드 차이 (명세 v1.0 ↔ 현실 mismatch)**: 명세 §3.3 `budgetMin/Max` + `timeSlot ("07:00")` ↔ 현실 `budget {min, max}` 객체 + `timeRange` enum + `priorities` array → 본 ISSUE 추출 시 어느 쪽 채택할지 결정 필요 → CMD-DIAG-001~007 에서 통합 결정 (현실 추인 또는 명세 정합 — §9.5 follow-up)
+  > 4. **CMD-DIAG-001~007 영역**: 06_TASK_LIST §2-A — 진단 로직 구현 = createDiagnosisSchema 의 owner. 본 ISSUE 가 추출 시 owner 침범 + N1 우회 가드 위반.
 
-  export interface DiagnosisDTO {
-    id: string;
-    userId: string;
-    deadline: string | null;
-    status: DiagnosisStatusType;
-    filters: DiagnosisFilters;
-    mode: 'couple' | 'single';
-    deadlineMode: boolean;
-    createdAt: string; // ISO 8601
-  }
+- [x] **3.4** `lib/constants/diagnosis-errors.ts` `DIAG_ERROR_MAP` (8 키) — **Phase B.2 완료 (37 lines)**
+  > 8 키 (DiagnosisErrorCode enum 전수) × `{message: string (한국어), httpStatus: number}` 매핑. Omit pattern (`Omit<DiagnosisErrorDTO, 'code' | 'originalError'>`) — code/originalError 는 createDiagnosisError 가 채움.
+  > HTTP 상태: 400 (입력검증 3) / 404 (NO_CANDIDATES_FOUND + DIAGNOSIS_NOT_FOUND) / 403 (FORBIDDEN) / 502 (RETRY_FAILED) / 504 (TIMEOUT)
 
-  export type DiagnosisStatusType = 'processing' | 'completed' | 'expired';
+- [⏸ QRY-DIAG-001 위임] **3.5** `lib/mappers/diagnosis-mapper.ts` `mapDiagnosisToDTO` — **Q9 부재 산출물 결정**
+  > **사유 4종 (DB-006 Q3 / API-001 Q6 일관 dead 회피):**
+  > 1. **★ N3 인라인 동작 중 (Phase A.5 확인)**: `app/api/diagnosis/[id]/route.ts:13 findUnique + L19-34 JSON.parse + NextResponse.json` 인라인 mapper 정상 동작 중 (`candidates: JSON.parse(diagnosis.candidates)` + `filters: JSON.parse(diagnosis.filters)` + status/deadline 변환 + ISO toISOString).
+  > 2. **★ lib/mappers/ 빈 디렉토리**: API-001 시점 빈 디렉토리 유지 + 본 ISSUE 도 작성 안 함 → mkdir + 단일 파일 만들 시 dead.
+  > 3. **★ QRY-DIAG-001 영역**: 06_TASK_LIST §2-A — 진단 조회 = mapDiagnosisToDTO owner. 본 ISSUE 추출 시 owner 침범 + N3 우회 가드 위반.
+  > 4. **Prisma model 의존**: mapper 시그니처 = `(diagnosis: PrismaDiagnosis, candidates: PrismaCandidateArea[]) => GetDiagnosisResponse` — Prisma Client import 필요. 본 ISSUE = DTO only owner → Prisma import 회피 (관심사 분리).
 
-  // === CandidateArea ===
-  export interface CandidateAreaDTO {
-    id: string;
-    name: string;                   // 행정동 이름
-    coord: { lat: number; lng: number };
-    commuteA: CommuteInfoDTO;       // 직장A까지
-    commuteB: CommuteInfoDTO;       // 직장B까지
-    score: number;                  // 종합 스코어
-    rank: number;
-  }
+- [x] **3.6 (helper)** `lib/helpers/diagnosis-error.ts` `createDiagnosisError(code, originalError?)` — **Phase B.3 완료 (20 lines)** ★ 명세 v1.0 §3.6 spec 항목 대비 추가 helper (API-001 §3.6 createAuthError 패턴 일관)
+  > `(code: DiagnosisErrorCode, originalError?: string): DiagnosisErrorDTO` — DIAG_ERROR_MAP lookup + originalError 병합. Sentry catch 와 연계 가능 (REQ-NF-035) — originalError 필드로 원본 에러 메시지 전달.
 
-  export interface CommuteInfoDTO {
-    durationMinutes: number;
-    transportType: 'transit' | 'car';
-    transfers: number;
-    walkingMinutes: number;
-  }
+- [⏸ TEST-001 위임] **3.6 (spec)** `__tests__/types/diagnosis-dto.spec.ts` (4 케이스)
+  > **사유 3종 (DB-001~007 + API-001 §3.7/3.8 일관 + vitest config 부재 + AC 위임 일관):**
+  > 1. vitest config 부재 (Phase A.7 확인) → spec 작성해도 실행 불가
+  > 2. AC-2/AC-3/AC-4 가 CMD-DIAG / QRY-DIAG 위임 → spec 도 동일 시점 작성
+  > 3. TEST-001 영역 — 교차 진단 GWT 시나리오 + DTO spec 일괄
 
-  // === Timeline (Deadline Mode) ===
-  export interface TimelineDTO {
-    steps: TimelineStepDTO[];
-    deadlineDate: string;
-  }
+- [⏸ TEST-001 위임] **3.7** `__tests__/validators/diagnosis.spec.ts` (6 케이스: 정상 / 주소 누락 / 잘못된 mode / 과거 deadline / 범위 초과 maxCommuteTime / 빈 filters)
+  > 사유: §3.3 Zod 자체 위임 (CMD-DIAG-001~007) → spec 동시 위임. AC-1/AC-2/AC-3/AC-4 모두 CMD-DIAG 활성 후 검증.
 
-  export interface TimelineStepDTO {
-    order: number;
-    title: string;
-    description: string;
-    dueDate: string;
-    completed: boolean;
-  }
-  ```
+- [⏸ TEST-001 위임] **3.8** `__tests__/mappers/diagnosis-mapper.spec.ts` (3 케이스)
+  > 사유: §3.5 mapper 자체 위임 (QRY-DIAG-001) → spec 동시 위임.
 
-- [ ] **3.2** `lib/types/diagnosis.ts`에 Diagnosis 에러 코드 enum 정의
-  ```typescript
-  export enum DiagnosisErrorCode {
-    ADDRESS_MISSING = 'DIAG_ADDRESS_MISSING',
-    ADDRESS_OUT_OF_COVERAGE = 'DIAG_ADDRESS_OUT_OF_COVERAGE',
-    NO_CANDIDATES_FOUND = 'DIAG_NO_CANDIDATES_FOUND',
-    TRANSPORT_API_TIMEOUT = 'DIAG_TRANSPORT_API_TIMEOUT',
-    TRANSPORT_API_RETRY_FAILED = 'DIAG_TRANSPORT_API_RETRY_FAILED',
-    DIAGNOSIS_NOT_FOUND = 'DIAG_NOT_FOUND',
-    DIAGNOSIS_FORBIDDEN = 'DIAG_FORBIDDEN',
-    DEADLINE_DATE_PAST = 'DIAG_DEADLINE_DATE_PAST',
-  }
-  ```
+### ★ Q1~Q10 결정 vs 명세 v1.0 mismatch 추적 표 (API-001 / DB-006 / 007 패턴 답습)
 
-- [ ] **3.3** `lib/validators/diagnosis.ts`에 Zod 유효성 스키마 정의
-  ```typescript
-  import { z } from 'zod';
-  export const createDiagnosisSchema = z.object({
-    addressA: z.string().min(1, '출발지 A 주소를 입력해 주세요'),
-    addressB: z.string().min(1, '출발지 B 주소를 입력해 주세요'),
-    coordA: z.object({ lat: z.number(), lng: z.number() }).optional(),
-    coordB: z.object({ lat: z.number(), lng: z.number() }).optional(),
-    filters: z.object({
-      maxCommuteTime: z.number().int().min(1).max(180).optional(),
-      budgetMin: z.number().min(0).optional(),
-      budgetMax: z.number().min(0).optional(),
-      timeSlot: z.string().regex(/^\d{2}:\d{2}$/).optional(),
-    }),
-    mode: z.enum(['couple', 'single']),
-    deadlineDate: z.string().datetime().nullable().optional(),
-  });
-  ```
-
-- [ ] **3.4** `lib/constants/diagnosis-errors.ts`에 에러코드→메시지 매핑
-- [ ] **3.5** `lib/mappers/diagnosis-mapper.ts`에 Prisma Diagnosis → DiagnosisDTO 변환 함수
-  - 시그니처: `export function mapDiagnosisToDTO(diagnosis: PrismaDiagnosis, candidates: PrismaCandidateArea[]): GetDiagnosisResponse`
-- [ ] **3.6** `__tests__/types/diagnosis-dto.spec.ts` — DTO 타입 검증 4개 케이스
-- [ ] **3.7** `__tests__/validators/diagnosis.spec.ts` — Zod 스키마 검증 6개 케이스 (정상, 주소 누락, 잘못된 mode, 과거 deadline, 범위 초과 maxCommuteTime, 빈 filters)
-- [ ] **3.8** `__tests__/mappers/diagnosis-mapper.spec.ts` — 변환 함수 테스트 3개 케이스
+| Q | 영역 | 명세 v1.0 (API-002.md) | 현실 (onday-app) | 결정 | 후행 처리 |
+|---|---|---|---|---|---|
+| **Q1** ★ | 작업 모드 (가장 상위, API-001 답습) | §3.1~3.8 8개 산출물 신규 작성 | DB-003 산출물 (diagnosis.ts DiagnosisStatusType + 주석) 활성 + N1 Zod 인라인 동작 중 + N3 mapper 인라인 동작 중 + spec 미실행 가능 | (B) **절충 — API-001 패턴 답습 + Phase B 활성 (3 파일) + 커밋 2개 (feat+docs 분리)**. API Contract 트랙 = DTO owner | Phase B 작성 (B.1/B.2/B.3) + Phase D 커밋 2개 |
+| **Q2** ★★ | L6 type alias 통합 + types.ts 가드 (★ 9칸 통틀어 가장 위험한 판단 — 가드 푸는 첫 위험 후보) | (명세 §3.1 신규 DTO 정의) | `types.ts:2-3` `DiagnosisMode`/`DiagnosisStatus` (DB-002/DB-003 의 ServiceModeType/DiagnosisStatusType 와 DRY 위반) — DiagnosisMode 11 호출처 + DiagnosisStatus 1 호출처 | **(b) cleanup ISSUE 신설 트리거 + DTO 작성 시 ServiceModeType / DiagnosisStatusType import** — types.ts:1-3 무수정 (9칸 가드 보존 첫 성공), DB-003 commit `2ea3a17` 주석 해석 A (★ "diagnosis.ts DTO 정의 시 ServiceModeType 사용" 직접 명시) 충족. 11+2 호출처 = cleanup ISSUE 일괄 처리 트리거 §9.4 | **cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계)** — types.ts:2-3 제거 + 11+2 호출처 + MockUser.mode + DiagnosisInput/Result 의존 파일 동시 (§9.4) |
+| **Q3** ★ | DTO append strategy | §3.1 8 DTO 전체 신규 정의 | DB-003 diagnosis.ts (DiagnosisStatusType + 주석) 활용 가능 + types.ts entity (CandidateArea 15 필드 Step 10.5 풍부 / CommuteInfo / DiagnosisInput 11 필드 Figma 비전 leisure superset / DiagnosisFilters 4 필드 현실 / DiagnosisResult) | (D) **re-export + 부재 신규 — API-001 (P1) 패턴 답습**. `CandidateAreaDTO = CandidateArea` + `CommuteInfoDTO = CommuteInfo` + `CreateDiagnosisRequest = DiagnosisInput` re-export (현실 superset 노출) + 부재 4 신규 (Response×2 + Timeline×2) + `DiagnosisDTO` 신규 (mode: ServiceModeType, status: DiagnosisStatusType — DB-003 산출물 첫 활성) | 후행 import 활용 (CMD-DIAG / QRY-DIAG / MOCK-001 · TEST-001) |
+| **Q4** | DiagnosisStatus ↔ DiagnosisStatusType 중복 | (명세 §3.1 신규 DiagnosisStatusType) | DB-003 산출물 DiagnosisStatusType 정의됨 (사용처 0건) + types.ts:3 DiagnosisStatus 사용 1건 | (A) **Q2 cleanup ISSUE 트리거에 포함** (Q2 답변에 이미 명시). 본 ISSUE 시점 두 type 동거 정상 (단계적 해소 패턴) | cleanup ISSUE (§9.4) |
+| **Q5** | §3.2 DiagnosisErrorCode enum (8 종) | 신규 작성 | 부재 (Route Handler `console.error` 인라인) | (A) **✅ Phase B.1 작성** — API-001 §3.2 AuthErrorCode 패턴 일관 | 후행 CMD-DIAG / QRY-DIAG import 활용 |
+| **Q6** | §3.4 DIAG_ERROR_MAP (8 키) | 신규 작성 | 부재 + `lib/constants/` (API-001 시점 auth-errors.ts 작성) | (A) **✅ Phase B.2 작성** — API-001 §3.5 AUTH_ERROR_MAP 패턴 일관 | 후행 createDiagnosisError lookup 대상 |
+| **Q7** (추가) | createDiagnosisError helper | (명세 v1.0 부재 — API-001 §3.6 패턴 추가) | 부재 + `lib/helpers/` (API-001 시점 auth-error.ts 작성) | (A) **✅ Phase B.3 작성** — API-001 §3.6 createAuthError 패턴 일관 | 후행 CMD-DIAG / QRY-DIAG import (DiagnosisErrorDTO 생성) |
+| **Q8** | §3.3 createDiagnosisSchema Zod | 신규 작성 | `diagnosisInputSchema` 23 lines (N1) 인라인 동작 중 + Route Handler L12 safeParse 호출처 활성 + filters 필드 차이 | (A) **⏸ CMD-DIAG-001~007 위임** — N1 인라인 보존 (DB-006 Q3 패턴) + Filters 차이 정리 | CMD-DIAG-001~007 (§9.1) |
+| **Q9** | §3.5 mapDiagnosisToDTO | 신규 작성 | `[id]/route.ts:19-34` 인라인 mapper (N3) + `lib/mappers/` 빈 디렉토리 | (A) **⏸ QRY-DIAG-001 위임** — N3 인라인 보존 (API-001 Q6 dead 회피 패턴) | QRY-DIAG-001 (§9.2) |
+| **Q10** | §3.6/3.7/3.8 spec ×3 | type spec 4 + validator spec 6 + mapper spec 3 | vitest config 부재 + vitest 의존성 (`^4.1.6`) 만 존재 + AC CMD-DIAG / QRY-DIAG 위임 | (A) **⏸ TEST-001 위임** — DB-001~007 + API-001 §3.7/3.8 일관 | TEST-001 (§9.3) |
+| **보조** | DiagnosisFilters 명세 v1.0 ↔ 현실 차이 (Q3 부수) | budgetMin/Max + timeSlot ("07:00") | budget {min, max} 객체 + timeRange enum + priorities 추가 | 현실 추인 (DiagnosisFilters re-export 없이 import only — `import type { DiagnosisFilters } from '../types'` 사용) + §9.5 follow-up 기록 (9칸 "이름같고 필드다름→현실추인+차이기록" 패턴 일관, DB-006 SavedSearch searchParams 패턴) | cleanup ISSUE 또는 후행 CMD-DIAG-001~007 시점 정리 (§9.5) |
 
 ---
 
-## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD — API-001 ⏸ 패턴 일관 + Phase B 작성분 충족)
 
-**AC-1 (정상):** createDiagnosis Request Zod 검증 통과
-- **Given** 두 주소(`addressA`, `addressB`)와 유효한 filters, `mode: 'couple'`이 포함된 요청 객체
-- **When** `createDiagnosisSchema.parse(request)` 호출
+**AC-1 (정상, ⏸ CMD-DIAG-001~007 위임):** createDiagnosis Request Zod 검증 통과
+- **Given** 두 주소(`addressA`, `addressB?`)와 유효한 filters, `mode: 'couple'`이 포함된 요청 객체
+- **When** `diagnosisInputSchema.parse(request)` 호출 (CMD-DIAG-001~007 시점 검증, 현재 N1 인라인 동작 중)
 - **Then** 검증 통과하여 파싱된 객체가 반환되며, 모든 필드 타입이 스키마와 일치
+- **Status:** ⏸ CMD-DIAG-001~007 시점 정합 검증 (N1 통합 + 명세 §3.3 → 현실 diagnosisInputSchema 차이 정리). ★ 본 ISSUE B.1 `CreateDiagnosisRequest = DiagnosisInput` (P1) re-export 완료 — Zod schema 의 z.infer 타입과 정합 확인은 CMD-DIAG 시점.
 
-**AC-2 (예외):** addressA 또는 addressB 누락 시 Zod 에러
-- **Given** `addressA`가 빈 문자열이고 `addressB`만 유효한 요청 객체
-- **When** `createDiagnosisSchema.parse(request)` 호출
-- **Then** ZodError 발생, `issues[0].path`가 `['addressA']`, `message`가 `'출발지 A 주소를 입력해 주세요'`
+**AC-2 (예외, ⏸ CMD-DIAG-001~007 위임):** addressA 누락 시 Zod 에러
+- **Given** `addressA`가 빈 문자열인 요청 객체
+- **When** `diagnosisInputSchema.parse(request)` 호출
+- **Then** ZodError 발생, `issues[0].path`가 `['addressA']`, `message`가 `'출발지 A를 입력해주세요'` (현실 메시지 — 명세 "출발지 A 주소를 입력해 주세요"와 차이)
+- **Status:** ⏸ CMD-DIAG-001~007 시점 검증. ★ 본 ISSUE B.1 `DiagnosisErrorCode.ADDRESS_MISSING` + B.2 `DIAG_ERROR_MAP[ADDRESS_MISSING]` + B.3 `createDiagnosisError()` 정의 완료 — Zod ZodError 와 DiagnosisErrorDTO 변환은 CMD-DIAG 시점.
 
-**AC-3 (예외):** 잘못된 mode 값 전달 시 에러
-- **Given** `mode: 'family'` (허용값 아님)인 요청 객체
-- **When** `createDiagnosisSchema.parse(request)` 호출
-- **Then** ZodError 발생, `issues[0].path`가 `['mode']`
+**AC-3 (예외, ✅ Phase B 산출물 충족):** DiagnosisErrorCode 전수 매핑 검증 (API-001 AC-5 패턴)
+- **Given** `DiagnosisErrorCode` enum 의 8 값 모두
+- **When** `DIAG_ERROR_MAP[code]` 조회
+- **Then** 8 값 모두 매핑 존재, `message` 한국어 문자열, `httpStatus` 100~599 범위
+- **Status:** ✅ Phase B.2 `DIAG_ERROR_MAP` 8 키 전수 매핑 작성 완료 — **TS 타입 레벨 `Record<DiagnosisErrorCode, ...>` 강제로 누락 시 컴파일 에러** (tsc Phase B.4 exit 0 검증). TEST-001 spec 으로 런타임 재검증 예정.
 
-**AC-4 (경계):** maxCommuteTime 범위 경계값 검증
-- **Given** `filters.maxCommuteTime: 180` (최대값)인 요청 객체
-- **When** `createDiagnosisSchema.parse(request)` 호출
-- **Then** 검증 통과. `maxCommuteTime: 181`이면 ZodError 발생
+**AC-4 (경계, ⏸ CMD-DIAG-001~007 위임):** maxCommuteTime 범위 경계값 검증
+- **Given** `filters.maxCommuteTime: 120` (현실 N1 최대값 — 명세 180과 차이) 인 요청 객체
+- **When** `diagnosisInputSchema.parse(request)` 호출
+- **Then** 검증 통과. `maxCommuteTime: 121`이면 ZodError 발생
+- **Status:** ⏸ CMD-DIAG-001~007 시점 검증 (현실 N1 의 10~120 범위 vs 명세 1~180 범위 차이 정리).
+
+**AC-5 (정상, ⏸ QRY-DIAG-001 위임):** Prisma Diagnosis → DiagnosisDTO 변환
+- **Given** Prisma `Diagnosis` row + `candidates` JSON.parse 결과
+- **When** `mapDiagnosisToDTO(diagnosis, candidates)` 호출 (QRY-DIAG-001 시점, 현재 N3 인라인 동작 중)
+- **Then** `GetDiagnosisResponse.diagnosis` 가 DiagnosisDTO 타입과 정합, `candidates` 가 CandidateAreaDTO[] 타입과 정합, ISO 8601 toISOString 적용
+- **Status:** ⏸ QRY-DIAG-001 시점 검증 (N3 통합). ★ 본 ISSUE B.1 `GetDiagnosisResponse` + `DiagnosisDTO` + `CandidateAreaDTO` 정의 완료.
 
 ---
 
@@ -208,48 +262,193 @@ assignees: []
 
 | NFR ID | SRS 본문 인용 | 본 태스크에서의 검증 방법 |
 |---|---|---|
-| REQ-NF-001 | "두 동선 교차 계산 응답 시간 — p95 ≤ 8,000ms" (§4.2.1) | DTO 설계 시 응답 직렬화 오버헤드가 최소화되도록 불필요한 중첩 제거. k6 부하 테스트에서 DTO 직렬화 포함 p95 측정 |
-| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | DiagnosisErrorCode에 Sentry로 전달할 원본 에러 정보를 포함하는 구조인지 확인 |
+| REQ-NF-001 | "두 동선 교차 계산 응답 시간 — p95 ≤ 8,000ms" (§4.2.1) | ✅ B.1 DTO 설계 — 응답 직렬화 오버헤드 최소화 (불필요한 중첩 제거, CandidateAreaDTO 평면 구조). ⏸ k6 부하 테스트는 CMD-DIAG / QRY-DIAG 시점 (DTO 직렬화 포함 p95 측정) |
+| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | ✅ B.1 `DiagnosisErrorDTO.originalError` 필드 정의 + B.3 `createDiagnosisError()` 가 originalError 를 받아 Sentry catch 와 연계 가능한 구조. ⏸ CMD-DIAG / QRY-DIAG (실 Sentry.captureException 호출) + MON-001 (Sentry 통합) |
 
 ---
 
-## 6. 📦 Deliverables (산출물 명시)
+## 6. 📦 Deliverables (산출물 명시 — 신규/보존/위임/정정 4 구역)
 
-- `lib/types/diagnosis.ts` (Diagnosis DTO 전체)
-- `lib/validators/diagnosis.ts` (Zod 스키마)
-- `lib/constants/diagnosis-errors.ts` (에러코드→메시지 매핑)
-- `lib/mappers/diagnosis-mapper.ts` (Prisma→DTO 변환)
-- `__tests__/types/diagnosis-dto.spec.ts`
-- `__tests__/validators/diagnosis.spec.ts`
-- `__tests__/mappers/diagnosis-mapper.spec.ts`
+### ✅ 신규 (4 — 3 코드 + 1 docs, Phase B + C)
+
+**Phase B 코드 (3 파일)**:
+- `onday-app/src/lib/types/diagnosis.ts` (121 lines, DB-003 보존 7 + append 115) — §3.1 (P1) re-export 3 + 부재 4 신규 + DiagnosisDTO 신규 + §3.2 DiagnosisErrorCode 8 종 + DiagnosisErrorDTO
+- `onday-app/src/lib/constants/diagnosis-errors.ts` (37 lines) — §3.4 DIAG_ERROR_MAP 8 키
+- `onday-app/src/lib/helpers/diagnosis-error.ts` (20 lines) — createDiagnosisError (API-001 §3.6 패턴, 명세 v1.0 대비 추가)
+
+**Phase C 명세 (1 파일)**:
+- `tasks/API-002.md` — 본 명세 현실 동기화 (Q1~Q10 + L6 3차 정정 + cleanup ISSUE 트리거 + mismatch 추적 + N1~N6 표 + §9 follow-up 8종)
+
+### ✅ 보존 (DB-001~007 12 + API-001 3 + types.ts + 11+2 호출처 + N1~N6 + mock-auth M1~M4 + .env.example = 20+종, 본 ISSUE 절대 미수정)
+
+**DB-001~007 누적 가드 (12)**: `prisma/schema.prisma`, `prisma.config.ts`, `prisma/migrations/20260429125124_init/`, `prisma/seed.ts`, `src/lib/db.ts`, `src/lib/types/errors/.gitkeep`, **`src/lib/types/user.ts`** (DB-002 — B.1 `ServiceModeType` import 재사용 대상), **`src/lib/types/diagnosis.ts` L1-7** (DB-003 — DB-003 산출물 + L3-4 주석, B.1 base append 대상), `__tests__/db/.gitkeep`, `package.json`, design 루트, `06_TASK_LIST_v1.3.md`
+
+**API-001 산출물 (3)**: `lib/types/auth.ts` (133 lines) + `lib/constants/auth-errors.ts` (42 lines) + `lib/helpers/auth-error.ts` (20 lines) — 본 ISSUE 미수정
+
+**Q2 추가 가드**: `src/lib/types.ts` (DiagnosisMode 11 호출처 + DiagnosisStatus 1 호출처 + AuthProvider 1 호출처 보존) — DM1~DM11 + DS1~DS2 가드 (위 §2 Q2 가드 사수 표 참조)
+
+**N1~N6 인라인 호출처 (가드 추가, DB-006 Q3 / API-001 mock-auth M1~M4 패턴 답습)**: N1 `validators/diagnosis.ts` / N2 `api/diagnosis/route.ts` POST / N3 `api/diagnosis/[id]/route.ts` GET / N4 `mock-calculator.ts` / N5 `diagnosis-store.ts` / N6 `detail-mapper.ts` — 본 ISSUE 미수정
+
+**mock-auth M1~M4 (API-001 산출물 가드 누적)**: `lib/auth.ts` 5 함수 / `stores/session.ts` Zustand / `mocks/users.ts` MOCK_SESSION / `components/auth/login-form.tsx` handleOAuth — 본 ISSUE 무관여
+
+**`.env.example` Supabase 3종**: `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY` — 본 ISSUE 미수정
+
+### ⏸ 위임 (4 + 정정 1 = 5)
+
+- §3.3 `lib/validators/diagnosis.ts` `createDiagnosisSchema` (현실 N1 통합 + 명세 정합) → **CMD-DIAG-001~007** (Q8)
+- §3.5 `lib/mappers/diagnosis-mapper.ts` `mapDiagnosisToDTO` (N3 통합) → **QRY-DIAG-001** (Q9)
+- §3.6/3.7/3.8 spec ×3 (type spec 4 + validator spec 6 + mapper spec 3) → **TEST-001** (Q10)
+- (Q2 cleanup) `types.ts:1-3` type alias 통합 + 11+2 호출처 일괄 치환 + MockUser.mode + DiagnosisInput/Result 의존 → **cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계)** (Q2, L6 3차 정정 트리거 §9.4)
+- (Q3 보조) DiagnosisFilters 명세 v1.0 ↔ 현실 차이 정리 → cleanup ISSUE 또는 CMD-DIAG-001~007 (§9.5)
+
+### 🔄 정정 이력 (1)
+
+- **L6 단계적 해소 체인 3차 정정** → §9 표 참조 (1차 DB-007 / 2차 API-001 / 3차 API-002 cleanup 신설 트리거)
 
 ---
 
 ## 7. 🔗 Dependencies (의존성 — 양방향)
 
-### 선행:
-- **DB-003:** `model Diagnosis` + Enum 정의
+### 선행 (이 ISSUE 시작 전 필요)
 
-### 후행:
-- **MOCK-001:** 진단 결과 Mock 데이터 — CandidateAreaDTO 구조 기반
-- **CMD-DIAG-001~007:** 진단 로직 구현 — Request/Response DTO 활용
-- **QRY-DIAG-001:** GET /api/diagnosis/[id] — GetDiagnosisResponse DTO 사용
-- **TEST-001:** 교차 진단 GWT 시나리오 — DTO 기반 테스트
+- **DB-002** (PR #76 머지 완료, main `d916a6f`): `src/lib/types/user.ts` (`ServiceModeType` TS union) — ★ B.1 `import type { ServiceModeType } from './user'` 재사용 (Q2 b 핵심).
+- **DB-003** (PR #77 머지 완료): `src/lib/types/diagnosis.ts` (7 lines, `DiagnosisStatusType` + L3-4 주석 트리거) — ★ B.1 **base append 대상 (L1-7 보존)**. 주석 트리거 완전 해소 (Q3 D + ServiceModeType import).
+- **API-001** (PR #81 머지 완료, main `ee83429`): `tasks/API-001.md` (Q1~Q10 + L6 2차 정정 + (P1) OAuthProvider=AuthProviderType 패턴) + 산출물 3 (auth.ts / auth-errors.ts / auth-error.ts). ★ 본 ISSUE 답습 기준 + L6 3차 정정 근거.
+- **DB-007** (PR #80 머지 완료): `tasks/DB-007.md` L6 1차 발견 — 본 ISSUE 3차 정정 누적 근거.
+- **DB-006** (PR #79) / **DB-004** (PR #78) / **DB-001** (PR #75): 간접 선행 (Phase 패턴 + dead 회피 논리 답습).
+
+### 후행 (이 ISSUE 완료 후 차례로 가능)
+
+- **★ CMD-DIAG-001~007**: §3.3 `createDiagnosisSchema` 신규 + N1 통합 + 명세 §3.3 정합 검증 + Filters 차이 정리 + DiagnosisErrorCode 활용
+- **★ CMD-DIAG-004** (진단 결과 서버 저장): N2 `api/diagnosis/route.ts:12, 34-46` POST 인라인 → `saveDiagnosisResult` Server Action 추출 + B.1 `CreateDiagnosisRequest` / `CreateDiagnosisResponse` import
+- **★ QRY-DIAG-001** (진단 조회): §3.5 `mapDiagnosisToDTO` 신규 + N3 통합 + B.1 `GetDiagnosisResponse` / `DiagnosisDTO` / `CandidateAreaDTO` import
+- **★ MOCK-001** (Diagnosis Mock 데이터): B.1 `CandidateAreaDTO` 3곳+ Mock + `GetDiagnosisResponse` Mock + `TimelineDTO` Mock
+- **★ TEST-001**: §3.6/3.7/3.8 + 교차 진단 GWT E2E 일괄 (vitest config + type spec 4 + validator spec 6 + mapper spec 3)
+- **★ cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계)**: L6 3차 정정 owner — types.ts:2-3 제거 + 11+2 호출처 + MockUser.mode + DiagnosisInput/Result 의존 일괄 §9.4
 
 ---
 
 ## 8. 🧪 Test Plan (검증 절차)
 
-- **단위 테스트:** `__tests__/types/diagnosis-dto.spec.ts` — 4개 케이스
-- **단위 테스트:** `__tests__/validators/diagnosis.spec.ts` — 6개 케이스
-- **단위 테스트:** `__tests__/mappers/diagnosis-mapper.spec.ts` — 3개 케이스
-- **수동 검증:** `tsc --noEmit` 통과, IDE 자동완성 정상 동작
-- **CI 게이트:** `tsc --noEmit`, Jest 100%, ESLint 통과
+### Phase A (본 ISSUE) — 사전 검증 (read-only) — ✅ 완료
+
+- ✅ A.1 main 동기화: `d1a6cba..ee83429` fast-forward (PR #81 머지본 흡수 — auth.ts + auth-errors.ts + auth-error.ts + API-001.md)
+- ✅ A.2 DB-001~007 + API-001 산출물 main 반영 확인 (`auth.ts` 5527B / `auth-errors.ts` 1624B / `auth-error.ts` 637B / `diagnosis.ts` 687B / `user.ts` 442B + 각 디렉토리 `.gitkeep`)
+- ✅ A.3 `types.ts:1-3` (Q2 가드 — AuthProvider/DiagnosisMode/DiagnosisStatus) + `diagnosis.ts` (DB-003 산출물 L1-7 + L3-4 주석 트리거) + `user.ts` (ServiceModeType/AuthProviderType/UserDTO) read-only
+- ✅ A.4 **Q2 가드 grep** — DiagnosisMode 11 호출처 (mock-calculator 3 + diagnosis-store 4 + types.ts 4) + DiagnosisStatus 1 사용 호출처 (types.ts:69) 정확 일치
+- ✅ A.5 **N1~N6 인라인 호출처 grep** — N1 validators/diagnosis.ts:8-30 (23 lines 본체, 파일 전체 47 lines) / N2 route.ts POST L12+L34-46 / N3 [id]/route.ts L13+L19-34 / N4 mock-calculator (DiagnosisMode 3) / N5 diagnosis-store (DiagnosisMode 4) / N6 detail-mapper (UI 표시용, 무관여)
+- ✅ A.6 **DiagnosisStatusType 사용처 0건 재확인** (diagnosis.ts:6 정의 only) → 본 ISSUE 가 첫 활성 (DiagnosisDTO.status + CreateDiagnosisResponse.status)
+- ✅ A.7 vitest config 부재 (vitest `^4.1.6` 의존성만 — DB-001~007 + API-001 일관)
+- ✅ A.8 `lib/constants/` + `lib/helpers/` 디렉토리 (API-001 시점 작성 후 `.gitkeep` + auth-errors.ts/auth-error.ts 존재) — Phase B 신규 파일 작성 위치 OK
+- ✅ A.9 `prisma validate` (`valid 🚀`) + `prisma generate` (7.8.0) + `tsc --noEmit` exit 0
+- ✅ A.10 env-less `npm run build` exit 0 + **Middleware 32.5 kB** (INFRA-001 AC-4 anchor, **9번째 회귀 0**)
+- ✅ A.11 `feature/API-002` 브랜치 분기 + untracked 2건 외 변경 0
+
+### Phase B (본 ISSUE) — 활성, 3 파일 신규/수정 — ✅ 완료
+
+- ✅ B.1 `lib/types/diagnosis.ts` append (DB-003 L1-7 보존 + L8~ append 115 lines, 총 121 lines — Q3 (D) re-export 3 + 부재 4 + DiagnosisDTO + DiagnosisErrorCode 8 + DiagnosisErrorDTO)
+- ✅ B.2 `lib/constants/diagnosis-errors.ts` (37 lines, DIAG_ERROR_MAP 8 키)
+- ✅ B.3 `lib/helpers/diagnosis-error.ts` (20 lines, createDiagnosisError)
+- ✅ B.4 `tsc --noEmit` exit 0 (회귀 0) + `prisma validate` exit 0 + DiagnosisMode 11 호출처 + DiagnosisStatus 2 호출처 코드 보존 (주석 텍스트 +2/+1 만 증가)
+
+### 후행 ISSUE 검증 (위임)
+
+- **CMD-DIAG-001~007**: §3.3 `createDiagnosisSchema` (N1 통합) + AC-1/AC-2/AC-4 + Filters 차이 정리
+- **QRY-DIAG-001**: §3.5 `mapDiagnosisToDTO` (N3 통합) + AC-5
+- **TEST-001**: §3.6/3.7/3.8 + 교차 진단 GWT E2E
+- **cleanup ISSUE**: types.ts:2-3 제거 + 11+2 호출처 + MockUser.mode + DiagnosisInput/Result 의존 일괄
+- **수동 검증** (CMD-DIAG / QRY-DIAG 시점):
+  1. `tsc --noEmit` 으로 DTO ↔ Zod schema z.infer ↔ Prisma model 호환 재확인
+  2. IDE 에서 `DiagnosisDTO` / `CandidateAreaDTO` 자동완성 정상 동작
+  3. Mock 모드 + 실 모드 모두 DTO 정합 확인
 
 ---
 
-## 9. 🚧 Open Questions / Risks (보류 사항)
+## 9. 🚧 Open Questions / Risks (보류 사항 — follow-up 8종 + ★ L6 단계적 해소 체인 3차 정정 표 + ★ cleanup ISSUE 신설 트리거 표)
 
-1. **CandidateArea Prisma 모델 존재 여부:** SRS ERD에 CandidateArea 별도 테이블이 명시되지 않음 — DIAGNOSIS.filters JSONB 내부에 포함할지, 별도 테이블로 분리할지 DB-003 작업 시 확정.
-2. **스코어링 기준 가중치:** §6.7 CLD ScoringEngine 기준이 상세 미정 — CMD-DIAG-003 작업 시 확정. DTO는 `score: number` 으로 추상화.
-3. **Timeline 스텝 개수:** SRS는 "≥5단계"로만 명시 — 최대 단계 수 제한이 필요한지 향후 확정.
+### ★ L6 단계적 해소 체인 3차 정정 이력 (정직 기록 — 1차/2차/3차 누적)
+
+본 ISSUE Phase A 시점 grep 호출처 분석 결과, DB-007 PR #80 본문의 L6 강화 follow-up 기록이 부정확했음을 API-001 PR #81 에서 2차 정정 + 본 ISSUE 에서 3차 cleanup ISSUE 신설 트리거 명시. 정정 경위·근거 명시 (영원히 미해소 위험 회피):
+
+| 차수 | 시점 | 기록/정정 |
+|---|---|---|
+| **1차** | DB-007 PR #80 본문 (2026-05-19) | `types.ts:87` "**UserDTO 중복** (user.ts:7-14 와 별도)" — **부정확** (실제는 MockUser interface, UserDTO 와 별 entity) |
+| **2차** | API-001 PR #81 §9 정정 (2026-05-19) | L6 = "UserDTO 중복" → **type alias DRY 위반** (AuthProvider ↔ AuthProviderType / DiagnosisMode ↔ ServiceModeType / DiagnosisStatus ↔ DiagnosisStatusType 동일 union 이름만 다름). owner 정정: **DiagnosisMode → ServiceModeType 통합 = API-002** (DB-003 commit `2ea3a17` `diagnosis.ts:4` 주석 직접 명시) / **AuthProvider + MockUser 정리 = MOCK-005** / **API-001 = (P1) OAuthProvider = AuthProviderType 재사용만 담당** |
+| **3차** | API-002 본 ISSUE (2026-05-20) | **★ cleanup ISSUE 신설 트리거 명시** — DB-003 주석 해석 A 로 본 ISSUE 가 부분 충족 (Q3 D 채택 — diagnosis.ts DTO 정의 시 ServiceModeType / DiagnosisStatusType 사용) + types.ts 가드 보존 (Q2 b) + **cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계) 신설 트리거** §9.4 명시 → 영원히 미해소 위험 회피. ★ DiagnosisStatusType 첫 활성도 동시 달성 (DB-003 commit `2ea3a17` 산출물 사용처 0건 → DiagnosisDTO.status + CreateDiagnosisResponse.status) |
+
+정정 근거: (i) grep 호출처 정량 분석 (DiagnosisMode 11 / DiagnosisStatus 2 / AuthProvider 1), (ii) DB-003 commit `2ea3a17` `diagnosis.ts:3-4` 주석 직접 인용, (iii) MockUser entity 의 4 필드 vs UserDTO 6 필드 정량 비교 (API-001 §9 누적), (iv) mock 도메인 ↔ production 도메인 분리 원칙, (v) types.ts 가드 9칸 누적 보존 사수 (Q2 b 9칸 통틀어 첫 위험 후보 → 가드 보존 첫 성공 사례).
+
+### ★ cleanup ISSUE 신설 트리거 전문 (REFACTOR-L6 또는 MOCK-005 연계, 4 항목 — 본 §9.4 가 트리거 owner)
+
+별도 cleanup ISSUE (예: **REFACTOR-L6** — 또는 **MOCK-005 연계 처리**) 신설 트리거 (본 ISSUE Phase C 시점 신설):
+
+| # | 항목 | 영향 파일·라인 | 비고 |
+|---|---|---|---|
+| **①** | `types.ts:2` `DiagnosisMode` type alias 제거 + 11 호출처 일괄 치환 → `ServiceModeType` | `types.ts:2` (정의) + `types.ts:55` (DiagnosisInput.mode) + `types.ts:66` (DiagnosisResult.mode) + `types.ts:88` (MockUser.mode) + `mock-calculator.ts:5/85/193` (3 호출처) + `diagnosis-store.ts:2/15/30/48` (4 호출처) | DM1~DM11 일괄 |
+| **②** | `types.ts:3` `DiagnosisStatus` type alias 제거 + 1 호출처 치환 → `DiagnosisStatusType` | `types.ts:3` (정의) + `types.ts:69` (DiagnosisResult.status) | DS1~DS2 일괄 |
+| **③** | `types.ts:88` `MockUser.mode` = **MOCK-005 영역 동시 처리 (분리 불가)** | types.ts:2 제거 시 L88 함께 깨짐 — MOCK-005 의 `MockUser` interface 정리와 동시 진행 | 분리 불가 |
+| **④** | `DiagnosisInput` / `DiagnosisResult` 의존 파일 동시 (mode 필드 type 변경 전파) | `use-diagnosis.ts:4,6,19` + `validators/diagnosis.ts:45` `z.infer<typeof diagnosisInputSchema>` + `result/[id]/page.tsx` | mode 타입 전파 영향 |
+
+본 §9.4 의 cleanup ISSUE 신설 트리거를 §9 별도 항목으로 두는 이유: 단순 follow-up 노트가 아닌 **신설 ISSUE 의 명세 자체** — 4 항목이 일괄 처리 불가능하면 영원히 미해소 (L6 단계적 해소 체인의 종착점).
+
+### 1. ★ §3.3 CMD-DIAG-001~007 위임 — `createDiagnosisSchema` 통합
+
+CMD-DIAG-001~007 시점에:
+- N1 `validators/diagnosis.ts:8-30` `diagnosisInputSchema` 23 lines 인라인 → 추출 또는 보존 결정
+- 명세 §3.3 `createDiagnosisSchema` 정합 검증: addressA `min(1)` (현실: "출발지 A를 입력해주세요" vs 명세 "출발지 A 주소를 입력해 주세요") + filters.maxCommuteTime 범위 (현실 10~120 vs 명세 1~180) + mode enum + deadlineDate 처리 + budget/timeRange/priorities 정리 (§9.5)
+- Route Handler L12 `safeParse` 호출처 N2 통합
+- B.1 `CreateDiagnosisRequest` (P1 re-export) import 정합 + `DiagnosisErrorCode.ADDRESS_MISSING` / `DiagnosisErrorCode.DEADLINE_DATE_PAST` 활용
+- AC-1 / AC-2 / AC-4 검증 활성 (TEST-001 시점)
+
+### 2. ★ §3.5 QRY-DIAG-001 위임 — `mapDiagnosisToDTO` 추출
+
+QRY-DIAG-001 시점에:
+- `lib/mappers/diagnosis-mapper.ts` 신규: `mapDiagnosisToDTO(diagnosis: PrismaDiagnosis, candidates: PrismaCandidateArea[]): GetDiagnosisResponse`
+- N3 `[id]/route.ts:19-34` JSON.parse + NextResponse 인라인 → mapper 추출 + 호출처 정리
+- B.1 `GetDiagnosisResponse` / `DiagnosisDTO` / `CandidateAreaDTO` 활용
+- Sentry catch (REQ-NF-035 충족) + `DiagnosisErrorCode.DIAGNOSIS_NOT_FOUND` 활용
+- AC-5 검증 활성 (TEST-001 시점)
+
+### 3. ★ §3.6/3.7/3.8 TEST-001 위임 — spec ×3 + 교차 진단 E2E
+
+TEST-001 시점에:
+- `vitest.config.ts` 신규 (DB-001~007 §3.10 + API-001 §3.7/3.8 + 본 ISSUE §3.6/3.7/3.8 일괄 위임 누적 해소)
+- `__tests__/types/diagnosis-dto.spec.ts` 4 케이스 (DiagnosisDTO 필수 필드 / CandidateAreaDTO=CandidateArea re-export 정합 / DiagnosisErrorCode 전수 매핑 / DiagnosisStatusType union 범위)
+- `__tests__/validators/diagnosis.spec.ts` 6 케이스 (정상 / 주소 누락 / mode 잘못 / 과거 deadline / maxCommuteTime 범위 / 빈 filters)
+- `__tests__/mappers/diagnosis-mapper.spec.ts` 3 케이스
+- `__tests__/helpers/diagnosis-error.spec.ts` 3 케이스 (createDiagnosisError 정상 / originalError 포함 / 모든 코드 매핑 존재) — 명세 v1.0 부재, API-001 helper spec 패턴 추가
+- 교차 진단 GWT E2E (REQ-FUNC-003 통합 — `/diagnosis` 입력 → `/api/diagnosis` POST → 후보 ≥3 → `/diagnosis/result/[id]` 렌더)
+
+### 4. ★ L6 3차 정정 — cleanup ISSUE 신설 트리거 (위 표 참조)
+
+별도 cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계) 4 항목 일괄 처리 — 위 §9.4 표 (★ cleanup ISSUE 신설 트리거 전문) 참조. 본 §9 항목은 트리거 owner — 단순 follow-up 이 아닌 **신설 ISSUE 의 명세 자체** 임을 §9 본문에서 명시.
+
+### 5. ★ DiagnosisFilters 명세 v1.0 ↔ 현실 필드 차이 (Q3 보조 follow-up)
+
+현실 `types.ts:37-42` `DiagnosisFilters` 4 필드:
+- `maxCommuteTime?: number` ✓ 명세와 일치
+- `budget?: { min: number; max: number }` ↔ 명세 `budgetMin?: number / budgetMax?: number` (**객체 vs 분리 필드 차이**)
+- `timeRange?: "morning" | "evening" | "flexible"` ↔ 명세 `timeSlot?: string` ("07:00" 형식) (**enum vs 자유 string 차이**)
+- `priorities?: string[]` ↔ 명세 **부재** (현실 추가 필드)
+
+본 ISSUE 결정: 현실 추인 (`import type { DiagnosisFilters } from '../types'` only — re-export 안 함). cleanup ISSUE 또는 CMD-DIAG-001~007 시점에 정합 결정 (현실 채택 + 명세 v1.0 갱신 vs 명세 정합으로 현실 마이그). 9칸 "이름같고 필드다름→현실추인+차이기록" 패턴 일관 (DB-006 SavedSearch searchParams 동일).
+
+### 6. ★ 47줄/23줄 정정 (Phase A 보너스 발견)
+
+메모리 `project-api002-resume` §3.3 + 가드 표기 "**47 lines**" = `validators/diagnosis.ts` **파일 전체** 47 lines 기준 (`diagnosisInputSchema` 23 lines + `shareLinkInputSchema` ~7 lines + `shareAccessSchema` ~3 lines + import + z.infer 2 종 등 합산). 실제 `diagnosisInputSchema` **본체는 L8-30 = 23 lines**. Phase A 시점 grep 으로 정확 측정 → 본 명세에 정정 기록 (정직성). CMD-DIAG-001~007 시점 N1 통합 시 23 lines 본체만 대상 (shareLink* 2 종은 SHARE 도메인 — CMD-SHARE 영역).
+
+### 7. ★ L6 단계적 해소 체인 (1/2/3차) (§9 본문 표 참조)
+
+위 §9 본문 "L6 단계적 해소 체인 3차 정정 이력" 표 참조. 1차 (DB-007 부정확) → 2차 (API-001 정정 + owner 정정) → 3차 (API-002 cleanup ISSUE 신설 트리거) 누적 정직 기록.
+
+### 8. ★ DiagnosisStatusType 첫 활성 (DB-003 위임 체인 작동 증거)
+
+DB-003 commit `2ea3a17` 시점 `DiagnosisStatusType` 정의 + L3-4 주석 ("API-002 가 DTO 정의 시 ServiceModeType 사용") → 사용처 0건 (정의만, A.6 확인) → 본 ISSUE 가 `DiagnosisDTO.status` + `CreateDiagnosisResponse.status` 에서 첫 사용 활성. DB-003 위임 체인 (DB → API → CMD/QRY) 의 작동 증거 — Wave 1 DB 도메인 산출물이 Wave 2 API Contract 트랙에서 정상 활성됨을 입증.
+
+### 추가 보조 (명세 §9 v1.0 보존)
+
+- **CandidateArea Prisma 모델 존재 여부**: SRS ERD 에 CandidateArea 별도 테이블 미명시 — 현재 DIAGNOSIS.candidates JSONB 인라인 (N2 `prisma.diagnosis.create` L40 `JSON.stringify(candidates)`). 별도 테이블 분리는 INFRA-002 Postgres 마이그 시점 결정.
+- **스코어링 기준 가중치**: §6.7 CLD ScoringEngine 기준 상세 미정 — CMD-DIAG-003 작업 시 확정. DTO 는 `score: number` 으로 추상화 (B.1 CandidateArea L28 활용).
+- **Timeline 스텝 개수**: SRS "≥5단계" 만 명시 — 최대 단계 수 제한 향후 확정 (CMD-DIAG-005 Timeline 영역).
+- **CommuteInfo 필드명 차이 (명세 v1.0 ↔ 현실)**: 명세 `durationMinutes` + `transportType: 'transit' | 'car'` + `transfers` + `walkingMinutes` (4 필드) vs 현실 `time` + `mode: 'transit' | 'driving'` + `transfers?` (3 필드) — 본 ISSUE re-export 로 현실 채택 (CommuteInfoDTO = CommuteInfo). 명세 v1.0 갱신은 CMD-DIAG / QRY-DIAG 시점.
+- **CandidateArea 필드 superset (명세 v1.0 ↔ 현실)**: 명세 7 필드 (id+name+coord+commuteA+commuteB+score+rank) vs 현실 15 필드 (Step 10.5 풍부 — dong+gu+coordinate+commuteA+commuteB?+leisureA?+leisureB?+score+safetyGrade?+priceRange?+facilities?+lines?+listingsCount?+avgArea?) — 본 ISSUE re-export 로 현실 superset 노출.


### PR DESCRIPTION
## 📌 Summary

API Contract 트랙 두 번째 진입 — Diagnosis 도메인 DTO + DiagnosisErrorCode 8 종 + DIAG_ERROR_MAP + createDiagnosisError helper 추가. **API-001 (B) 절충 패턴 정확 답습** (Phase B 활성 + 커밋 2개 feat+docs 분리). 

**산출물:** 신규 3 코드 + 명세 1 갱신 = 4 파일. 위임 4 (Zod/mapper/spec/cleanup) + 정정 1 (L6 3차).

**Refs #12** (자동 닫힘 방지)

---

## 🎯 산출물 요약

| # | 파일 | 라인 | 내용 |
|---|---|---|---|
| **B.1** | `onday-app/src/lib/types/diagnosis.ts` | DB-003 보존 7 + append 115 = **121** | (P1) re-export 3 + 부재 4 신규 + DiagnosisDTO + DiagnosisErrorCode 8 종 + DiagnosisErrorDTO |
| **B.2** | `onday-app/src/lib/constants/diagnosis-errors.ts` | **37** | DIAG_ERROR_MAP 8 키 |
| **B.3** | `onday-app/src/lib/helpers/diagnosis-error.ts` | **20** | createDiagnosisError(code, originalError?) |
| **C** | `tasks/API-002.md` | 256 → **454** | 명세 현실 동기화 |

---

## ★ Q2 가드 사수 표 (9칸 통틀어 가장 위험한 판단 — 첫 성공 사례)

DiagnosisMode 11 호출처 + DiagnosisStatus 2 호출처 본 ISSUE 0 치환 (`types.ts:1-3` 무수정 + cleanup ISSUE 위임).

| # | 위치 | 라인 | 역할 | 본 ISSUE | cleanup 통합 |
|---|---|---|---|---|---|
| DM1 | types.ts | L2 | DiagnosisMode 정의 | 미수정 | 제거 |
| DM2-DM4 | types.ts | L55/66/88 | DiagnosisInput/Result/MockUser.mode | 미수정 | ServiceModeType |
| DM5-DM7 | mock-calculator.ts | L5/85/193 | import + parameter ×2 | 미수정 | cleanup |
| DM8-DM11 | diagnosis-store.ts | L2/15/30/48 | import + state + action + initial | 미수정 | cleanup |
| DS1 | types.ts | L3 | DiagnosisStatus 정의 | 미수정 | 제거 |
| DS2 | types.ts | L69 | DiagnosisResult.status | 미수정 | DiagnosisStatusType |

**합계: DiagnosisMode 11 + DiagnosisStatus 2 = 13 호출처 0 치환** (코드 grep 검증, 주석 텍스트 +2/+1 만 증가).

---

## ★ Q3 (D) re-export 패턴 (API-001 P1 OAuthProvider=AuthProviderType 답습 — 신규 type alias 정의 금지)

\`\`\`typescript
import type { ServiceModeType } from './user';
import type { CandidateArea, CommuteInfo, DiagnosisFilters, DiagnosisInput } from '../types';

export type CandidateAreaDTO = CandidateArea;       // Step 10.5 풍부 15 필드 superset
export type CommuteInfoDTO = CommuteInfo;
export type CreateDiagnosisRequest = DiagnosisInput;  // Figma 비전 leisure 4 필드 superset
\`\`\`

★ **DB-003 commit \`2ea3a17\` 주석 트리거 완전 해소**: \`diagnosis.ts:3-4\` "DTO 정의 시 \`import { ServiceModeType } from './user'\` 패턴" 충족 + **DiagnosisStatusType 첫 활성** (사용처 0건 → DiagnosisDTO.status + CreateDiagnosisResponse.status).

---

## ★ N1~N6 인라인 호출처 (본 ISSUE 미수정 — DB-006 Q3 / API-001 mock-auth M1~M4 패턴)

| # | 위치 | 역할 | 후행 |
|---|---|---|---|
| **N1** | validators/diagnosis.ts:8-30 | diagnosisInputSchema 23 lines 본체 (파일 전체 47 lines) | CMD-DIAG-001~007 |
| **N2** | api/diagnosis/route.ts:12, 34-46 | POST safeParse + prisma.create 인라인 | CMD-DIAG-004 |
| **N3** | api/diagnosis/[id]/route.ts:13, 19-34 | GET findUnique + JSON.parse + NextResponse 인라인 mapper | QRY-DIAG-001 |
| **N4** | mock-calculator.ts | DiagnosisMode 3 호출처 | cleanup ISSUE |
| **N5** | diagnosis-store.ts | DiagnosisMode 4 호출처 | cleanup ISSUE |
| **N6** | detail-mapper.ts | UI 표시용 (§3.5 API mapper 별 영역) | 무관여 |

---

## ★ 부재 산출물 (위임 5종)

| 명세 §3 | 현실 | 위임 |
|---|---|---|
| §3.3 createDiagnosisSchema | N1 인라인 동작 중 + filters 차이 | **CMD-DIAG-001~007** |
| §3.5 mapDiagnosisToDTO | N3 인라인 동작 중 + lib/mappers/ 빈 | **QRY-DIAG-001** |
| §3.6 type spec 4 | vitest config 부재 | **TEST-001** |
| §3.7 validator spec 6 | 동상 | **TEST-001** |
| §3.8 mapper spec 3 | 동상 | **TEST-001** |

---

## ★ L6 3차 cleanup ISSUE 신설 트리거 전문 (REFACTOR-L6 또는 MOCK-005 연계, 4 항목 — 본 PR §9.4 가 트리거 owner)

| # | 항목 | 영향 파일·라인 |
|---|---|---|
| **①** | types.ts:2 DiagnosisMode 제거 + 11 호출처 → ServiceModeType | types.ts L2/55/66/88 + mock-calculator.ts L5/85/193 + diagnosis-store.ts L2/15/30/48 |
| **②** | types.ts:3 DiagnosisStatus 제거 + 1 호출처 → DiagnosisStatusType | types.ts L3/69 |
| **③** | types.ts:88 MockUser.mode = **MOCK-005 영역 동시 (분리 불가)** | types.ts:2 제거 시 L88 함께 깨짐 |
| **④** | DiagnosisInput/DiagnosisResult 의존 동시 | use-diagnosis.ts:4,6,19 + validators/diagnosis.ts:45 z.infer + result/[id]/page.tsx |

★ **단순 follow-up 아닌 "신설 ISSUE 의 명세 자체"** — 4 항목 일괄 처리 불가 시 영원히 미해소 위험 회피.

---

## ★ L6 단계적 해소 체인 1/2/3차 (정직 기록)

| 차수 | 시점 | 기록/정정 |
|---|---|---|
| **1차** | DB-007 PR #80 본문 (2026-05-19) | "types.ts:87 UserDTO 중복" — **부정확** (실제 MockUser interface) |
| **2차** | API-001 PR #81 §9 (2026-05-19) | 정정: type alias DRY 위반. owner 정정 (DiagnosisMode=API-002 / AuthProvider+MockUser=MOCK-005) |
| **3차** | API-002 본 PR (2026-05-20) | **★ cleanup ISSUE 신설 트리거 명시** — DB-003 주석 부분 충족 + types.ts 가드 보존 + DiagnosisStatusType 첫 활성 |

**정정 근거 5종:** (i) grep 호출처 정량 (DiagnosisMode 11 / DiagnosisStatus 2 / AuthProvider 1), (ii) DB-003 commit \`2ea3a17\` 주석 직접 인용, (iii) MockUser 4 필드 vs UserDTO 6 필드 정량, (iv) mock ↔ production 분리, (v) 9칸 가드 누적 보존 사수.

---

## ★ DiagnosisFilters 명세 v1.0 ↔ 현실 차이 (Q3 보조, §9.5)

| 필드 | 명세 v1.0 | 현실 | 처리 |
|---|---|---|---|
| maxCommuteTime | ✓ | ✓ | 일치 |
| budget | budgetMin/Max (분리 필드) | { min, max } (객체) | 현실 추인 |
| timeRange/Slot | timeSlot string "07:00" | timeRange enum (morning/evening/flexible) | 현실 추인 |
| priorities | (부재) | string[] 추가 | 현실 추가 |

→ 본 ISSUE: 현실 추인 (import only, re-export 안 함). cleanup ISSUE 또는 CMD-DIAG-001~007 시점 정합 결정. **9칸 "이름같고 필드다름→현실추인+차이기록" 패턴 일관** (DB-006 SavedSearch searchParams 답습).

---

## ★ 47줄/23줄 정정 (Phase A 보너스, §9.6)

메모리/grill 표기 "47 lines" = \`validators/diagnosis.ts\` **파일 전체** 47 lines (diagnosisInputSchema 23 + shareLinkInputSchema 7 + shareAccessSchema 3 + import + z.infer 등 합산). 실제 \`diagnosisInputSchema\` **본체 = L8-30 = 23 lines**. CMD-DIAG-001~007 시점 N1 통합 시 23 lines 본체만 대상 (shareLink* 2 종 = CMD-SHARE 영역).

---

## §9 follow-up 8종

1. §3.3 Zod = CMD-DIAG-001~007 (N1 + Filters 차이 + AC-1/2/4)
2. §3.5 mapper = QRY-DIAG-001 (N3 + AC-5)
3. §3.6/3.7/3.8 spec + helper spec + 교차 진단 GWT E2E = TEST-001 (vitest config + DB-001~007 + API-001 누적 해소)
4. L6 3차 cleanup ISSUE 신설 트리거 (위 4 항목)
5. DiagnosisFilters 명세 v1.0 ↔ 현실 차이
6. 47줄/23줄 정정 (Phase A 보너스)
7. L6 단계적 해소 체인 1/2/3차 (정정 근거 5종)
8. **DiagnosisStatusType 첫 활성 (DB-003 위임 체인 작동 증거 — Wave 1 DB → Wave 2 API Contract 활성 입증)**

+ 추가 보조 4종 (명세 §9 v1.0 보존): CandidateArea Prisma model / 스코어링 가중치 / Timeline 스텝 / CommuteInfo + CandidateArea 필드 superset 차이

---

## ✅ 검증 결과

| 검증 | 결과 | 비고 |
|---|---|---|
| npx prisma validate | ✅ exit 0 | valid 🚀 |
| npx prisma generate | ✅ exit 0 | Prisma Client 7.8.0 |
| npx tsc --noEmit | ✅ exit 0 | 회귀 0, Phase B 기준선 유지 |
| env-less npm run build | ✅ exit 0 | — |
| **ƒ Middleware** | ✅ **32.5 kB** | INFRA-001 AC-4 — **9번째 회귀 0** (INFRA-001/DB-001~007/API-001/API-002) |
| User 모델 password grep | ✅ 0건 | DB-002/004 AC-6 일관 (ShareLink.passwordHash 는 별 모델) |
| 가드 무수정 (5 그룹) | ✅ 0 lines | types.ts / N1~N6 + mock-auth M1~M4 / API-001 산출물 3 / DB-001~007 12 / diagnosis.ts L1-7 |

---

## 📂 격리 검증

\`\`\`
M  onday-app/src/lib/types/diagnosis.ts        (+115/-0, DB-003 L1-7 보존 append)
A  onday-app/src/lib/constants/diagnosis-errors.ts  (+37, 신규)
A  onday-app/src/lib/helpers/diagnosis-error.ts     (+20, 신규)
M  tasks/API-002.md                            (+372/-173, 256 → 454 lines)
\`\`\`

untracked 2건 (\`.agents/skills\`, \`tasks/ISSUE_REGISTER_LOG.md\`) staging 안 함.

---

## 🔗 명세 문서

[tasks/API-002.md](../blob/feature/API-002/tasks/API-002.md) — Q1~Q10 mismatch 추적 표 11행 + Q2 가드 사수 표 13행 + N1~N6 + 부재 산출물 + L6 3차 cleanup 트리거 4항목 + L6 체인 1/2/3차 + §9 follow-up 8종

## 🔀 커밋 (2개 분리 — API-001 패턴 정확 답습)

- \`34ce730\` feat(API-002): 신규 3 코드 파일 (172 insertions)
- \`7d95f93\` docs(API-002): tasks/API-002.md 명세 동기화 (+372/-173)

★ 머지·Issue #12 닫기는 PR 보고 직접 결정 (자동 머지 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)