### PR TITLE
[Feature] API-003: ShareLink DTO 명세 현실 동기화 + 3 파일 신규 (share-link.ts 신규 첫 owner + ★ Wave 2 체인 작동 첫 코드 입증 + S3+S4 dual mapper QRY-SHARE-001 단일 owner)

### DIFF
--- a/onday-app/src/lib/constants/share-link-errors.ts
+++ b/onday-app/src/lib/constants/share-link-errors.ts
@@ -1,0 +1,33 @@
+import { ShareLinkErrorCode, type ShareLinkErrorDTO } from '@/lib/types/share-link';
+
+/** ShareLinkErrorCode → 사용자 메시지·HTTP 상태 매핑 (7 키 — code/originalError 는 createShareLinkError 가 채움) */
+export const SHARE_LINK_ERROR_MAP: Record<ShareLinkErrorCode, Omit<ShareLinkErrorDTO, 'code' | 'originalError'>> = {
+  [ShareLinkErrorCode.LINK_EXPIRED]: {
+    message: '이 링크는 만료되었습니다. 진단을 공유한 분께 새 링크를 요청해 주세요.',
+    httpStatus: 410,
+  },
+  [ShareLinkErrorCode.LINK_NOT_FOUND]: {
+    message: '공유 링크를 찾을 수 없어요. 링크가 올바른지 확인해 주세요.',
+    httpStatus: 404,
+  },
+  [ShareLinkErrorCode.DIAGNOSIS_NOT_FOUND]: {
+    message: '진단 결과를 찾을 수 없어요. 원본 진단이 삭제됐을 수 있어요.',
+    httpStatus: 404,
+  },
+  [ShareLinkErrorCode.PASSWORD_REQUIRED]: {
+    message: '이 공유 링크는 비밀번호로 보호돼 있어요. 비밀번호를 입력해 주세요.',
+    httpStatus: 401,
+  },
+  [ShareLinkErrorCode.PASSWORD_MISMATCH]: {
+    message: '비밀번호가 일치하지 않아요. 다시 확인해 주세요.',
+    httpStatus: 401,
+  },
+  [ShareLinkErrorCode.PREVIEW_EXHAUSTED]: {
+    message: '무료 미리보기 1곳을 모두 확인했어요. 전체 리포트는 진단을 공유한 분의 안내를 따라 주세요.',
+    httpStatus: 403,
+  },
+  [ShareLinkErrorCode.UNAUTHORIZED_ACCESS]: {
+    message: '이 리포트를 열람할 권한이 없어요.',
+    httpStatus: 403,
+  },
+};

--- a/onday-app/src/lib/helpers/share-link-error.ts
+++ b/onday-app/src/lib/helpers/share-link-error.ts
@@ -1,0 +1,20 @@
+import { ShareLinkErrorCode, type ShareLinkErrorDTO } from '@/lib/types/share-link';
+import { SHARE_LINK_ERROR_MAP } from '@/lib/constants/share-link-errors';
+
+/**
+ * ShareLinkErrorDTO 생성 헬퍼.
+ * SHARE_LINK_ERROR_MAP 에서 사용자 메시지·HTTP 상태를 lookup 한 뒤 originalError 를 합쳐 반환.
+ * Sentry catch 와 연계 가능 (REQ-NF-035) — originalError 필드로 원본 에러 메시지 전달.
+ */
+export function createShareLinkError(
+  code: ShareLinkErrorCode,
+  originalError?: string,
+): ShareLinkErrorDTO {
+  const mapped = SHARE_LINK_ERROR_MAP[code];
+  return {
+    code,
+    message: mapped.message,
+    httpStatus: mapped.httpStatus,
+    originalError,
+  };
+}

--- a/onday-app/src/lib/types/share-link.ts
+++ b/onday-app/src/lib/types/share-link.ts
@@ -1,0 +1,129 @@
+// ──────────────────────────────────────────────
+// API-003 ShareLink 도메인 DTO (★ 신규 첫 owner — DB-002/003 와 다름, DB-004 base type 0)
+//
+// ★ Q3 (C) hybrid strategy:
+//   - mode: ServiceModeType 재사용 (Q2 (A) — DiagnosisMode 미사용, 9칸 가드 보존)
+//   - candidates: CandidateAreaDTO[] (★ API-002 (P1) 산출물 첫 외부 활용 = Wave 2 체인 작동 증거)
+//   - Prisma model import 0 (관심사 분리, API-001/002 일관)
+//   - (P1) re-export 패턴 적용 불가 (DB-004 base 0) — 자기 도메인 type 신규 정의 정상
+// ──────────────────────────────────────────────
+
+import type { ServiceModeType } from './user';
+import type { CandidateAreaDTO } from './diagnosis';
+
+// ──────────────────────────────────────────────
+// 1. Request DTO
+// ──────────────────────────────────────────────
+
+/** POST /api/share — 공유 링크 생성 요청 */
+export interface CreateShareLinkRequest {
+  diagnosisId: string;
+  password?: string;
+}
+
+/** POST /api/share/[uuid]/verify — 비밀번호 검증 요청 */
+export interface VerifyPasswordRequest {
+  token: string;
+  password: string;
+}
+
+// ──────────────────────────────────────────────
+// 2. Response DTO
+// ──────────────────────────────────────────────
+
+/** POST /api/share 응답 — shareUrl + 30일 만료 + 비밀번호 설정 여부 */
+export interface CreateShareLinkResponse {
+  shareUrl: string;
+  expiresAt: string;
+  hasPassword: boolean;
+}
+
+/** GET /api/diagnosis/[id]/report 응답 — 리포트 + 데이터 출처 + 공유 링크 메타 */
+export interface GetReportResponse {
+  report: ReportDTO;
+  sources: DataSourceDTO[];
+  shareLink: ShareLinkMetaDTO;
+}
+
+/** POST /api/share/[uuid]/verify 응답 */
+export interface VerifyPasswordResponse {
+  verified: boolean;
+  error?: ShareLinkErrorCode;
+}
+
+// ──────────────────────────────────────────────
+// 3. Report DTO (mode=ServiceModeType — Q2 (A), candidates=CandidateAreaDTO[] — API-002 (P1) 첫 외부 활용)
+// ──────────────────────────────────────────────
+
+/**
+ * 공유 리포트 본체.
+ * mode: Q2 (A) — types.ts DiagnosisMode 가 아니라 user.ts ServiceModeType 사용 (Q2 가드 보존).
+ * candidates: API-002 (P1) `CandidateAreaDTO = CandidateArea` re-export 첫 외부 활용 (Wave 2 API-001→API-002→API-003 체인 작동 증거).
+ * previewCandidateId: §9.1 follow-up — 선정 로직 CMD-SHARE/QRY-SHARE 위임 (스코어 1위 자동 vs 사용자 선택).
+ */
+export interface ReportDTO {
+  diagnosisId: string;
+  candidates: CandidateAreaDTO[];
+  mode: ServiceModeType;
+  createdAt: string;
+  freePreviewUsed: boolean;
+  previewCandidateId: string | null;
+}
+
+// ──────────────────────────────────────────────
+// 4. Data Source DTO (§9.6 follow-up — 목록은 UI-007 영역)
+// ──────────────────────────────────────────────
+
+export interface DataSourceDTO {
+  name: string;
+  type: 'public_data' | 'api' | 'static';
+  lastUpdated: string;
+}
+
+// ──────────────────────────────────────────────
+// 5. ShareLink Meta DTO
+// ──────────────────────────────────────────────
+
+/**
+ * 공유 링크 메타 정보.
+ * isExpired: runtime 계산 필드 — mapper QRY-SHARE-001 위임 + DB-004 §9.1 isShareLinkExpired = CMD-SHARE-001 영역. 본 ISSUE = DTO contract only.
+ */
+export interface ShareLinkMetaDTO {
+  id: string;
+  uniqueUrl: string;
+  viewCount: number;
+  expiresAt: string;
+  isExpired: boolean;
+  hasPassword: boolean;
+  freePreviewUsed: boolean;
+}
+
+// ──────────────────────────────────────────────
+// 6. Error Code (7 종, API-001 9종 / API-002 8종 패턴 답습)
+// ──────────────────────────────────────────────
+
+/** 공유 링크 도메인 에러 코드 (7 종) */
+export enum ShareLinkErrorCode {
+  // 만료 1
+  LINK_EXPIRED = 'SHARE_LINK_EXPIRED',
+
+  // 조회 2
+  LINK_NOT_FOUND = 'SHARE_LINK_NOT_FOUND',
+  DIAGNOSIS_NOT_FOUND = 'SHARE_DIAGNOSIS_NOT_FOUND',
+
+  // 비밀번호 2
+  PASSWORD_REQUIRED = 'SHARE_PASSWORD_REQUIRED',
+  PASSWORD_MISMATCH = 'SHARE_PASSWORD_MISMATCH',
+
+  // 권한 2
+  PREVIEW_EXHAUSTED = 'SHARE_PREVIEW_EXHAUSTED',
+  UNAUTHORIZED_ACCESS = 'SHARE_UNAUTHORIZED_ACCESS',
+}
+
+/** 공유 링크 도메인 에러 응답 DTO */
+export interface ShareLinkErrorDTO {
+  code: ShareLinkErrorCode;
+  message: string;
+  httpStatus: number;
+  originalError?: string;
+}

--- a/tasks/API-003.md
+++ b/tasks/API-003.md
@@ -1,20 +1,37 @@
 ---
 name: Feature Task
-title: "[Feature] API-003: ShareLink 도메인 Request/Response DTO"
+title: "[Feature] API-003: ShareLink 도메인 DTO 명세 현실 동기화 + 3 파일 신규 (API Contract 트랙 세 번째, API-001/002 (B) 절충 답습 + ★ share-link.ts 신규 첫 owner (DB-004 base type 0, P1 적용 불가) + ★ API-002 (P1) CandidateAreaDTO 첫 외부 활용 (Wave 2 체인 작동 첫 코드 입증) + ★ S3+S4 dual mapper 패턴 (QRY-SHARE-001 단일 owner 신규 명시) + Q2 가드 2회째 사수 + API-002 §9.6 트리거 수신)"
 labels: ['feature', 'priority:M', 'epic:API Contract', 'wave:2']
 assignees: []
 ---
 
 ## 1. 🎯 Summary
 
-- **기능명:** [API-003] ShareLink 도메인 Request/Response DTO 정의 — createShareLink(), GET /api/diagnosis/[id]/report
+- **기능명:** [API-003] ShareLink 도메인 Request/Response DTO 정의 — createShareLink() / GET /api/diagnosis/[id]/report 의 통신 계약 + ShareLinkErrorCode (7 종) + SHARE_LINK_ERROR_MAP + createShareLinkError helper. ★ **API Contract 트랙 세 번째 진입** (Wave 2 — API-001 PR #81 + API-002 PR #82 직후). 본 ISSUE 산출물 = **신규 3 코드 + 명세 1 파일 갱신** + **커밋 2개 (feat + docs 분리, API-001/002 패턴 정확 답습)**. Zod (§3.3) + mapper (§3.5) + spec (§3.6/3.7/3.8) + DB-004 §9.1 helper 는 호출처 인라인 동작 중 / 영역 분리 원칙 (DB-006 Q3 / API-001 Q6 / API-002 Q8/Q9 일관) 으로 위임. ★ **share-link.ts 신규 첫 owner** — DB-004 산출물 = 코드 0 (Q7/Q8 결정 명세만), DB-002 (user.ts) / DB-003 (diagnosis.ts) 와 달리 base type 부재 → API-003 가 신규 정의 진입점. **(P1) re-export 패턴 적용 자체 불가** (base 0). ★ **API-002 (P1) CandidateAreaDTO 첫 외부 활용 = Wave 2 API-001→API-002→API-003 체인 작동 첫 코드 입증** (Wave 1→Wave 2 DiagnosisStatusType 첫 활성 패턴 답습 + Wave 2 내부 체인 확장). ★ **S3+S4 dual mapper 패턴 신규 명시** — Route Handler (`api/share/[uuid]/route.ts` 61줄) + SSR (`app/share/[uuid]/page.tsx` 76줄) 양쪽 인라인. **QRY-SHARE-001 단일 owner 통합 (mapper 분리 금지)** — 미래 작업자 가이드. API-001/002 single inline 과 다른 신규 패턴. ★ **Q2 가드 2회째 사수** — `types.ts:1-3` 무수정 + DiagnosisMode 11 + DiagnosisStatus 2 호출처 본 ISSUE 미치환 + DiagnosisMode forward 2 호출처 (page.tsx:42 + route.ts:49) cleanup ISSUE 의존성 약함. ★ **API-002 §9.6 정정 트리거 수신** — "validators/diagnosis.ts 47줄 = 파일 전체, shareLink* 2종 = CMD-SHARE 영역" → 본 ISSUE 가 CMD-SHARE-001 §3.3 위임으로 받음.
 - **목적 (Why):**
-  - **비즈니스:** 배우자 공유 링크의 생성·열람 API 계약을 확립하여, 공유 링크 생성(CMD-SHARE)과 SSR 리포트 열람(QRY-SHARE) 구현의 타입 기반을 마련한다.
-  - **사용자 가치:** 공유 링크 생성·만료·비밀번호 검증·무료 미리보기 시나리오가 명확한 타입으로 정의되어, 예측 가능한 공유 경험을 제공한다.
+  - **비즈니스:** 배우자 공유 링크 (F2) 의 API 통신 계약 (Request/Response DTO + 에러 매핑 + helper) 을 단일 진실 공급원 (SSoT) 으로 확립하여, 후속 공유 링크 Command·Query 태스크 (CMD-SHARE-001~004 + QRY-SHARE-001 + MOCK-002 + TEST-003/004 + UI-007) 가 일관된 타입으로 import 한다. ★ API Contract 트랙 = **DTO 정의 자체가 본 ISSUE 의 owner** → docs only 시 빈 contract 로 Wave 2 진입 의미 상실. ★ 단 Zod (`createShareLinkSchema` / `verifyPasswordSchema`) + mapper (`mapShareLinkToMeta` + `mapToReportResponse`) 는 현재 인라인 동작 중 (`validators/diagnosis.ts:32-43` shareLinkInputSchema + shareAccessSchema 23 lines + Route Handler L13 호출처 활성 / `api/share/[uuid]/route.ts:12-54` + `app/share/[uuid]/page.tsx:15-?` **dual 인라인 mapper**) → 본 ISSUE 가 추출 시 동작 중 인라인 가드 위반 + S3+S4 dual 우회 (DB-006 Q3 / API-002 §3.5 인라인 보존 패턴 답습). spec 도 vitest config 부재 (DB-001~007 + API-001/002 일관) → TEST-003/004 위임. ★ **(P1) 패턴 미묘 구분 명시** — API-001 OAuthProvider=AuthProviderType / API-002 CandidateAreaDTO=CandidateArea (둘 다 base 존재 = (P1) 적용) vs **API-003 share-link.ts** (DB-004 base 0 = (P1) 적용 불가, 자기 도메인 type 신규 정의 정상). "(P1) 정신 = 기존 도메인 entity 재사용이지 Prisma 직접 노출이 아님" — 향후 새 도메인 type 만드는 ISSUE 가이드. ★ Q2 (A) — ReportDTO.mode = ServiceModeType (`from './user'`) 사용 (DiagnosisMode 미사용, 9칸 가드 보존). DiagnosisMode forward 2 호출처 (page.tsx:42 `as` cast + route.ts:49) cleanup ISSUE 의존성 약함 확인.
+  - **사용자 가치:** 진단 결과를 배우자에게 안전하게 공유하고, 만료·비밀번호·열람 횟수·무료 미리보기 시나리오가 명확한 타입으로 정의되어 예측 가능한 공유 경험을 제공한다 — Mock 환경에서는 `validators/diagnosis.ts` Zod + `api/share/route.ts` POST + `api/share/[uuid]/route.ts` GET + `app/share/[uuid]/page.tsx` SSR 가 정상 동작 중, 실 환경에서는 CMD-SHARE-001~004 + QRY-SHARE-001 시점 활성.
 - **범위 (What):**
-  - ✅ 만드는 것: createShareLink Request/Response DTO, 리포트 조회 Response DTO, ShareLink 에러 코드, Zod 스키마, 변환 함수
-  - ❌ 만들지 않는 것: 공유 링크 CRUD 로직(CMD-SHARE 범위), 결제 관련 타입
-- **복잡도:** M
+  - ✅ 만드는 것 (신규 3 코드 파일 + 명세 1 파일):
+    - **`onday-app/src/lib/types/share-link.ts`** (신규 129 lines, **DB-002/003 와 달리 base type 0 → 신규 첫 owner**) — §3.1 6섹션 (Request 2 + Response 3 + ReportDTO + DataSourceDTO + ShareLinkMetaDTO + ShareLinkErrorCode 7종 + ShareLinkErrorDTO). **import 부 정확 2 (정직 기록): `import type { ServiceModeType } from './user'` + `import type { CandidateAreaDTO } from './diagnosis'` — Prisma 0, types.ts DiagnosisMode/DiagnosisStatus 0**.
+    - **`onday-app/src/lib/constants/share-link-errors.ts`** (신규 33 lines) — §3.4 `SHARE_LINK_ERROR_MAP` (7 키 × {message, httpStatus}).
+    - **`onday-app/src/lib/helpers/share-link-error.ts`** (신규 20 lines) — `createShareLinkError(code, originalError?)` helper (API-001 §3.6 / API-002 §3.6 createXError 패턴 일관).
+    - **`tasks/API-003.md`** — 본 명세 현실 동기화 (Q1~Q10 + (P1) 미묘 구분 § + Q2 가드 사수 표 15행 + S1~S6 + dual mapper § + Wave 2 체인 작동 증거 § + API-002 §9.6 트리거 수신 § + §9 follow-up 6+).
+  - ❌ 만들지 않는 것 (인라인 동작 중 dead 회피 + Q2 가드 + 영역 분리 + DB-004 §9.1 = CMD-SHARE-001):
+    - `lib/validators/share-link.ts` 신규 또는 `validators/diagnosis.ts:32-43` 수정 (§3.3 `createShareLinkSchema` 명세 vs 현실 `shareLinkInputSchema`) — **CMD-SHARE-001 위임** (S1 인라인 동작 중 + Route Handler L13 호출처 활성 + ★ API-002 §9.6 트리거 수신, DB-006 Q3 / API-002 Q8 인라인 보존 패턴 답습)
+    - `lib/mappers/share-link-mapper.ts` (§3.5 `mapShareLinkToMeta` + `mapToReportResponse`) — **QRY-SHARE-001 단일 owner 위임** (★ S3+S4 dual 인라인 — Route Handler `api/share/[uuid]/route.ts:12-54` + SSR `app/share/[uuid]/page.tsx:15-?` 양쪽 동작 중. mapper 분리 금지 — 단일 owner 통합)
+    - `__tests__/types/share-link-dto.spec.ts` + `__tests__/validators/share-link.spec.ts` + `__tests__/mappers/share-link-mapper.spec.ts` — **TEST-003 (GWT) + TEST-004 (보안) 분배 위임** (vitest config 부재)
+    - **DB-004 §9.1 helper** (`calculateExpiresAt` + `isShareLinkExpired` + `generateShareLinkToken`) — **CMD-SHARE-001 영역** (DB-004 §9.1 명시 + S2/S3/S4 인라인 등가 동작 중 — `new Date()` 비교 + UUID 생성). 본 ISSUE = DTO contract only, helper 작성 owner 아님.
+    - `types.ts:1-3` `AuthProvider`/`DiagnosisMode`/`DiagnosisStatus` 통합 정리 — **Q2 가드 2회째 사수 (API-002 Q2 첫 성공 일관)**. owner = 별도 cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계, API-002 §9.4 트리거)
+    - `DiagnosisMode` 11 호출처 + `DiagnosisStatus` 2 호출처 일괄 치환 — Q2 cleanup ISSUE 위임 (API-002 §9.4 일관)
+    - `shareLink.diagnosis.mode` forward 2 호출처 (page.tsx:42 `as "couple" | "single"` cast + route.ts:49) 치환 — cleanup ISSUE 의존성 약함 (forward 패턴, types.ts 직접 import 0)
+    - S1~S6 ShareLink 현실 코드 (`validators/diagnosis.ts:32-43` / `api/share/route.ts` POST / `api/share/[uuid]/route.ts` GET / `app/share/[uuid]/page.tsx` SSR / `features/share/preview-stats.ts` / `components/share/` 3) — 본 ISSUE 미수정 (후행 CMD-SHARE / QRY-SHARE / UI-007 통합 대상)
+    - mock-auth M1~M4 + N1~N6 (API-001/002 가드 누적) — 본 ISSUE 무관여
+    - API-001 산출물 (`auth.ts` + `auth-errors.ts` + `auth-error.ts`) + API-002 산출물 (`diagnosis.ts` DB-003 보존 + append + `diagnosis-errors.ts` + `diagnosis-error.ts`) — 본 ISSUE 미수정
+    - `ShareLinkMetaDTO = PrismaShareLink` 등 **Prisma model re-export** — **(P1) 패턴 오해 금지**. (P1) 정신 = 기존 도메인 entity 재사용 (`OAuthProvider=AuthProviderType` / `CandidateAreaDTO=CandidateArea`)이지 Prisma 직접 노출 아님. 관심사 분리 (API-001/002 일관).
+    - `CandidateArea` 직접 import (`from '../types'`) — **API-002 (P1) re-export 우회 = 체인 깨짐**. `CandidateAreaDTO` import (`from './diagnosis'`) 만 허용.
+    - `DiagnosisMode` / `ServiceModeType` / `DiagnosisStatusType` / `CandidateArea` 재정의·중복 정의 — **절대 금지** (3+중 중복 원인 차단, DB-007 §3.8 UserDTO 추인 + API-001 (P1) OAuthProvider=AuthProviderType + API-002 (P1) CandidateAreaDTO 패턴 일관)
+- **복잡도:** M (명세 v1.0 동일)
 - **Wave:** 2 (API Contract 트랙)
 
 ---
@@ -23,184 +40,270 @@ assignees: []
 
 ### SRS 인용 (REQ ID + 본문 발췌)
 
-- **REQ-FUNC-009** (§4.1.2): "시스템은 진단 리포트 생성 완료 후 \"공유 링크 생성\" 버튼을 제공해야 하며, 클릭 시 고유 URL(UUID v4, entropy ≥ 128bit)을 생성하여 클립보드에 복사해야 한다. 링크 생성 응답 시간은 500ms 이내여야 한다."
-- **REQ-FUNC-010** (§4.1.2): "공유 링크의 유효기간은 생성일로부터 30일 이상이어야 한다. 만료된 링크 접근 시 \"이 링크는 만료되었습니다\" 안내 페이지를 1초 이내에 로딩하고, 원 사용자에게 재생성 알림 푸시를 발송해야 한다."
+- **REQ-FUNC-009** (§4.1.2): "시스템은 진단 리포트 생성 완료 후 '공유 링크 생성' 버튼을 제공해야 하며, 클릭 시 고유 URL(UUID v4, entropy ≥ 128bit)을 생성하여 클립보드에 복사해야 한다. 링크 생성 응답 시간은 500ms 이내여야 한다."
+- **REQ-FUNC-010** (§4.1.2): "공유 링크의 유효기간은 생성일로부터 30일 이상이어야 한다. 만료된 링크 접근 시 '이 링크는 만료되었습니다' 안내 페이지를 1초 이내에 로딩하고, 원 사용자에게 재생성 알림 푸시를 발송해야 한다."
 - **REQ-FUNC-011** (§4.1.2): "배우자(비회원)가 공유 링크를 클릭하면 앱 설치 없이 모바일 웹에서 리포트 전체를 열람하고 무료 미리보기 1곳을 확인할 수 있어야 한다. 3G 환경 기준 페이지 로딩 시간은 p95 ≤ 2,000ms여야 한다."
 - **REQ-NF-006** (§4.2.1): "공유 링크 생성 응답 시간 — ≤ 500ms"
 - **REQ-NF-020** (§4.2.3): "공유 링크 보안 — URL entropy ≥ 128bit (UUID v4), 열람 비밀번호 옵션, 열람 로그 실시간 알림"
 - **REQ-NF-021** (§4.2.3): "비인가 제3자 공유 링크 개인정보 접근 차단 — 비인가 접근 시 개인정보 노출 0건"
+- **REQ-NF-035** (§4.2.6): "에러 로그 알림 — Sentry 기본 알림 설정 사용"
+
+### `prototypes/design/CLAUDE.md` §3 (1인 MVP 제약) 인용
+
+- "Vercel Serverless Timeout = 10초" → 본 ISSUE 비대상 (API Contract 트랙, DTO only).
+- "Out of Scope ... 자동 코드 생성 금지" → §3.3 Zod 인라인 동작 중 + §3.5 dual mapper 인라인 동작 중 = 미리 추출 시 dead 또는 인라인 우회 (DB-006 Q3 / API-001 Q6 / API-002 Q8/Q9 일관)
 
 ### API 엔드포인트 (§6.1)
 
 | # | Method | Endpoint | 요청 Body | 응답 Body | 응답 시간 |
 |---|---|---|---|---|---|
-| API-03 | POST | `createShareLink()` | `diagnosis_id`, `password`(optional) | `share_url`, `expires_at` | ≤ 500ms |
-| API-04 | GET | `/api/diagnosis/[id]/report` | Query: `token` | `report`, `sources[]` | p95 ≤ 2,000ms |
+| API-03 | POST | `/api/share` (createShareLink) | `diagnosisId`, `password?` | `shareUrl`, `expiresAt`, `hasPassword` | ≤ 500ms |
+| API-04 | GET | `/api/diagnosis/[id]/report` | Query: `token` | `report`, `sources[]`, `shareLink` | p95 ≤ 2,000ms |
 
-### ERD 컬럼 (§6.2.3 SHARE_LINK)
+### ERD 컬럼 vs Prisma model ShareLink (§6.2.3 SHARE_LINK — 현실 추인)
 
-| 필드명 | 타입 | 제약조건 | 설명 |
-|---|---|---|---|
-| `id` | UUID | PK | 공유 링크 식별자 |
-| `diagnosis_id` | UUID | FK → DIAGNOSIS.id | 공유 대상 진단 |
-| `unique_url` | VARCHAR(255) | UNIQUE | 고유 URL (UUID v4) |
-| `password_hash` | VARCHAR(255) | NULLABLE | 비밀번호 해시 |
-| `view_count` | INTEGER | DEFAULT 0 | 열람 횟수 |
-| `free_preview_used` | BOOLEAN | DEFAULT FALSE | 미리보기 사용 여부 |
-| `expires_at` | DATE | NOT NULL | 만료일 (생성일+30일) |
-| `created_at` | TIMESTAMP | DEFAULT NOW() | 생성일시 |
+| 필드 | SRS | Prisma model ShareLink (DB-004 PR #78 머지) |
+|---|---|---|
+| `id` | UUID PK | `String @id @default(uuid())` |
+| `diagnosis_id` | UUID FK → DIAGNOSIS.id | `String @unique @map("diagnosis_id")` (1:0..1) |
+| `unique_url` | VARCHAR(255) UNIQUE | `String @unique @map("unique_url") // UUID v4` |
+| `password_hash` | VARCHAR(255) NULLABLE | `String? @map("password_hash") // bcrypt hash` |
+| `view_count` | INTEGER DEFAULT 0 | `Int @default(0) @map("view_count")` |
+| `free_preview_used` | BOOLEAN DEFAULT FALSE | `Boolean @default(false) @map("free_preview_used")` |
+| `expires_at` | DATE NOT NULL | `DateTime @map("expires_at")` |
+| `created_at` | TIMESTAMP DEFAULT NOW() | `DateTime @default(now()) @map("created_at")` |
+| FK CASCADE | (관계) | `diagnosis Diagnosis @relation(...) onDelete: Cascade` |
 
-### 시퀀스 다이어그램 (§6.3.2)
+### ★ Phase B 작성 산출물 표 (신규 3 파일)
 
-- **참여 Actor:** 사용자A(발신), 배우자(수신, 비회원), Next.js Client, Server Action, SSR 공유 페이지, Prisma, 푸시 알림 서비스
-- **핵심 메시지:** `createShareLink(diagnosisId, password?)` → UUID v4 생성 → ShareLink create (expires_at=NOW()+30일) → `{share_url, expires_at}` (≤500ms)
+| # | 파일 | 라인 | 내용 | 명세 §3 매핑 |
+|---|---|---|---|---|
+| **B.1** | `onday-app/src/lib/types/share-link.ts` (신규 첫 owner) | **129** | 6 섹션 (Request 2 / Response 3 / ReportDTO / DataSourceDTO / ShareLinkMetaDTO / ShareLinkErrorCode 7종 + ShareLinkErrorDTO). **import 부 정확 2 (DB-002/003 와 다른 신규 패턴 — 정직 기록): `import type { ServiceModeType } from './user'` + `import type { CandidateAreaDTO } from './diagnosis'` — Prisma 0, types.ts Mode/Status 0** | §3.1 + §3.2 |
+| **B.2** | `onday-app/src/lib/constants/share-link-errors.ts` | **33** | `SHARE_LINK_ERROR_MAP: Record<ShareLinkErrorCode, Omit<ShareLinkErrorDTO, 'code' \| 'originalError'>>` 7 키 — 만료 1 (410) + 조회 2 (404 × 2) + 비밀번호 2 (401 × 2) + 권한 2 (403 × 2) | §3.4 |
+| **B.3** | `onday-app/src/lib/helpers/share-link-error.ts` | **20** | `createShareLinkError(code, originalError?): ShareLinkErrorDTO` — SHARE_LINK_ERROR_MAP lookup + originalError 병합. Sentry catch 연계 가능 (REQ-NF-035). API-001/002 §3.6 createXError 패턴 일관 | (API-001/002 §3.6 패턴) |
+
+### ★ (P1) 패턴 미묘 구분 표 (★ API-003 특화 발견 — 향후 새 도메인 type ISSUE 가이드)
+
+(P1) "재사용 패턴" 은 **기존 도메인 entity 재사용** 정신 — Prisma 직접 노출 아님. base type 존재 여부에 따라 적용 분기:
+
+| ISSUE | base type 존재 | (P1) 적용 | 패턴 | 신규 정의 |
+|---|---|---|---|---|
+| **API-001** | ✅ user.ts `AuthProviderType` (DB-002) | ✅ 적용 | `export type OAuthProvider = AuthProviderType;` (re-export) | OAuthSignInOptions / AuthSessionDTO 등 8 섹션 신규 |
+| **API-002** | ✅ types.ts `CandidateArea` / `CommuteInfo` / `DiagnosisInput` (4/29 onday-app entity) + user.ts `ServiceModeType` (DB-002) + diagnosis.ts `DiagnosisStatusType` (DB-003) | ✅ 적용 (3 re-export) | `export type CandidateAreaDTO = CandidateArea;` + 2종 (P1 re-export) | DiagnosisDTO / CreateDiagnosisResponse 등 4 신규 |
+| **★ API-003** | ❌ **DB-004 base type 0** (DB-004 Q7/Q8 결정 — 코드 0 명세만, DTO=API-003 위임) | ❌ **적용 불가** | 자기 도메인 type 신규 정의 (Prisma model re-export 절대 금지) | **ShareLinkMetaDTO / ReportDTO / CreateShareLinkRequest 등 6 섹션 전부 신규 정의** |
+
+**외부 도메인 type 재사용 (Q3 (C) hybrid)**:
+- `ServiceModeType` from `'./user'` (Q2 (A) — DB-002 산출물 재사용, **DiagnosisMode 미사용 = Q2 가드**)
+- **`CandidateAreaDTO` from `'./diagnosis'` (★ API-002 (P1) 산출물 첫 외부 활용 = Wave 2 체인 작동 첫 코드 입증)**
+
+**(P1) 정신 명시 (향후 가이드)**:
+- (P1) = 기존 도메인 entity 재사용 (`OAuthProvider=AuthProviderType` / `CandidateAreaDTO=CandidateArea`)
+- (P1) ≠ Prisma 직접 노출 (`ShareLinkMetaDTO=PrismaShareLink` 금지 — 관심사 분리)
+- base type 부재 시 자기 도메인 신규 정의 = 정상 (DB-004 패턴 일관 — 본 ISSUE 의 share-link.ts)
+- 향후 새 도메인 type 만드는 ISSUE 는 본 §2 (P1) 미묘 구분 표 참조
+
+### ★ Q2 가드 사수 표 — DiagnosisMode 11 + DiagnosisStatus 2 호출처 + forward 2건 = 15 행 (★ Q2 가드 2회째 사수, API-002 Q2 첫 성공 일관)
+
+본 ISSUE Phase A 시점 grep 결과 (코드 호출처만, 주석 텍스트 제외):
+
+| # | 위치 | 라인 | 역할 | 본 ISSUE | cleanup 통합 |
+|---|---|---|---|---|---|
+| DM1 | `src/lib/types.ts` | L2 | `export type DiagnosisMode` 정의 | 미수정 (가드) | 제거 |
+| DM2 | `src/lib/types.ts` | L55 | `DiagnosisInput.mode: DiagnosisMode` | 미수정 (가드) | ServiceModeType |
+| DM3 | `src/lib/types.ts` | L66 | `DiagnosisResult.mode: DiagnosisMode` | 미수정 (가드) | ServiceModeType |
+| DM4 | `src/lib/types.ts` | L88 | `MockUser.mode: DiagnosisMode` | 미수정 (가드) | ServiceModeType (MOCK-005 동시) |
+| DM5-7 | `src/features/diagnosis/mock-calculator.ts` | L5/85/193 | import + parameter ×2 | 미수정 (가드) | cleanup ISSUE |
+| DM8-11 | `src/stores/diagnosis-store.ts` | L2/15/30/48 | import + state + action + initial | 미수정 (가드) | cleanup ISSUE |
+| DS1 | `src/lib/types.ts` | L3 | `export type DiagnosisStatus` 정의 | 미수정 (가드) | 제거 |
+| DS2 | `src/lib/types.ts` | L69 | `DiagnosisResult.status: DiagnosisStatus` | 미수정 (가드) | DiagnosisStatusType |
+| **★ F1** | `src/app/share/[uuid]/page.tsx` | **L42** | `mode: shareLink.diagnosis.mode as "couple" \| "single"` (literal cast) — **forward 패턴 (types.ts 직접 import 0)** | 미수정 | ServiceModeType 명확화 (cleanup ISSUE 시 자연 정합, **의존성 약함**) |
+| **★ F2** | `src/app/api/share/[uuid]/route.ts` | **L49** | `mode: shareLink.diagnosis.mode` (cast 없음 Prisma string 그대로) — **forward 패턴** | 미수정 | ServiceModeType 명확화 (의존성 약함) |
+
+**합계: DiagnosisMode 11 + DiagnosisStatus 2 + forward 2 = 15 행 본 ISSUE 0 치환** (코드 grep 검증).
+
+**Q2 (A) ServiceModeType import-only 사유 (★ Q2 가드 2회째 사수, API-002 Q2 첫 성공 일관)**:
+1. **★ 9칸+10칸 가드 보존 — 11칸 누적 (API-002 첫 성공 + API-003 2회째 사수)**: INFRA-001 / DB-001~007 / API-001/002 누적 10 ISSUE 동안 `types.ts` 무수정 가드 유지 + API-002 Q2 (b) 첫 성공 + 본 ISSUE Q2 (A) 2회째 사수.
+2. **forward 패턴 (F1+F2 grep 검증)**: `shareLink.diagnosis.mode` forward = 2 호출처만 (page.tsx:42 + route.ts:49), `types.ts` DiagnosisMode 직접 import 0. cleanup ISSUE 의존성 = **약함** (어느 owner 채택해도 cleanup 영향 적음). ReportDTO.mode = ServiceModeType 채택으로 cleanup ISSUE 자연 정합.
+3. **(P1) 미묘 구분 — Q2 (A) 자연 통합**: ServiceModeType 은 user.ts 의 기존 entity 재사용 ((P1) 정신 일관). DiagnosisMode 재정의 또는 forward 그대로 채택 = (P1) 정신 위반 + DRY 위반.
+4. **DB-006 Q3 / API-001 mock-auth M1~M4 / API-002 cleanup ISSUE 트리거 일관**: 인라인 보존 + cleanup 별도 ISSUE 분리 패턴 답습.
+
+### ★ S1~S6 ShareLink 현실 코드 표 (위치/라인/역할/본 ISSUE 미수정/후행 통합 — DB-006 Q3 / API-002 N1~N6 패턴 답습)
+
+| # | 위치 | 라인 | 역할 | 본 ISSUE 처리 | 후행 통합 대상 |
+|---|---|---|---|---|---|
+| **S1** | `onday-app/src/lib/validators/diagnosis.ts:32-43` | 23 (본체) | `shareLinkInputSchema` (diagnosisId UUID + password 4~20자 optional) + `shareAccessSchema` (password optional) + ShareLinkInputSchema z.infer L46. ★ **API-002 §9.6 정정 "47줄 = 파일 전체, shareLink* 2종 = CMD-SHARE 영역" 트리거 본 ISSUE 수신** | 미수정 | **CMD-SHARE-001** (S1 추출 + 명세 §3.3 createShareLinkSchema / verifyPasswordSchema 정합 검증 + 명세 §3.3 password.min(4) 메시지 ↔ 현실 "비밀번호는 4자 이상이어야 합니다" 정합) |
+| **S2** | `onday-app/src/app/api/share/route.ts` (POST) | 60 | L13 shareLinkInputSchema.safeParse + L31 prisma.shareLink.findUnique (중복 체크) + L43 prisma.shareLink.create + L53 `shareUrl: /share/${shareLink.uniqueUrl}` + L54 expiresAt toISOString | 미수정 | **CMD-SHARE-001** (S2 createShareLink Server Action 추출 + bcrypt 해싱 + DB-004 §9.1 calculateExpiresAt 30일 + B.1 CreateShareLinkRequest / CreateShareLinkResponse import) |
+| **S3** | `onday-app/src/app/api/share/[uuid]/route.ts` (GET) | 61 | L12 findUnique({where: {uniqueUrl}}) + L24 expiresAt < new Date() 만료 분기 + L35 update viewCount 증가 + L41 candidates JSON.parse + L45-51 인라인 flat response (uniqueUrl/diagnosisId/addressA/addressB/mode/candidates/expiresAt) | 미수정 | **QRY-SHARE-001 단일 owner** (S3 mapper 추출, ★ S4 와 dual 통합) |
+| **S4** | `onday-app/src/app/share/[uuid]/page.tsx` (SSR) | 76 | S3 와 거의 동일 dual 패턴: findUnique + 만료 분기 + viewCount update + candidates JSON.parse + 리포트 렌더 (`mode: shareLink.diagnosis.mode as "couple" \| "single"` L42 literal cast — F1) | 미수정 | **QRY-SHARE-001 단일 owner** (★ S3+S4 dual 통합 — mapper 분리 금지) |
+| **S5** | `onday-app/src/features/share/preview-stats.ts` | 0.8 KB | `buildReportStats(c: CandidateArea): ReportStat[]` UI 표시용 (통근/시세/환승) | 미수정 (UI 표시, 본 ISSUE 무관여) | UI-007 영역 (변동 없음) |
+| **S6** | `onday-app/src/components/share/` 3 | locked-card 2.1KB / report-card 1.8KB / share-hero 2.1KB | UI 컴포넌트 | 미수정 (본 ISSUE 무관여) | UI-007 영역 |
+
+본 ISSUE 가 S1~S4 추출 산출물을 미작성하는 사유 (DB-006 Q3 / API-001 Q6 / API-002 Q8/Q9 일관 dead 회피):
+- S1 Zod: `validators/diagnosis.ts:32-43` 23 lines 인라인 동작 중 + Route Handler L13 호출처 활성 → 본 ISSUE 추출 시 S1 우회 가드 위반 + API-002 §9.6 트리거 수신 (validators/diagnosis.ts 47줄 파일 전체 중 shareLink* 2종 = CMD-SHARE 영역 명시 → 본 ISSUE 가 CMD-SHARE-001 §3.3 위임으로 받음)
+- S2 POST: prisma.shareLink.create 인라인 + 비밀번호 bcrypt 해싱 미적용 (현재 평문) → CMD-SHARE-001 시점 bcrypt 추가 + DB-004 §9.1 helper 통합
+- S3+S4 dual mapper: **★ 본 ISSUE 특화 패턴** — 두 곳 인라인 동작 (Route Handler + SSR 양쪽) → QRY-SHARE-001 시점 추출 시 양쪽 우회 가드 위반 + dual 분리 시 DRY 위반 (다음 § 참조)
+
+### ★ S3+S4 dual mapper 패턴 표 (★ ShareLink 특화 신규 — API-002 mapper 와 다름)
+
+| 항목 | API-002 mapper | **★ API-003 mapper (★ 신규 패턴)** |
+|---|---|---|
+| 인라인 위치 | N3 `[id]/route.ts:19-34` (single inline) | **★ S3 `api/share/[uuid]/route.ts:12-54` (Route Handler) + S4 `app/share/[uuid]/page.tsx:15-?` (SSR) — dual inline 양쪽** |
+| 추출 owner | QRY-DIAG-001 (single owner) | **★ QRY-SHARE-001 단일 owner (mapper 분리 금지)** |
+| 분리 위험 | — | **★ S3 mapper / S4 mapper 분리 시 DRY 위반 + 유지보수 폭발 (Route + SSR 양쪽 mode/expires/viewCount/candidates 동일 변환 로직 중복)** |
+| 미래 작업자 가이드 | — | **★ QRY-SHARE-001 시점 단일 mapper (`mapShareLinkToMeta` + `mapToReportResponse`) 신규 + S3+S4 양쪽 호출처 통합 (Route Handler 와 SSR 가 같은 mapper 함수 import)** |
+
+**dual mapper 패턴 신규 명시 사유**: API-001/002 의 single inline mapper 패턴과 다른 새 패턴 발견 → 본 §2 표 + §9 follow-up 명시. 향후 다른 도메인에서 Route + SSR 양쪽 인라인 발견 시 본 표 참조 (예: deadline / single 도메인 — page.tsx + route.ts 양쪽 동작 가능성).
+
+### ★ 부재 산출물 표 (인라인 동작 중 / 영역 분리 → 위임 5+)
+
+| 명세 §3 산출물 | 현실 (Phase A 확인) | 위임 대상 |
+|---|---|---|
+| §3.3 `lib/validators/share-link.ts` `createShareLinkSchema` + `verifyPasswordSchema` 신규 | S1 `validators/diagnosis.ts:32-43` 23 lines 인라인 동작 중 + Route Handler L13 호출처 활성 + **API-002 §9.6 트리거 수신** | **CMD-SHARE-001** |
+| §3.5 `lib/mappers/share-link-mapper.ts` `mapShareLinkToMeta` + `mapToReportResponse` | **S3 + S4 dual 인라인 동작 중** + `lib/mappers/` 빈 디렉토리 (API-001/002 시점 빈, 본 ISSUE 도 작성 안 함) | **★ QRY-SHARE-001 단일 owner (mapper 분리 금지)** |
+| §3.6 `__tests__/types/share-link-dto.spec.ts` (4 케이스) | vitest config 부재 (DB-001~007 + API-001/002 일관) | **TEST-003 (공유 링크 GWT)** |
+| §3.7 `__tests__/validators/share-link.spec.ts` (5 케이스) | 동상 | **TEST-003** |
+| §3.8 `__tests__/mappers/share-link-mapper.spec.ts` (3 케이스) | 동상 | **TEST-003** |
+| (보안 케이스 — REQ-NF-021 UNAUTHORIZED_ACCESS + PASSWORD_MISMATCH) | 동상 | **TEST-004 (공유 링크 보안)** |
+| DB-004 §9.1 helper (`calculateExpiresAt` + `isShareLinkExpired` + `generateShareLinkToken`) | DB-004 §9.1 CMD-SHARE-001 위임 명시 + S2/S3/S4 인라인 등가 동작 | **CMD-SHARE-001 영역 (본 ISSUE 미수정, §9 명확화만)** |
 
 ### 선행 태스크 산출물
 
-| 선행 Task ID | 제공 산출물 | 본 태스크에서의 사용처 |
+| 선행 Task ID | 제공 산출물 | 본 ISSUE 사용처 |
 |---|---|---|
-| DB-004 | `model ShareLink` Prisma 스키마 | DTO가 ShareLink 모델을 래핑하여 API 응답 구조로 변환 |
+| **DB-002** (PR #76 머지 완료, main `d916a6f`) | `src/lib/types/user.ts` (`ServiceModeType` TS union, commit `2ea3a17`) | ★ B.1 `share-link.ts:11` `import type { ServiceModeType } from './user'` — `ReportDTO.mode` 에 사용 (Q2 (A) 핵심 — DiagnosisMode 미사용) |
+| **DB-003** (PR #77 머지 완료) | `src/lib/types/diagnosis.ts` (`DiagnosisStatusType` + L3-4 주석 트리거 → API-002 PR #82 완전 해소) | 간접 선행 — API-002 산출물 활용 토대 |
+| **DB-004** (PR #78 머지 완료, main `0e846b2`) | `tasks/DB-004.md` (코드 0, 명세만 — Q7/Q8 결정으로 DTO=API-003 위임 + §9.1 helper=CMD-SHARE-001 위임) | ★ **본 ISSUE 가 DTO 위임 트리거 수신** — share-link.ts 신규 첫 owner. **§9.1 helper 본 ISSUE 미수정 (CMD-SHARE-001 영역)** |
+| **API-001** (PR #81 머지 완료, main `ee83429`) | `lib/types/auth.ts` (133 lines) + `auth-errors.ts` (42) + `auth-error.ts` (20) + `tasks/API-001.md` (Q1~Q10 + L6 2차 정정 + (P1) OAuthProvider=AuthProviderType 패턴) | ★ 본 ISSUE 답습 기준 — (B) 절충 + Phase B 활성 + 커밋 2개 + (P1) 정신 |
+| **API-002** (PR #82 머지 완료, main `891ae97`) | `lib/types/diagnosis.ts` (DB-003 보존 + append 115 lines, **★ `CandidateAreaDTO = CandidateArea` re-export L27**) + `diagnosis-errors.ts` (37) + `diagnosis-error.ts` (20) + `tasks/API-002.md` (Q1~Q10 + Q2 9칸 가드 첫 성공 + L6 3차 cleanup 트리거 + **§9.6 정정 "shareLink* 2종 = CMD-SHARE 영역"**) | ★ **본 ISSUE 핵심 — `CandidateAreaDTO` 첫 외부 활용** (Wave 2 체인 작동 첫 코드 입증) + **§9.6 트리거 수신** (CMD-SHARE-001 §3.3 위임으로 받음) |
+| **DB-007** (PR #80 머지 완료) | L6 1차 발견 (추후 API-001 2차 / API-002 3차 정정) | 본 ISSUE = Q2 가드 2회째 사수 (cleanup ISSUE 의존성 약함) |
+| DB-006 / DB-001 | 간접 선행 (Phase 패턴 + dead 회피 논리 답습) | DB-* 패턴 답습 |
+
+### 후행 ISSUE 정합성 (Q1~Q10 결정 트리거)
+
+| 후행 Task ID | 본 ISSUE 위임 트리거 |
+|---|---|
+| **★ CMD-SHARE-001** (공유 링크 생성) | S1 (shareLinkInputSchema + shareAccessSchema) + S2 (POST createShareLink Server Action 추출) + DB-004 §9.1 helper (calculateExpiresAt 30일 / isShareLinkExpired / generateShareLinkToken UUID v4) + bcrypt 해싱 + 명세 §3.3 정합 검증 + B.1 `CreateShareLinkRequest` / `CreateShareLinkResponse` import + `DiagnosisErrorCode.DIAGNOSIS_NOT_FOUND` 활용 |
+| **★ QRY-SHARE-001** (리포트 조회) — **dual owner** | ★ **S3 + S4 dual mapper 통합** (Route Handler + SSR 양쪽). `mapShareLinkToMeta(shareLink: PrismaShareLink): ShareLinkMetaDTO` + `mapToReportResponse(shareLink, diagnosis, candidates): GetReportResponse` 신규. B.1 `GetReportResponse` / `ReportDTO` / `ShareLinkMetaDTO` 활용. **★ mapper 분리 금지 (single owner)** + ShareLinkMetaDTO.isExpired runtime 계산 통합 |
+| **CMD-SHARE-002~004** (비밀번호 검증 / 만료 처리 / 미리보기) | B.1 `VerifyPasswordRequest` / `VerifyPasswordResponse` + `ShareLinkErrorCode.PASSWORD_REQUIRED/MISMATCH/PREVIEW_EXHAUSTED` 활용 |
+| **★ TEST-003** (공유 링크 GWT) | type spec 4 + validator spec 5 + mapper spec 3 (정상 / 만료 / 비밀번호 / 미리보기) — AC-1/2/3/4 검증 |
+| **★ TEST-004** (공유 링크 보안) | UNAUTHORIZED_ACCESS + PASSWORD_MISMATCH + 비인가 접근 시 개인정보 노출 0건 (REQ-NF-021) |
+| **★ MOCK-002** (ShareLink Mock 데이터) | B.1 `GetReportResponse` Mock + `ShareLinkMetaDTO` Mock + 만료/비밀번호 시나리오 3종 |
+| **★ UI-007** (SSR 공유 리포트 페이지) | B.1 `DataSourceDTO` 목록 정의 + OG 메타태그 `generateMetadata()` + 무료 미리보기 1곳 + 데이터 출처 배지 UI |
+| **★ cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계)** | API-002 §9.4 트리거 일관 + 본 ISSUE 의존성 약함 (F1+F2 forward 2 호출처만, types.ts 직접 import 0) |
 
 ---
 
 ## 3. 🛠️ Task Breakdown (실행 체크리스트)
 
-- [ ] **3.1** `lib/types/share-link.ts`에 ShareLink 도메인 DTO 전체 정의
-  ```typescript
-  // === Request DTOs ===
-  export interface CreateShareLinkRequest {
-    diagnosisId: string;
-    password?: string;  // 선택적 열람 비밀번호 (평문, 서버에서 bcrypt 해싱)
-  }
+> ★ API-001/002 패턴 답습 (Phase A 사전 검증 + Phase B 활성 3 파일 + Phase C 명세 동기화 + Phase D 커밋 2개) + (B) 절충 + (Q3 C) hybrid + Q2 (A) 가드 2회째 사수.
 
-  // === Response DTOs ===
-  export interface CreateShareLinkResponse {
-    shareUrl: string;    // 전체 URL (e.g., https://domain/share/{token})
-    expiresAt: string;   // ISO date
-    hasPassword: boolean;
-  }
+- [x] **3.1** `lib/types/share-link.ts` 신규 첫 owner — **Phase B.1 완료 (129 lines)**
+  > **★ DB-002/003 와 다른 신규 첫 owner** (DB-004 base type 0 → (P1) re-export 적용 불가, 자기 도메인 type 신규 정의 정상).
+  > import 부 (정확 2, 정직 기록):
+  > - `import type { ServiceModeType } from './user';` (Q2 (A) — DiagnosisMode 미사용, 9칸 가드 보존)
+  > - `import type { CandidateAreaDTO } from './diagnosis';` (★ API-002 (P1) 산출물 첫 외부 활용 = Wave 2 체인 작동 첫 코드 입증)
+  > Prisma model import 0 + types.ts DiagnosisMode/DiagnosisStatus import 0
+  > 6 섹션:
+  > 1. Request DTO: `CreateShareLinkRequest` + `VerifyPasswordRequest`
+  > 2. Response DTO: `CreateShareLinkResponse` + `GetReportResponse` + `VerifyPasswordResponse`
+  > 3. ReportDTO (mode: ServiceModeType, candidates: CandidateAreaDTO[], previewCandidateId: string \| null + §9.6 follow-up 주석)
+  > 4. DataSourceDTO (type: 'public_data' \| 'api' \| 'static')
+  > 5. ShareLinkMetaDTO (isExpired runtime 계산 필드 + QRY-SHARE-001 mapper / DB-004 §9.1 isShareLinkExpired = CMD-SHARE-001 영역 주석)
+  > 6. ShareLinkErrorCode enum 7 종 (만료 1 / 조회 2 / 비밀번호 2 / 권한 2) + ShareLinkErrorDTO
 
-  export interface GetReportResponse {
-    report: ReportDTO;
-    sources: DataSourceDTO[];
-    shareLink: ShareLinkMetaDTO;
-  }
+- [x] **3.2** `lib/types/share-link.ts` `ShareLinkErrorCode` enum 7 종 — **Phase B.1 완료 (같은 파일 §6 섹션)**
+  > 만료 1 (LINK_EXPIRED) + 조회 2 (LINK_NOT_FOUND / DIAGNOSIS_NOT_FOUND) + 비밀번호 2 (PASSWORD_REQUIRED / PASSWORD_MISMATCH) + 권한 2 (PREVIEW_EXHAUSTED / UNAUTHORIZED_ACCESS). API-001 9종 / API-002 8종 패턴 답습.
 
-  export interface ReportDTO {
-    diagnosisId: string;
-    candidates: import('./diagnosis').CandidateAreaDTO[];
-    mode: 'couple' | 'single';
-    createdAt: string;
-    freePreviewUsed: boolean;
-    previewCandidateId: string | null; // 무료 미리보기 1곳
-  }
+- [⏸ CMD-SHARE-001 위임] **3.3** `lib/validators/share-link.ts` `createShareLinkSchema` + `verifyPasswordSchema` — **Q7 부재 산출물 결정**
+  > **사유 4종 (DB-006 Q3 / API-001 Q6 / API-002 Q8 일관 dead 회피 + 인라인 동작 중):**
+  > 1. **★ S1 인라인 동작 중 (Phase A.4 확인)**: `validators/diagnosis.ts:32-43` `shareLinkInputSchema` + `shareAccessSchema` 23 lines (본체) 정상 동작 중.
+  > 2. **★ Route Handler 호출처 활성**: `api/share/route.ts:13` `shareLinkInputSchema.safeParse(body)` 호출처 활성.
+  > 3. **★ API-002 §9.6 트리거 수신**: API-002 PR #82 §9.6 "validators/diagnosis.ts 47줄 = 파일 전체, shareLink* 2종 = CMD-SHARE 영역" → 본 ISSUE 가 CMD-SHARE-001 §3.3 위임으로 받음.
+  > 4. **CMD-SHARE-001 영역**: 06_TASK_LIST §2-A — 공유 링크 생성 = createShareLinkSchema 의 owner. 본 ISSUE 가 추출 시 owner 침범 + S1 우회 가드 위반.
 
-  export interface DataSourceDTO {
-    name: string;      // e.g., "카카오 모빌리티 API"
-    type: 'public_data' | 'api' | 'static';
-    lastUpdated: string;
-  }
+- [x] **3.4** `lib/constants/share-link-errors.ts` `SHARE_LINK_ERROR_MAP` (7 키) — **Phase B.2 완료 (33 lines)**
+  > 7 키 (ShareLinkErrorCode enum 전수) × `{message: string (한국어), httpStatus: number}` 매핑. Omit pattern. HTTP 상태: 410 (LINK_EXPIRED) / 404 (LINK_NOT_FOUND + DIAGNOSIS_NOT_FOUND) / 401 (PASSWORD_REQUIRED + PASSWORD_MISMATCH) / 403 (PREVIEW_EXHAUSTED + UNAUTHORIZED_ACCESS).
 
-  export interface ShareLinkMetaDTO {
-    id: string;
-    uniqueUrl: string;
-    viewCount: number;
-    expiresAt: string;
-    isExpired: boolean;
-    hasPassword: boolean;
-    freePreviewUsed: boolean;
-  }
+- [⏸ QRY-SHARE-001 단일 owner 위임] **3.5** `lib/mappers/share-link-mapper.ts` `mapShareLinkToMeta` + `mapToReportResponse` — **Q8 부재 산출물 결정**
+  > **사유 5종 (DB-006 Q3 / API-002 Q9 일관 dead 회피 + ★ S3+S4 dual mapper 신규 패턴):**
+  > 1. **★ S3 + S4 dual 인라인 동작 중 (Phase A.4 확인)**: Route Handler `api/share/[uuid]/route.ts:12-54` (61 lines) + SSR `app/share/[uuid]/page.tsx:15-?` (76 lines) **양쪽 인라인** (`expiresAt < new Date()` 만료 분기 + viewCount update + candidates JSON.parse + 인라인 flat response).
+  > 2. **★ lib/mappers/ 빈 디렉토리**: API-001/002 시점 빈 디렉토리 유지 + 본 ISSUE 도 작성 안 함 → mkdir + 단일 파일 만들 시 dead + S3/S4 우회.
+  > 3. **★ QRY-SHARE-001 단일 owner 영역 (mapper 분리 금지)**: 06_TASK_LIST §2-A — 리포트 조회 = mapShareLinkToMeta + mapToReportResponse owner. 본 ISSUE 추출 시 owner 침범 + S3+S4 dual 우회 가드 위반.
+  > 4. **★ dual mapper 분리 위험**: S3 mapper / S4 mapper 분리 시 DRY 위반 + 유지보수 폭발 (Route + SSR 양쪽 같은 변환 로직 중복). QRY-SHARE-001 시점 단일 mapper 함수 + S3+S4 양쪽 호출처 통합 필수.
+  > 5. **Prisma model 의존**: mapper 시그니처 = `(shareLink: PrismaShareLink, diagnosis: PrismaDiagnosis, candidates: PrismaCandidateArea[]) => GetReportResponse` — Prisma Client import 필요. 본 ISSUE = DTO only owner → Prisma import 회피 (관심사 분리, API-001/002 일관).
 
-  // === Password Verification ===
-  export interface VerifyPasswordRequest {
-    token: string;
-    password: string;
-  }
+- [x] **3.6 (helper)** `lib/helpers/share-link-error.ts` `createShareLinkError(code, originalError?)` — **Phase B.3 완료 (20 lines)** ★ 명세 v1.0 §3.6 spec 항목 대비 추가 helper (API-001/002 §3.6 패턴 일관)
+  > `(code: ShareLinkErrorCode, originalError?: string): ShareLinkErrorDTO` — SHARE_LINK_ERROR_MAP lookup + originalError 병합. Sentry catch 연계 가능 (REQ-NF-035).
 
-  export interface VerifyPasswordResponse {
-    verified: boolean;
-    error?: ShareLinkErrorCode;
-  }
-  ```
+- [⏸ TEST-003 위임] **3.6 (spec)** `__tests__/types/share-link-dto.spec.ts` (4 케이스)
+  > **사유 3종**: vitest config 부재 (Phase A.7 확인) → spec 작성해도 실행 불가 / AC-1/2/4 CMD-SHARE / QRY-SHARE 위임 → spec 동일 시점 / TEST-003 영역 (공유 링크 GWT).
 
-- [ ] **3.2** `lib/types/share-link.ts`에 ShareLink 에러 코드 enum 정의
-  ```typescript
-  export enum ShareLinkErrorCode {
-    LINK_EXPIRED = 'SHARE_LINK_EXPIRED',
-    LINK_NOT_FOUND = 'SHARE_LINK_NOT_FOUND',
-    PASSWORD_REQUIRED = 'SHARE_PASSWORD_REQUIRED',
-    PASSWORD_MISMATCH = 'SHARE_PASSWORD_MISMATCH',
-    DIAGNOSIS_NOT_FOUND = 'SHARE_DIAGNOSIS_NOT_FOUND',
-    PREVIEW_EXHAUSTED = 'SHARE_PREVIEW_EXHAUSTED',
-    UNAUTHORIZED_ACCESS = 'SHARE_UNAUTHORIZED_ACCESS',
-  }
-  ```
+- [⏸ TEST-003 위임] **3.7** `__tests__/validators/share-link.spec.ts` (5 케이스: 정상 / diagnosisId 무효 / password 3자 / password 누락 정상 / 빈 token)
+  > 사유: §3.3 Zod 자체 위임 (CMD-SHARE-001) → spec 동시 위임.
 
-- [ ] **3.3** `lib/validators/share-link.ts`에 Zod 스키마 정의
-  ```typescript
-  import { z } from 'zod';
-  export const createShareLinkSchema = z.object({
-    diagnosisId: z.string().uuid('유효한 진단 ID를 입력해 주세요'),
-    password: z.string().min(4, '비밀번호는 4자 이상이어야 합니다').max(20).optional(),
-  });
-  export const verifyPasswordSchema = z.object({
-    token: z.string().uuid(),
-    password: z.string().min(1),
-  });
-  ```
+- [⏸ TEST-003 + TEST-004 분배 위임] **3.8** `__tests__/mappers/share-link-mapper.spec.ts` (3 케이스: 정상 / 만료 / 비밀번호 설정) + **★ TEST-004 보안 케이스 추가** (UNAUTHORIZED_ACCESS + PASSWORD_MISMATCH + REQ-NF-021 비인가 접근 시 개인정보 노출 0건)
+  > 사유: §3.5 mapper 자체 위임 (QRY-SHARE-001) → spec 동시 위임. 보안 케이스 = TEST-004 분배.
 
-- [ ] **3.4** `lib/constants/share-link-errors.ts`에 에러코드→메시지 매핑
-  ```typescript
-  import { ShareLinkErrorCode } from '@/lib/types/share-link';
-  export const SHARE_LINK_ERROR_MAP: Record<ShareLinkErrorCode, { message: string; httpStatus: number }> = {
-    [ShareLinkErrorCode.LINK_EXPIRED]: { message: '이 링크는 만료되었습니다.', httpStatus: 410 },
-    [ShareLinkErrorCode.LINK_NOT_FOUND]: { message: '공유 링크를 찾을 수 없습니다.', httpStatus: 404 },
-    [ShareLinkErrorCode.PASSWORD_REQUIRED]: { message: '비밀번호를 입력해 주세요.', httpStatus: 401 },
-    [ShareLinkErrorCode.PASSWORD_MISMATCH]: { message: '비밀번호가 일치하지 않습니다.', httpStatus: 401 },
-    [ShareLinkErrorCode.DIAGNOSIS_NOT_FOUND]: { message: '진단 결과를 찾을 수 없습니다.', httpStatus: 404 },
-    [ShareLinkErrorCode.PREVIEW_EXHAUSTED]: { message: '무료 미리보기가 소진되었습니다.', httpStatus: 403 },
-    [ShareLinkErrorCode.UNAUTHORIZED_ACCESS]: { message: '접근 권한이 없습니다.', httpStatus: 403 },
-  };
-  ```
+- [본 ISSUE 미수정, §9 명확화만] **3.9 (Q10)** DB-004 §9.1 helper (`calculateExpiresAt` + `isShareLinkExpired` + `generateShareLinkToken`) — **CMD-SHARE-001 영역**
+  > DB-004 §9.1 CMD-SHARE-001 위임 명시 + S2/S3/S4 인라인 등가 동작 중 (`new Date()` 비교 + UUID 생성). 본 ISSUE = DTO contract only, helper 작성 owner 아님 — §9 명확화만.
 
-- [ ] **3.5** `lib/mappers/share-link-mapper.ts`에 Prisma ShareLink → DTO 변환 함수
-  ```typescript
-  export function mapShareLinkToMeta(shareLink: PrismaShareLink): ShareLinkMetaDTO { /* ... */ }
-  export function mapToReportResponse(shareLink: PrismaShareLink, diagnosis: PrismaDiagnosis, candidates: any[]): GetReportResponse { /* ... */ }
-  ```
+### ★ Q1~Q10 결정 vs 명세 v1.0 mismatch 추적 표 (API-001/002 패턴 답습)
 
-- [ ] **3.6** `__tests__/types/share-link-dto.spec.ts` — DTO 타입 검증 4개 케이스
-- [ ] **3.7** `__tests__/validators/share-link.spec.ts` — Zod 스키마 검증 5개 케이스 (정상, diagnosisId 무효, password 3자, password 누락 정상, 빈 token)
-- [ ] **3.8** `__tests__/mappers/share-link-mapper.spec.ts` — 변환 함수 테스트 3개 케이스 (정상, 만료 링크, 비밀번호 설정 링크)
+| Q | 영역 | 명세 v1.0 (API-003.md) | 현실 (onday-app) | 결정 | 후행 처리 |
+|---|---|---|---|---|---|
+| **Q1** ★ | 작업 모드 (가장 상위, API-001/002 답습) | §3.1~3.8 8개 산출물 신규 작성 | DB-004 산출물 = 코드 0 (Q7/Q8 DTO=API-003 위임) + S1 Zod 인라인 + S3+S4 dual mapper 인라인 + spec 미실행 가능 | (B) **절충 — API-001/002 패턴 정확 답습 + Phase B 활성 (3 파일) + 커밋 2개 (feat+docs 분리)** | Phase B 작성 (B.1/B.2/B.3) + Phase D 커밋 2개 |
+| **페이스** | 세션 진행 범위 | — | API-002 풀세트 직후 + Q3 새 판단 + S1~S6 광범위 | (가) **grill + 메모리까지 — Phase A~D 다음 세션** (안전 분기 답습) | 본 세션 grill 완료, Phase 다음 세션 |
+| **Q2** | ReportDTO.mode owner (가드 충돌 점검) | (명세 §3.1 신규 ReportDTO.mode `'couple' \| 'single'` literal) | `shareLink.diagnosis.mode` forward = 2 호출처만 (page.tsx:42 + route.ts:49), types.ts DiagnosisMode 직접 import 0, API-002 cleanup ISSUE 의존성 약함 | **(A) ServiceModeType import** (`from './user'`) — Q3 strategy 에 포섭. Q2 가드 2회째 사수 (API-002 Q2 첫 성공 일관) | cleanup ISSUE 자연 정합 (의존성 약함) |
+| **Q3** ★★ | share-link.ts 신규 정의 strategy (본 ISSUE 핵심 분기) | §3.1 7 DTO 전체 신규 정의 | DB-004 base type 0 + 명세 §3.1 7섹션 + 현실 S1~S6 광범위 + Prisma model ShareLink 8 필드 | **(C) API-002 (D)/(P1) hybrid** — ① `CandidateAreaDTO from './diagnosis'` (★ API-002 (P1) 산출물 첫 외부 활용 = Wave 2 체인 작동 증거) ② `mode: ServiceModeType` (Q2 A) ③ ShareLinkMetaDTO/ReportDTO/Request/Response 신규 정의 (Prisma 직접 활용 X) ④ ShareLinkErrorCode + ShareLinkErrorDTO 신규 (API-001/002 §3.2 패턴) | 후행 import 활용 (CMD-SHARE / QRY-SHARE / MOCK-002 / TEST-003·004 / UI-007) |
+| **Q4** | §3.2 ShareLinkErrorCode enum 7 종 | 신규 작성 | 부재 (Route Handler `console.error` 인라인) | (A) **✅ Phase B.1 작성** — API-001/002 §3.2 패턴 일관 + 카테고리 (만료 1 / 조회 2 / 비밀번호 2 / 권한 2) | 후행 CMD-SHARE / QRY-SHARE import 활용 |
+| **Q5** | §3.4 SHARE_LINK_ERROR_MAP 7 키 | 신규 작성 | 부재 + `lib/constants/` (auth-errors.ts + diagnosis-errors.ts 존재) | (A) **✅ Phase B.2 작성** — API-001/002 패턴 일관. HTTP 상태 410/404/404/401/401/403/403 | 후행 createShareLinkError lookup 대상 |
+| **Q6** (추가) | createShareLinkError helper | (명세 v1.0 부재 — API-001/002 §3.6 패턴 추가) | 부재 + `lib/helpers/` (auth-error.ts + diagnosis-error.ts 존재) | (A) **✅ Phase B.3 작성** — API-001/002 §3.6 createXError 패턴 일관 | 후행 CMD-SHARE / QRY-SHARE import (ShareLinkErrorDTO 생성) |
+| **Q7** | §3.3 createShareLinkSchema + verifyPasswordSchema Zod | 신규 작성 | S1 `validators/diagnosis.ts:32-43` 23 lines 인라인 + Route Handler 호출처 활성 + **API-002 §9.6 트리거 수신** | (A) **⏸ CMD-SHARE-001 위임** — S1 인라인 보존 (DB-006 Q3 / API-002 Q8 패턴) | CMD-SHARE-001 (§9.1) |
+| **Q8** | §3.5 mapShareLinkToMeta + mapToReportResponse | 신규 작성 | **★ S3 + S4 dual 인라인** (Route Handler + SSR 양쪽) + `lib/mappers/` 빈 디렉토리 | (A) **⏸ QRY-SHARE-001 단일 owner (mapper 분리 금지)** — S3+S4 dual 패턴 신규 명시 + API-001 Q6 / API-002 Q9 dead 회피 패턴 + dual 분리 시 DRY 위반 | QRY-SHARE-001 (§9.2) |
+| **Q9** | §3.6/3.7/3.8 spec ×3 | type spec 4 + validator spec 5 + mapper spec 3 | vitest config 부재 + AC CMD-SHARE/QRY-SHARE 위임 | (A) **⏸ TEST-003 (GWT) + TEST-004 (보안) 분배 위임** — DB-001~007 + API-001/002 일관 | TEST-003 + TEST-004 (§9.3) |
+| **Q10** | DB-004 §9.1 helper 명확화 | DB-004 §9.1 CMD-SHARE-001 위임 명시 | DB-004 결정 그대로 + S2/S3/S4 인라인 등가 동작 중 | **본 ISSUE 미수정, §9 명확화만** — CMD-SHARE-001 영역, DB-004 §9.1 정합. 본 ISSUE = DTO contract only | CMD-SHARE-001 (§9.4) |
+| **보조 1** | DiagnosisFilters 명세 v1.0 ↔ 현실 차이 | (API-002 §9.5 기록) | 본 ISSUE 무관여 (DiagnosisFilters import 0) | — | — |
+| **보조 2** | previewCandidateId 선정 로직 / DataSourceDTO 목록 / OG 메타 | 명세 §9.1~9.3 보존 | 부재 (CMD-SHARE/QRY-SHARE/UI-007 영역) | §9 follow-up 기록 | CMD-SHARE / QRY-SHARE / UI-007 (§9.5/9.6) |
 
 ---
 
-## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD — API-001/002 ⏸ 패턴 일관 + Phase B 작성분 충족)
 
-**AC-1 (정상):** createShareLink Request Zod 검증 통과
-- **Given** 유효한 `diagnosisId` (UUID 형식)와 `password: 'test1234'`가 포함된 요청
-- **When** `createShareLinkSchema.parse(request)` 호출
-- **Then** 검증 통과, 파싱된 객체의 `diagnosisId`가 UUID 형식이며 `password`가 원본과 일치
+**AC-1 (정상, ⏸ CMD-SHARE-001 위임):** createShareLink Request Zod 검증 통과
+- **Given** 유효한 `diagnosisId` (UUID 형식) + `password: 'test1234'` 요청
+- **When** `shareLinkInputSchema.parse(request)` 호출 (CMD-SHARE-001 시점, 현재 S1 인라인 동작 중)
+- **Then** 검증 통과, 파싱된 객체의 `diagnosisId` UUID 형식 + `password` 원본 일치
+- **Status:** ⏸ CMD-SHARE-001 시점 정합 검증 (S1 통합 + 명세 §3.3 → 현실 shareLinkInputSchema 차이 정리). ★ 본 ISSUE B.1 `CreateShareLinkRequest` 신규 정의 완료 — Zod schema z.infer 타입 정합 확인은 CMD-SHARE-001 시점.
 
-**AC-2 (예외):** 만료된 링크 접근 시 에러 DTO 반환
-- **Given** `expires_at`이 현재보다 과거인 ShareLink 레코드
-- **When** `mapShareLinkToMeta(shareLink)` 호출
-- **Then** 반환된 `ShareLinkMetaDTO.isExpired`가 `true`이고, 에러 코드 `SHARE_LINK_EXPIRED`에 매핑되는 메시지가 `'이 링크는 만료되었습니다.'`, httpStatus가 `410`
+**AC-2 (예외, ✅ Phase B 산출물 충족):** 만료된 링크 접근 시 에러 DTO 반환
+- **Given** `expires_at` 이 현재보다 과거인 ShareLink 레코드
+- **When** `createShareLinkError(ShareLinkErrorCode.LINK_EXPIRED)` 호출
+- **Then** `ShareLinkErrorDTO.code === 'SHARE_LINK_EXPIRED'`, `message === '이 링크는 만료되었습니다. 진단을 공유한 분께 새 링크를 요청해 주세요.'`, `httpStatus === 410`
+- **Status:** ✅ Phase B.1 `ShareLinkErrorCode.LINK_EXPIRED` + B.2 `SHARE_LINK_ERROR_MAP[LINK_EXPIRED]` + B.3 `createShareLinkError()` 정의 완료 — **B.2/B.3 lookup 동작 자체 충족** (mapper isExpired 계산 = QRY-SHARE-001 시점).
 
-**AC-3 (예외):** 비밀번호 4자 미만 시 Zod 에러
-- **Given** `password: '123'` (3자)인 요청
-- **When** `createShareLinkSchema.parse(request)` 호출
-- **Then** ZodError 발생, `issues[0].message`가 `'비밀번호는 4자 이상이어야 합니다'`
+**AC-3 (예외, ⏸ CMD-SHARE-001 위임):** 비밀번호 4자 미만 시 Zod 에러
+- **Given** `password: '123'` (3자) 요청
+- **When** `shareLinkInputSchema.parse(request)` 호출
+- **Then** ZodError 발생, `issues[0].message === '비밀번호는 4자 이상이어야 합니다'`
+- **Status:** ⏸ CMD-SHARE-001 시점 검증 (S1 현실 메시지 그대로 사용 — 명세 §3.3 동일).
 
-**AC-4 (경계):** 비밀번호 없이 공유 링크 생성 (정상)
-- **Given** `diagnosisId`만 있고 `password`가 undefined인 요청
-- **When** `createShareLinkSchema.parse(request)` 호출
-- **Then** 검증 통과, `password`가 `undefined`
+**AC-4 (경계, ⏸ CMD-SHARE-001 위임):** 비밀번호 없이 공유 링크 생성 (정상)
+- **Given** `diagnosisId` 만, `password` undefined 요청
+- **When** `shareLinkInputSchema.parse(request)` 호출
+- **Then** 검증 통과, `password === undefined`
+- **Status:** ⏸ CMD-SHARE-001 시점 검증. ★ 본 ISSUE B.1 `CreateShareLinkRequest.password` optional 정의 완료.
 
-**AC-5 (예외):** 에러 코드 전수 매핑 검증
-- **Given** `ShareLinkErrorCode` enum의 모든 값
-- **When** 각 값에 대해 `SHARE_LINK_ERROR_MAP[code]` 조회
-- **Then** 모든 enum 값에 매핑이 존재하며, `message`가 한국어 문자열, `httpStatus`가 유효한 HTTP 상태 코드
+**AC-5 (정상, ✅ Phase B 산출물 충족):** ShareLinkErrorCode 전수 매핑 검증 (API-001 AC-5 / API-002 AC-3 패턴)
+- **Given** `ShareLinkErrorCode` enum 의 7 값 모두
+- **When** `SHARE_LINK_ERROR_MAP[code]` 조회
+- **Then** 7 값 모두 매핑 존재, `message` 한국어 문자열, `httpStatus` 100~599 범위
+- **Status:** ✅ Phase B.2 `SHARE_LINK_ERROR_MAP` 7 키 전수 매핑 작성 완료 — **TS 타입 레벨 `Record<ShareLinkErrorCode, ...>` 강제로 누락 시 컴파일 에러** (tsc Phase B.4 exit 0 검증).
+
+**AC-6 (정상, ⏸ QRY-SHARE-001 단일 owner 위임):** Prisma ShareLink → ShareLinkMetaDTO / GetReportResponse 변환 (★ dual mapper 통합)
+- **Given** Prisma `ShareLink` row + `Diagnosis` row + `candidates` JSON.parse 결과
+- **When** `mapShareLinkToMeta(shareLink)` + `mapToReportResponse(shareLink, diagnosis, candidates)` 호출 (QRY-SHARE-001 시점, 현재 S3 + S4 dual 인라인 동작 중)
+- **Then** `ShareLinkMetaDTO.isExpired` runtime 계산 (`expires_at < new Date()`) + `GetReportResponse.report` ReportDTO 정합 + `candidates` CandidateAreaDTO[] 정합 (★ API-002 (P1) 활성)
+- **Status:** ⏸ QRY-SHARE-001 시점 검증 (★ S3+S4 dual 통합 — mapper 분리 금지). ★ 본 ISSUE B.1 `GetReportResponse` + `ReportDTO` + `ShareLinkMetaDTO` 정의 완료.
 
 ---
 
@@ -208,50 +311,212 @@ assignees: []
 
 | NFR ID | SRS 본문 인용 | 본 태스크에서의 검증 방법 |
 |---|---|---|
-| REQ-NF-006 | "공유 링크 생성 응답 시간 — ≤ 500ms" (§4.2.1) | DTO 직렬화 오버헤드가 최소화되도록 불필요 중첩 제거. 응답 시간은 CMD-SHARE-001 통합 테스트에서 검증 |
-| REQ-NF-020 | "공유 링크 보안 — URL entropy ≥ 128bit (UUID v4), 열람 비밀번호 옵션" (§4.2.3) | CreateShareLinkRequest에 password optional 필드 포함. ShareLinkMetaDTO에 hasPassword 플래그로 비밀번호 설정 상태 노출 |
-| REQ-NF-021 | "비인가 접근 시 개인정보 노출 0건" (§4.2.3) | ShareLinkErrorCode.UNAUTHORIZED_ACCESS 에러 시 report 데이터를 응답에 포함하지 않는 구조 검증 |
+| REQ-NF-006 | "공유 링크 생성 응답 시간 — ≤ 500ms" (§4.2.1) | ✅ B.1 DTO 설계 — 응답 직렬화 오버헤드 최소화 (CreateShareLinkResponse 3 필드 평면 구조). ⏸ k6 부하 테스트 = CMD-SHARE-001 시점 |
+| REQ-NF-020 | "공유 링크 보안 — URL entropy ≥ 128bit (UUID v4), 열람 비밀번호 옵션, 열람 로그 실시간 알림" (§4.2.3) | ✅ B.1 `CreateShareLinkRequest.password` optional + `ShareLinkMetaDTO.hasPassword` 플래그로 비밀번호 설정 상태 노출. ⏸ UUID v4 entropy ≥ 128bit = CMD-SHARE-001 시점 (DB-004 §9.1 generateShareLinkToken) |
+| REQ-NF-021 | "비인가 접근 시 개인정보 노출 0건" (§4.2.3) | ✅ B.1 `ShareLinkErrorCode.UNAUTHORIZED_ACCESS` 정의 + B.2 `SHARE_LINK_ERROR_MAP` 403 응답. ⏸ TEST-004 (보안 케이스) 시점 통합 테스트 |
+| REQ-NF-035 | "에러 로그 알림 — Sentry 기본 알림 설정 사용" (§4.2.6) | ✅ B.1 `ShareLinkErrorDTO.originalError` 필드 정의 + B.3 `createShareLinkError()` 가 originalError 받아 Sentry catch 연계 가능. ⏸ CMD-SHARE / QRY-SHARE (실 Sentry.captureException) + MON-001 (Sentry 통합) |
 
 ---
 
-## 6. 📦 Deliverables (산출물 명시)
+## 6. 📦 Deliverables (산출물 명시 — 신규/보존/위임/정직성 4 구역)
 
-- `lib/types/share-link.ts` (ShareLink DTO 전체)
-- `lib/validators/share-link.ts` (Zod 스키마)
-- `lib/constants/share-link-errors.ts` (에러코드→메시지 매핑)
-- `lib/mappers/share-link-mapper.ts` (Prisma→DTO 변환)
-- `__tests__/types/share-link-dto.spec.ts`
-- `__tests__/validators/share-link.spec.ts`
-- `__tests__/mappers/share-link-mapper.spec.ts`
+### ✅ 신규 (4 — 3 코드 + 1 docs, Phase B + C)
+
+**Phase B 코드 (3 파일)**:
+- `onday-app/src/lib/types/share-link.ts` (신규 129 lines, **DB-002/003 와 다른 신규 첫 owner**) — §3.1 6 섹션 + §3.2 ShareLinkErrorCode 7 종 + ShareLinkErrorDTO
+- `onday-app/src/lib/constants/share-link-errors.ts` (33 lines) — §3.4 SHARE_LINK_ERROR_MAP 7 키
+- `onday-app/src/lib/helpers/share-link-error.ts` (20 lines) — createShareLinkError (API-001/002 §3.6 패턴)
+
+**Phase C 명세 (1 파일)**:
+- `tasks/API-003.md` — 본 명세 현실 동기화 (Q1~Q10 + (P1) 미묘 구분 표 + Q2 가드 사수 15행 + S1~S6 + dual mapper 신규 패턴 + Wave 2 체인 작동 증거 + API-002 §9.6 트리거 수신 + §9 follow-up 6+)
+
+### ✅ 보존 (DB-001~007 12 + API-001/002 산출물 6 + types.ts + 11+2+2 호출처 + S1~S6 + N1~N6 + mock-auth M1~M4 + .env.example = 25+종, 본 ISSUE 절대 미수정)
+
+**DB-001~007 누적 가드 (12)**: `prisma/schema.prisma`, `prisma.config.ts`, `prisma/migrations/`, `prisma/seed.ts`, `src/lib/db.ts`, `src/lib/types/errors/.gitkeep`, **`src/lib/types/user.ts`** (DB-002 — B.1 `ServiceModeType` import 재사용), **`src/lib/types/diagnosis.ts`** (DB-003 + API-002 — B.1 `CandidateAreaDTO` import 재사용), `__tests__/db/.gitkeep`, `package.json`, design 루트, `06_TASK_LIST_v1.3.md`
+
+**API-001 산출물 (3)**: `lib/types/auth.ts` (133 lines) + `auth-errors.ts` (42) + `auth-error.ts` (20) — 본 ISSUE 미수정
+
+**API-002 산출물 (3)**: `lib/types/diagnosis.ts` (DB-003 보존 + append, ★ `CandidateAreaDTO` import 재사용 대상) + `diagnosis-errors.ts` (37) + `diagnosis-error.ts` (20) — 본 ISSUE 미수정
+
+**Q2 가드 (15 행, ★ 2회째 사수)**: `src/lib/types.ts` (DiagnosisMode 11 호출처 DM1~DM11 + DiagnosisStatus 2 호출처 DS1~DS2 + forward 2건 F1~F2) — 위 §2 Q2 가드 사수 표 참조
+
+**S1~S6 ShareLink 현실 코드 가드 (DB-006 Q3 / API-002 N1~N6 패턴 답습)**: S1 `validators/diagnosis.ts:32-43` / S2 `api/share/route.ts` / S3 `api/share/[uuid]/route.ts` / S4 `app/share/[uuid]/page.tsx` / S5 `features/share/preview-stats.ts` / S6 `components/share/` 3 — 본 ISSUE 미수정
+
+**mock-auth M1~M4 + N1~N6 (API-001/002 가드 누적)**: `lib/auth.ts` 5 함수 / `stores/session.ts` / `mocks/users.ts` / `login-form.tsx` + N1 validators/diagnosis.ts:8-30 / N2~N3 api/diagnosis/route.ts POST + [id]/route.ts GET / N4 mock-calculator / N5 diagnosis-store / N6 detail-mapper — 본 ISSUE 무관여
+
+**`.env.example` Supabase 3종**: 본 ISSUE 미수정
+
+### ⏸ 위임 (5 + 명확화 1 = 6)
+
+- §3.3 `lib/validators/share-link.ts` `createShareLinkSchema` + `verifyPasswordSchema` (현실 S1 통합 + 명세 정합 + API-002 §9.6 트리거 수신) → **CMD-SHARE-001** (Q7)
+- §3.5 `lib/mappers/share-link-mapper.ts` `mapShareLinkToMeta` + `mapToReportResponse` (★ S3+S4 dual 통합) → **QRY-SHARE-001 단일 owner (mapper 분리 금지)** (Q8)
+- §3.6 type spec 4 케이스 + §3.7 validator spec 5 케이스 + §3.8 mapper spec 3 케이스 → **TEST-003 (GWT)** (Q9)
+- 보안 케이스 (UNAUTHORIZED_ACCESS + PASSWORD_MISMATCH + REQ-NF-021) → **TEST-004 (보안)** (Q9)
+- DB-004 §9.1 helper (calculateExpiresAt / isShareLinkExpired / generateShareLinkToken) → **CMD-SHARE-001 명확화** (Q10, DB-004 §9.1 정합)
+- DataSourceDTO 목록 + OG 메타태그 → **UI-007** (§9.5/9.6 follow-up)
+
+### 🔄 정직성 (1)
+
+- **★ Wave 2 체인 작동 첫 코드 입증** — DB-003 DiagnosisStatusType (사용처 0건) → API-002 첫 활성 (Wave 1→Wave 2) → **API-003 CandidateAreaDTO 첫 외부 활용 (Wave 2 내부 체인)**. 12 ISSUE 누적 워크플로 = 격리된 칸 아닌 체인 시스템 입증. §9 본문 표 참조.
 
 ---
 
 ## 7. 🔗 Dependencies (의존성 — 양방향)
 
-### 선행:
-- **DB-004:** `model ShareLink` Prisma 스키마 — DTO 변환 대상
+### 선행 (이 ISSUE 시작 전 필요)
 
-### 후행:
-- **MOCK-002:** 공유 링크 Mock 데이터 — ShareLinkMetaDTO, GetReportResponse 기반
-- **CMD-SHARE-001~004:** 공유 링크 CRUD 구현 — Request/Response DTO 활용
-- **QRY-SHARE-001:** 리포트 SSR 열람 — GetReportResponse DTO 사용
-- **TEST-003:** 공유 링크 GWT 시나리오 — DTO 기반 테스트
-- **TEST-004:** 공유 링크 보안 테스트
+- **DB-002** (PR #76 머지 완료): `user.ts` `ServiceModeType` — ★ B.1 `import type { ServiceModeType } from './user'` 재사용 (Q2 (A) 핵심).
+- **DB-003** (PR #77 머지 완료): `diagnosis.ts` base + L3-4 주석 (API-002 PR #82 완전 해소) — 간접 선행.
+- **DB-004** (PR #78 머지 완료, main `0e846b2`): `tasks/DB-004.md` (코드 0, 명세만 — Q7/Q8 DTO=API-003 위임 + §9.1 helper=CMD-SHARE-001 위임). ★ **본 ISSUE 가 DTO 위임 트리거 수신**.
+- **API-001** (PR #81 머지 완료, main `ee83429`): API Contract 트랙 (B) 절충 + 커밋 2개 + (P1) OAuthProvider=AuthProviderType 패턴. ★ 본 ISSUE 답습 기준.
+- **API-002** (PR #82 머지 완료, main `891ae97`): `lib/types/diagnosis.ts` (★ `CandidateAreaDTO = CandidateArea` re-export L27) + Q2 9칸 가드 첫 성공 + L6 3차 cleanup 트리거 + **§9.6 정정 "shareLink* 2종 = CMD-SHARE 영역"**. ★ **본 ISSUE 핵심 — CandidateAreaDTO 첫 외부 활용 + §9.6 트리거 수신**.
+- **DB-007** (PR #80 머지 완료): L6 1차 발견 — 본 ISSUE = Q2 가드 2회째 사수 (cleanup 의존성 약함).
+- **DB-006** (PR #79) / **DB-001** (PR #75): 간접 선행 (Phase 패턴 + dead 회피 논리 답습).
+
+### 후행 (이 ISSUE 완료 후 차례로 가능)
+
+- **★ CMD-SHARE-001** (공유 링크 생성): S1 (shareLinkInputSchema + shareAccessSchema) + S2 (POST createShareLink Server Action 추출) + DB-004 §9.1 helper (calculateExpiresAt 30일 / isShareLinkExpired / generateShareLinkToken UUID v4) + bcrypt 해싱 + B.1 import + API-002 §9.6 트리거 수신
+- **★ QRY-SHARE-001** (리포트 조회) — **단일 owner**: ★ S3 + S4 dual mapper 통합 (Route Handler + SSR 양쪽) + B.1 활용 + isExpired runtime 계산 통합 (mapper 분리 금지)
+- **CMD-SHARE-002~004** (비밀번호 검증 / 만료 처리 / 미리보기): B.1 VerifyPasswordRequest / Response + ShareLinkErrorCode 활용
+- **★ TEST-003** (공유 링크 GWT): 정상 / 만료 / 비밀번호 / 미리보기 (AC-1~4)
+- **★ TEST-004** (공유 링크 보안): UNAUTHORIZED + PASSWORD_MISMATCH + REQ-NF-021
+- **★ MOCK-002** (ShareLink Mock 데이터): B.1 활성 후 GetReportResponse / ShareLinkMetaDTO Mock + 만료/비밀번호 시나리오 3종
+- **★ UI-007** (SSR 공유 리포트 페이지): DataSourceDTO 목록 + OG 메타태그 `generateMetadata()` + 무료 미리보기 1곳 + 데이터 출처 배지 UI
+- **★ cleanup ISSUE (REFACTOR-L6 또는 MOCK-005 연계)**: API-002 §9.4 트리거 일관. 본 ISSUE 의존성 약함 (F1+F2 forward 2 호출처, types.ts 직접 import 0)
 
 ---
 
 ## 8. 🧪 Test Plan (검증 절차)
 
-- **단위 테스트:** `__tests__/types/share-link-dto.spec.ts` — 4개 케이스
-- **단위 테스트:** `__tests__/validators/share-link.spec.ts` — 5개 케이스
-- **단위 테스트:** `__tests__/mappers/share-link-mapper.spec.ts` — 3개 케이스 (정상, 만료, 비밀번호 설정)
-- **수동 검증:** `tsc --noEmit` 통과
-- **CI 게이트:** `tsc --noEmit`, Jest 100%, ESLint 통과
+### Phase A (본 ISSUE) — 사전 검증 (read-only) — ✅ 완료
+
+- ✅ A.1 main 동기화: `ee83429..891ae97` fast-forward (PR #82 머지본 흡수 — API-002 산출물)
+- ✅ A.2 DB-001~007 + API-001/002 산출물 main 반영 확인 (`auth.ts` 5527B / `auth-errors.ts` 1624B / `auth-error.ts` 637B / `diagnosis.ts` 5313B DB-003 보존 + append / `diagnosis-errors.ts` 1677B / `diagnosis-error.ts` 677B / `user.ts` 442B)
+- ✅ A.3 `types.ts:1-3` (가드) + `diagnosis.ts` (API-002 산출물 — L27 CandidateAreaDTO 첫 외부 활용 대상) + `user.ts` (ServiceModeType) read-only
+- ✅ A.4 **S1~S6 ShareLink 현실 코드 grep** — S1 validators 23 (본체) / S2 60 / S3 61 / S4 76 / S5 0.8 KB / S6 3 components (메모리 정확 일치)
+- ✅ A.5 **Q2 DiagnosisMode forward grep** — F1 page.tsx:42 + F2 route.ts:49 = 정확 2건 (메모리 일치, types.ts 직접 import 0, cleanup 의존성 약함 근거)
+- ✅ A.6 Prisma model ShareLink read-only (8 필드 + 1 relation — Q8 mapper sig 근거, 본 ISSUE 미작성)
+- ✅ A.7 vitest config 부재 (vitest `^4.1.6` 의존성만 — DB-001~007 + API-001/002 일관)
+- ✅ A.8 `lib/constants/` (auth-errors.ts + diagnosis-errors.ts) + `lib/helpers/` (auth-error.ts + diagnosis-error.ts) 상태 확인 + `lib/types/` (auth.ts + diagnosis.ts + user.ts + errors/) — share-link-* 신규 작성 위치 OK
+- ✅ A.9 `prisma validate` exit 0 + `prisma generate` exit 0 (7.8.0, 21ms) + `tsc --noEmit` exit 0
+- ✅ A.10 env-less `npm run build` exit 0 + **Middleware 32.5 kB** (INFRA-001 AC-4 anchor, **10번째 회귀 0**)
+- ✅ A.11 `feature/API-003` 브랜치 분기 + untracked 2건 외 변경 0
+
+### Phase B (본 ISSUE) — 활성, 3 파일 신규 — ✅ 완료
+
+- ✅ B.1 `lib/types/share-link.ts` 신규 129 lines (6 섹션 + ShareLinkErrorCode 7종 + ShareLinkErrorDTO, ★ DB-002/003 와 다른 신규 첫 owner)
+- ✅ B.2 `lib/constants/share-link-errors.ts` 신규 33 lines (SHARE_LINK_ERROR_MAP 7 키)
+- ✅ B.3 `lib/helpers/share-link-error.ts` 신규 20 lines (createShareLinkError)
+- ✅ B.4 `tsc --noEmit` exit 0 (회귀 0) + `prisma validate` exit 0 + 가드 8 그룹 무수정 (DiagnosisMode 11 + DiagnosisStatus 2 + types.ts + API-001/002 산출물 + DB-001~007 + S1~S6 + F/G/H grep)
+
+### 후행 ISSUE 검증 (위임)
+
+- **CMD-SHARE-001**: §3.3 `createShareLinkSchema` (S1 통합) + AC-1/3/4 + DB-004 §9.1 helper 통합
+- **QRY-SHARE-001 단일 owner**: §3.5 `mapShareLinkToMeta` + `mapToReportResponse` (★ S3+S4 dual 통합) + AC-2/6
+- **TEST-003 + TEST-004**: §3.6/3.7/3.8 + 보안 케이스 분배
+- **UI-007**: DataSourceDTO + OG 메타태그
+- **수동 검증** (CMD-SHARE / QRY-SHARE 시점):
+  1. `tsc --noEmit` 으로 DTO ↔ Zod schema z.infer ↔ Prisma model 호환 재확인
+  2. IDE 에서 `ShareLinkMetaDTO` / `GetReportResponse` 자동완성 정상 동작
+  3. Mock 모드 + 실 모드 모두 DTO 정합 확인
 
 ---
 
-## 9. 🚧 Open Questions / Risks (보류 사항)
+## 9. 🚧 Open Questions / Risks (보류 사항 — follow-up 6+ + ★ Wave 2 체인 작동 증거 표 + ★ (P1) 미묘 구분 § + ★ API-002 §9.6 트리거 수신 §)
 
-1. **무료 미리보기 1곳 선정 로직:** `previewCandidateId`를 어떻게 결정할지 — 스코어 1위 자동 선택 vs 사용자 선택 — CMD-SHARE-001/QRY-SHARE-001 작업 시 확정.
-2. **DataSourceDTO 목록:** 데이터 출처 배지에 포함할 소스 목록이 SRS에 구체적으로 열거되지 않음 — UI-007 작업 시 확정. DTO는 유연한 배열 구조로 설계.
-3. **OG 메타태그 데이터:** §6.3.2에서 `generateMetadata()` 언급 — GetReportResponse에 OG용 필드(title, description, image)를 포함할지 — UI-007 작업 시 확정.
+### ★ Wave 2 체인 작동 증거 표 (★ 본 ISSUE 첫 코드 입증 — 향후 후행 ISSUE 학습 가이드)
+
+12 ISSUE 누적 워크플로 = 격리된 칸 아닌 **체인 시스템** 입증. 본 ISSUE 가 첫 코드 증거:
+
+| 체인 | 시점 | 증거 |
+|---|---|---|
+| **Wave 1 → Wave 2** | DB-003 PR #77 (`DiagnosisStatusType` 정의, 사용처 0건) → API-002 PR #82 (DiagnosisDTO.status + CreateDiagnosisResponse.status 첫 활성) | 1 단계 — DB → API 트랙 |
+| **★ Wave 2 내부 (★ 본 ISSUE)** | API-002 PR #82 (`CandidateAreaDTO = CandidateArea` re-export, diagnosis.ts L27 — 외부 활용 0건) → **★ API-003 본 ISSUE (`ReportDTO.candidates: CandidateAreaDTO[]` 첫 외부 활용)** | 2 단계 — API → API 트랙 내부 체인 작동 첫 코드 입증 |
+
+**입증 내용**:
+- 12 ISSUE (INFRA-001 / DB-001~007 / API-001/002/003) 가 격리된 칸이 아닌 의존 체인으로 동작
+- DTO 위임 트리거 (DB-003 → API-002 / DB-004 → API-003) + (P1) 재사용 체인 (API-001 → API-002 → **API-003**) + cleanup ISSUE 트리거 체인 (DB-007 L6 1차 → API-001 L6 2차 → API-002 L6 3차) 가 정상 작동
+- 향후 후행 ISSUE (CMD-DIAG / QRY-DIAG / CMD-SHARE / QRY-SHARE / TEST-* / cleanup ISSUE) 가 본 체인 답습 가능
+
+### ★ (P1) 패턴 미묘 구분 § (★ 본 ISSUE 특화 발견 — 향후 새 도메인 type 만드는 ISSUE 가이드)
+
+§2 (P1) 미묘 구분 표 참조. 핵심 요점 재명시:
+- (P1) 정신 = **기존 도메인 entity 재사용** (`OAuthProvider=AuthProviderType` / `CandidateAreaDTO=CandidateArea`)
+- (P1) ≠ Prisma 직접 노출 (`ShareLinkMetaDTO=PrismaShareLink` 절대 금지 — 관심사 분리)
+- base type 부재 시 자기 도메인 신규 정의 = 정상 (DB-004 패턴 일관 — 본 ISSUE 의 share-link.ts)
+- API-001 → API-002 = (P1) 적용 / **API-003 = (P1) 적용 불가 (base 0) + Q3 (C) hybrid** (외부 도메인 type re-import + 자기 도메인 type 신규 정의)
+- 향후 새 도메인 type 만드는 ISSUE (예: SavedSearch DTO=API-005 base 존재 / Notification DTO=base 부재 등) 는 본 표 참조
+
+### ★ API-002 §9.6 트리거 수신 § (★ 트리거 체인 작동 — mismatch 추적 정신 누적)
+
+**API-002 PR #82 §9.6** ("validators/diagnosis.ts 47줄 = 파일 전체 / diagnosisInputSchema 본체 23줄 / shareLinkInputSchema + shareAccessSchema = CMD-SHARE 영역") → **본 ISSUE 가 수신**:
+- §2 S1 표 + §3.3 명세 + §9.1 follow-up 모두 명시
+- CMD-SHARE-001 위임 트리거 활성 (S1 인라인 동작 중 보존 + 명세 §3.3 정합)
+- 9칸 + API-001/002 mismatch 추적 정신 체인 작동 (정직 기록 → 후행 ISSUE 수신 → 다음 ISSUE 위임 트리거)
+- 향후 후행 ISSUE (CMD-SHARE-001) 가 본 §9.1 follow-up 트리거 그대로 받음
+
+### 1. ★ §3.3 CMD-SHARE-001 위임 — `createShareLinkSchema` + `verifyPasswordSchema` 통합
+
+CMD-SHARE-001 시점에:
+- S1 `validators/diagnosis.ts:32-43` 23 lines 인라인 → 추출 또는 보존 결정
+- 명세 §3.3 정합 검증 + `password.min(4)` 메시지 ↔ 현실 "비밀번호는 4자 이상이어야 합니다" 정합
+- Route Handler L13 `safeParse` 호출처 S2 통합
+- B.1 `CreateShareLinkRequest` / `VerifyPasswordRequest` import 정합 + `ShareLinkErrorCode.PASSWORD_REQUIRED/MISMATCH` 활용
+- AC-1 / AC-3 / AC-4 검증 활성 (TEST-003 시점)
+- ★ API-002 §9.6 트리거 수신 반영 (validators/diagnosis.ts 47줄 = 파일 전체 → shareLink* 2종 분리 검토 또는 위임 유지)
+
+### 2. ★ §3.5 QRY-SHARE-001 단일 owner 위임 — `mapShareLinkToMeta` + `mapToReportResponse` 추출 (★ mapper 분리 금지)
+
+QRY-SHARE-001 시점에:
+- `lib/mappers/share-link-mapper.ts` 신규: `mapShareLinkToMeta(shareLink: PrismaShareLink): ShareLinkMetaDTO` + `mapToReportResponse(shareLink, diagnosis, candidates): GetReportResponse`
+- **★ S3 + S4 dual 인라인 → 단일 mapper 추출 + 양쪽 호출처 통합** (Route Handler + SSR 가 같은 mapper 함수 import)
+- **★ mapper 분리 금지** — S3 mapper / S4 mapper 분리 시 DRY 위반 + 유지보수 폭발 (Route + SSR 양쪽 같은 변환 로직 중복)
+- B.1 `GetReportResponse` / `ReportDTO` / `ShareLinkMetaDTO` 활용
+- ShareLinkMetaDTO.isExpired runtime 계산 (`expires_at < new Date()`) + DB-004 §9.1 `isShareLinkExpired` helper 활용 (CMD-SHARE-001 통합)
+- Sentry catch + `ShareLinkErrorCode.DIAGNOSIS_NOT_FOUND` / `LINK_NOT_FOUND` / `LINK_EXPIRED` / `UNAUTHORIZED_ACCESS` 활용
+- AC-2 / AC-6 검증 활성 (TEST-003/004 시점)
+- ★ S5 (preview-stats) + S6 (components/share/) 는 본 mapper 와 별 영역 (UI 표시) — UI-007 영역 유지
+
+### 3. ★ §3.6/3.7/3.8 TEST-003 + TEST-004 분배 위임
+
+TEST-003 (공유 링크 GWT) 시점에:
+- `vitest.config.ts` 신규 (DB-001~007 §3.10 + API-001 §3.7/3.8 + API-002 §3.6/3.7/3.8 + 본 ISSUE §3.6/3.7/3.8 일괄 위임 누적 해소)
+- `__tests__/types/share-link-dto.spec.ts` 4 케이스 (ShareLinkMetaDTO 필수 필드 / CreateShareLinkResponse 정합 / GetReportResponse.report.candidates: CandidateAreaDTO[] 정합 / ShareLinkErrorCode 전수 매핑)
+- `__tests__/validators/share-link.spec.ts` 5 케이스 (정상 / diagnosisId 무효 / password 3자 / password 누락 정상 / 빈 token)
+- `__tests__/mappers/share-link-mapper.spec.ts` 3 케이스 (정상 / 만료 / 비밀번호 설정)
+- `__tests__/helpers/share-link-error.spec.ts` 3 케이스 (API-001 helper spec 패턴 추가)
+- 공유 링크 GWT E2E (REQ-FUNC-009~011 통합 — POST /api/share → 공유 URL → 비회원 SSR /share/[uuid] → 무료 미리보기 1곳)
+
+TEST-004 (공유 링크 보안) 시점에:
+- `UNAUTHORIZED_ACCESS` + `PASSWORD_MISMATCH` 케이스 + REQ-NF-021 비인가 접근 시 개인정보 노출 0건 검증
+
+### 4. ★ Q10 — DB-004 §9.1 helper CMD-SHARE-001 영역 명확화 (본 ISSUE 미수정)
+
+본 ISSUE 미수정. CMD-SHARE-001 시점에:
+- `calculateExpiresAt(createdAt: Date): Date` — 30일 만료 계산
+- `isShareLinkExpired(expiresAt: Date): boolean` — 만료 체크 (QRY-SHARE-001 mapper 활용)
+- `generateShareLinkToken(): string` — UUID v4 entropy ≥ 128bit (REQ-NF-020)
+- S2/S3/S4 인라인 등가 동작 통합 (DB-004 §9.1 위임 트리거 활성)
+
+### 5. ★ previewCandidateId 선정 로직 (Q3 보조 follow-up)
+
+본 ISSUE B.1 `ReportDTO.previewCandidateId: string | null` 정의 + 주석 "§9.1 follow-up — 선정 로직 CMD-SHARE/QRY-SHARE 위임".
+CMD-SHARE-001 (생성 시점 자동) 또는 QRY-SHARE-001 (조회 시점 자동) 시점 결정:
+- 옵션 A: 스코어 1위 자동 선택 (candidates[0].score 기준)
+- 옵션 B: 사용자 선택 (UI-007 영역)
+- 옵션 C: 둘 다 지원 (DB 필드 추가 — 별도 ISSUE)
+
+### 6. ★ DataSourceDTO 목록 + OG 메타태그 — UI-007 영역
+
+UI-007 (SSR 공유 리포트 페이지) 시점에:
+- DataSourceDTO 목록 정의 (`name`, `type: 'public_data' | 'api' | 'static'`, `lastUpdated`)
+- 예시: 카카오 모빌리티 API / 서울시 공공데이터 (안전등급) / 통계청 등
+- OG 메타태그 `generateMetadata()` — title (`{진단명} 공유 리포트`) / description / image (`/og/share/{uuid}.png` 동적 생성)
+- 무료 미리보기 1곳 + 데이터 출처 배지 UI
+
+### 추가 보조 (명세 §9 v1.0 보존)
+
+- **CandidateArea Prisma 모델 존재 여부**: SRS ERD 에 CandidateArea 별도 테이블 미명시 — 현재 DIAGNOSIS.candidates JSONB 인라인 (API-002 §9 추가 보조 일관). INFRA-002 Postgres 마이그 시점 결정.
+- **무료 미리보기 1곳 정책**: candidates[0] (스코어 1위) 자동 선정 vs 사용자 선택 — CMD-SHARE-001 / QRY-SHARE-001 / UI-007 협업 결정
+- **공유 링크 만료 알림 푸시 (REQ-FUNC-010)**: 본 ISSUE 비대상 — CMD-SHARE 영역 (만료 30일 시점 푸시 발송)
+- **비밀번호 4~20자 정책**: 현실 S1 정합 (`min(4)` `max(20)`). 명세 §3.3 동일.


### PR DESCRIPTION
## 📌 Summary

API Contract 트랙 세 번째 진입 — ShareLink 도메인 DTO + ShareLinkErrorCode 7 종 + SHARE_LINK_ERROR_MAP + createShareLinkError helper 추가. **API-001/002 (B) 절충 패턴 정확 답습** (Phase B 활성 + 커밋 2개 feat+docs 분리).

**산출물:** 신규 3 코드 + 명세 1 갱신 = 4 파일. 위임 5 + 명확화 1 (CMD-SHARE-001 / QRY-SHARE-001 단일 / TEST-003·004 / UI-007 / DB-004 §9.1).

**Refs #13** (자동 닫힘 방지)

---

## 🎯 산출물 요약

| # | 파일 | 라인 | 내용 |
|---|---|---|---|
| **B.1** | `onday-app/src/lib/types/share-link.ts` | **129** (★ DB-002/003 와 다른 신규 첫 owner) | 6 섹션: Request 2 + Response 3 + ReportDTO + DataSourceDTO + ShareLinkMetaDTO + ShareLinkErrorCode 7종 + ShareLinkErrorDTO |
| **B.2** | `onday-app/src/lib/constants/share-link-errors.ts` | **33** | SHARE_LINK_ERROR_MAP 7 키 (410/404x2/401x2/403x2) |
| **B.3** | `onday-app/src/lib/helpers/share-link-error.ts` | **20** | createShareLinkError(code, originalError?) |
| **C** | `tasks/API-003.md` | 256 → **522** | 명세 현실 동기화 |

---

## ★ (P1) 패턴 미묘 구분 표 (★ 본 ISSUE 특화 발견 — 향후 새 도메인 type ISSUE 가이드)

(P1) "재사용 패턴" = **기존 도메인 entity 재사용** 정신, Prisma 직접 노출 아님. base type 존재 여부에 따라 적용 분기:

| ISSUE | base type 존재 | (P1) 적용 | 패턴 | 신규 정의 |
|---|---|---|---|---|
| **API-001** | ✅ user.ts AuthProviderType (DB-002) | ✅ 적용 | OAuthProvider=AuthProviderType (re-export) | 8 섹션 신규 |
| **API-002** | ✅ types.ts CandidateArea/CommuteInfo/DiagnosisInput + user.ts ServiceModeType + diagnosis.ts DiagnosisStatusType | ✅ 적용 (3 re-export) | CandidateAreaDTO=CandidateArea + 2종 | 4 신규 |
| **★ API-003** | ❌ **DB-004 base type 0** (Q7/Q8 명세만, DTO=API-003 위임) | ❌ **적용 불가** | 자기 도메인 type 신규 정의 (Prisma re-export 절대 금지) | **6 섹션 전부 신규** |

**외부 도메인 type 재사용 (Q3 (C) hybrid)**:
- `ServiceModeType` from `'./user'` (Q2 (A) — DB-002 산출물, **DiagnosisMode 미사용 = Q2 가드**)
- **`CandidateAreaDTO` from `'./diagnosis'` (★ API-002 (P1) 산출물 첫 외부 활용 = Wave 2 체인 작동 첫 코드 입증)**

---

## ★ Q2 가드 사수 표 15행 (DM + DS + ★ F1+F2 forward — Q2 가드 2회째 사수)

DiagnosisMode 11 + DiagnosisStatus 2 + forward 2 = 15 호출처 본 ISSUE 0 치환:

| # | 위치 | 라인 | 본 ISSUE |
|---|---|---|---|
| DM1-DM4 | types.ts | L2/55/66/88 | 미수정 |
| DM5-DM7 | mock-calculator.ts | L5/85/193 | 미수정 |
| DM8-DM11 | diagnosis-store.ts | L2/15/30/48 | 미수정 |
| DS1 | types.ts | L3 (DiagnosisStatus 정의) | 미수정 |
| DS2 | types.ts | L69 (DiagnosisResult.status) | 미수정 |
| **★ F1** | app/share/[uuid]/page.tsx | **L42** (`as "couple" \| "single"` cast — forward) | 미수정 (의존성 약함) |
| **★ F2** | app/api/share/[uuid]/route.ts | **L49** (Prisma string 그대로 forward) | 미수정 (의존성 약함) |

★ Q2 가드 2회째 사수 (API-002 Q2 첫 성공 일관) — ReportDTO.mode = ServiceModeType (Q2 A) + cleanup ISSUE 의존성 약함 (forward 패턴, types.ts 직접 import 0).

---

## ★ S1~S6 ShareLink 현실 코드 (본 ISSUE 미수정, DB-006 Q3 / API-002 N1~N6 패턴 답습)

| # | 위치 | 라인 | 후행 |
|---|---|---|---|
| **S1** | validators/diagnosis.ts:32-43 | 23 (본체) | CMD-SHARE-001 (★ API-002 §9.6 트리거 수신) |
| **S2** | api/share/route.ts (POST) | 60 | CMD-SHARE-001 (Server Action + bcrypt + DB-004 §9.1) |
| **S3** | api/share/[uuid]/route.ts (GET) | 61 | QRY-SHARE-001 단일 owner (★ dual) |
| **S4** | app/share/[uuid]/page.tsx (SSR) | 76 | QRY-SHARE-001 단일 owner (★ dual) |
| **S5** | features/share/preview-stats.ts | 0.8 KB | UI-007 무관여 |
| **S6** | components/share/ 3 | 6 KB | UI-007 무관여 |

---

## ★ S3+S4 dual mapper 패턴 표 (★ ShareLink 특화 신규 — API-002 mapper 와 다름)

| 항목 | API-002 mapper | **★ API-003 mapper (신규 패턴)** |
|---|---|---|
| 인라인 위치 | N3 [id]/route.ts:19-34 (single inline) | **★ S3 + S4 dual inline (Route + SSR 양쪽)** |
| 추출 owner | QRY-DIAG-001 (single) | **★ QRY-SHARE-001 단일 owner (mapper 분리 금지)** |
| 분리 위험 | — | **★ DRY 위반 + 유지보수 폭발 (Route + SSR 양쪽 같은 변환 로직 중복)** |
| 미래 작업자 가이드 | — | **★ 단일 mapper (`mapShareLinkToMeta` + `mapToReportResponse`) + S3+S4 양쪽 호출처 통합** |

---

## ★ 부재 산출물 (위임 5 + 명확화 1)

| 명세 §3 | 현실 | 위임 |
|---|---|---|
| §3.3 createShareLinkSchema + verifyPasswordSchema | S1 인라인 + API-002 §9.6 트리거 수신 | **CMD-SHARE-001** |
| §3.5 mapShareLinkToMeta + mapToReportResponse | ★ S3+S4 dual 인라인 | **★ QRY-SHARE-001 단일 owner (분리 금지)** |
| §3.6/3.7/3.8 spec ×3 | vitest config 부재 | **TEST-003 (GWT)** |
| 보안 케이스 (UNAUTHORIZED + PASSWORD_MISMATCH + REQ-NF-021) | vitest config 부재 | **TEST-004 (보안)** |
| DB-004 §9.1 helper (calculateExpiresAt / isShareLinkExpired / generateShareLinkToken) | S2/S3/S4 인라인 등가 | **CMD-SHARE-001 명확화** |

---

## ★ Wave 2 체인 작동 증거 표 (★ 본 ISSUE 첫 코드 입증)

12 ISSUE 누적 워크플로 = 격리된 칸 아닌 체인 시스템:

| 체인 | 시점 | 증거 |
|---|---|---|
| **Wave 1 → Wave 2** | DB-003 PR #77 (DiagnosisStatusType 정의, 사용처 0건) → API-002 PR #82 (DiagnosisDTO.status + CreateDiagnosisResponse.status 첫 활성) | 1 단계 |
| **★ Wave 2 내부 (★ 본 ISSUE)** | API-002 PR #82 (CandidateAreaDTO=CandidateArea re-export, diagnosis.ts L27 — 외부 활용 0건) → **★ API-003 본 ISSUE (ReportDTO.candidates: CandidateAreaDTO[] 첫 외부 활용)** | 2 단계 |

**입증**: DTO 위임 트리거 (DB-003→API-002 / DB-004→API-003) + (P1) 재사용 체인 (API-001 → API-002 → **API-003**) + cleanup ISSUE 트리거 체인 (DB-007 L6 1차 → API-001 L6 2차 → API-002 L6 3차) 정상 작동.

---

## ★ (P1) 패턴 미묘 구분 § (향후 새 도메인 type 만드는 ISSUE 가이드)

- (P1) 정신 = **기존 도메인 entity 재사용** (OAuthProvider=AuthProviderType / CandidateAreaDTO=CandidateArea)
- (P1) ≠ Prisma 직접 노출 (ShareLinkMetaDTO=PrismaShareLink 절대 금지 — 관심사 분리)
- base type 부재 시 자기 도메인 신규 정의 = 정상 (DB-004 패턴 일관 — 본 ISSUE)
- 향후 새 도메인 type 만드는 ISSUE (예: SavedSearch DTO=API-005 base 존재 / Notification DTO=base 부재 등) 본 표 참조

---

## ★ API-002 §9.6 트리거 수신 § (트리거 체인 작동)

**API-002 PR #82 §9.6** ("validators/diagnosis.ts 47줄 = 파일 전체 / diagnosisInputSchema 본체 23줄 / shareLinkInputSchema + shareAccessSchema = CMD-SHARE 영역") → **본 ISSUE 가 수신**:
- §2 S1 표 + §3.3 명세 + §9.1 follow-up 모두 명시
- CMD-SHARE-001 위임 트리거 활성
- 9칸 + API-001/002 mismatch 추적 정신 체인 작동 (정직 기록 → 후행 수신 → 다음 위임 트리거)

---

## §9 follow-up 6+

1. §3.3 Zod = CMD-SHARE-001 (S1+S2 POST + bcrypt + DB-004 §9.1 helper)
2. §3.5 mapper = QRY-SHARE-001 단일 owner (★ S3+S4 dual 통합)
3. §3.6/3.7/3.8 spec + helper spec + 공유 링크 GWT E2E = TEST-003 + TEST-004 분배
4. Q10 DB-004 §9.1 helper = CMD-SHARE-001 명확화
5. previewCandidateId 선정 로직 = CMD-SHARE/QRY-SHARE (스코어 1위 자동 vs 사용자 선택)
6. DataSourceDTO 목록 + OG 메타태그 = UI-007 (generateMetadata)

+ 추가 보조 4종: CandidateArea Prisma model / 무료 미리보기 1곳 정책 / 만료 알림 푸시 / 비밀번호 4~20자

---

## ✅ 검증 결과

| 검증 | 결과 | 비고 |
|---|---|---|
| npx prisma validate | ✅ exit 0 | valid 🚀 |
| npx prisma generate | ✅ exit 0 | Prisma Client 7.8.0 (24ms) |
| npx tsc --noEmit | ✅ exit 0 | 회귀 0, Phase B 기준선 유지 |
| env-less npm run build | ✅ exit 0 | — |
| **ƒ Middleware** | ✅ **32.5 kB** | INFRA-001 AC-4 — **10번째 회귀 0** (INFRA-001/DB-001~007/API-001/API-002/API-003) |
| User 모델 password grep | ✅ 0건 | DB-002/004 AC-6 일관 (ShareLink.passwordHash 별 모델) |
| 가드 무수정 (5 그룹) | ✅ 0 lines | types.ts/S1~S6/N1~N6+mock-auth/API-001/002 산출물/DB-001~007 |

---

## 📂 격리 검증

```
A  onday-app/src/lib/types/share-link.ts            (+129, 신규 첫 owner)
A  onday-app/src/lib/constants/share-link-errors.ts (+33, 신규)
A  onday-app/src/lib/helpers/share-link-error.ts    (+20, 신규)
M  tasks/API-003.md                                 (+452/-187, 256→522 lines)
```

untracked 2건 (`.agents/skills`, `tasks/ISSUE_REGISTER_LOG.md`) staging 안 함.

---

## 🔗 명세 문서

[tasks/API-003.md](../blob/feature/API-003/tasks/API-003.md) — Q1~Q10 mismatch 추적 표 12행 + (P1) 미묘 구분 표 + Q2 가드 사수 표 15행 + S1~S6 + S3+S4 dual mapper 패턴 표 + Wave 2 체인 작동 증거 표 + §9 follow-up 6+

## 🔀 커밋 (2개 분리 — API-001/002 패턴 정확 답습)

- `d002d95` feat(API-003): 신규 3 코드 파일 (+182)
- `6259b24` docs(API-003): tasks/API-003.md 명세 동기화 (+452/-187)

★ 머지·Issue #13 닫기는 PR 보고 직접 결정 (자동 머지 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)