### PR TITLE
[REFACTOR] UI-003-FEEDBACK — 사용자 검증 + 즉시 반영 워크플로 답습 7회째 (★ 진짜 버그 정정 ㊒ + 5건 정정) + ★ "사용자 입력 → 결과" 자연 흐름 도달 (르르 짚음 정수) + ★★★ Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 (본 ISSUE 진짜 가치 진화 정점 + ㊗ + ㊘ 2건 Phase A 시점 발견 + Phase B 0건) + "한 ISSUE 한 본질" 분리 답습 + 별도 ISSUE 사전 명시 (FEAT-DIAGNOSIS-INPUT-FILTERS + FEAT-RESULT-WHAT-IF-SIMULATION) + ISSUE 신설 자동화 답습 7회째 + 27칸 도달

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -32,13 +32,6 @@ import { useUIStore } from "@/stores/ui";
 import { SortControl } from "./sort-control";
 import { TimeSlotSelector, type TimeSlot } from "./time-slot-selector";
 
-const TIME_OPTIONS: { value: string; label: string }[] = [
-  { value: "07:00", label: "07:00" },
-  { value: "08:00", label: "08:00" },
-  { value: "09:00", label: "09:00" },
-  { value: "10:00", label: "10:00" },
-];
-
 interface ResultContentProps {
   candidates: CandidateArea[];
   filters: DiagnosisFilters;
@@ -67,7 +60,9 @@ export function ResultContent({
 
   const [selectedId, setSelectedId] = React.useState<string | null>(null);
   const [openId, setOpenId] = React.useState<string | null>(null);
-  const [timeSlot, setTimeSlot] = React.useState<TimeSlot>("08:00");
+  // Issue #106 ㊒ — 진단 입력 출근시간 → 결과 페이지 표시 (데이터 흐름 정합).
+  const initialTime = (filters.commuteSchedule?.departureTime ?? "08:00") as TimeSlot;
+  const [timeSlot, setTimeSlot] = React.useState<TimeSlot>(initialTime);
 
   const selectedCandidate = React.useMemo(
     () => (openId ? sorted.find((c) => c.id === openId) ?? null : null),
@@ -124,21 +119,26 @@ export function ResultContent({
   return (
     <div className="space-y-s-4">
       <FilterPanel
-        time="08:00"
-        onTimeChange={() => notifyComingSoon("출근 시간대")}
-        timeOptions={TIME_OPTIONS}
+        // Issue #106 ㊘ — TimeTabs 미박힘 (★ "사용자 입력 → 결과" 자연 흐름 도달).
+        //   ㊔ 사용자 입력 X 필터는 chip 숨김 (★ "제한 없음"/"전체" 표시 X).
+        //   ㊒ 출근시간 chip = 사용자 입력값 박힘 (★ 진단 → 결과 데이터 흐름 정합).
         filters={[
           {
+            label: "출근시간",
+            value: filters.commuteSchedule?.departureTime ?? "08:00",
+            onClick: () => notifyComingSoon("출근시간 필터"),
+          },
+          filters.maxCommuteTime != null && {
             label: "통근시간",
             value: formatCommuteFilter(filters.maxCommuteTime),
             onClick: () => notifyComingSoon("통근시간 필터"),
           },
-          {
+          filters.budget != null && {
             label: "예산",
             value: formatBudgetFilter(filters.budget),
             onClick: () => notifyComingSoon("예산 필터"),
           },
-        ]}
+        ].filter(Boolean) as { label: string; value: string; onClick: () => void }[]}
       />
 
       <MapCanvas markers={markers} onMarkerClick={open} height={320} />

--- a/onday-app/src/app/diagnosis/result/[id]/time-slot-selector.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/time-slot-selector.tsx
@@ -6,7 +6,8 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
 const TIME_SLOTS = ["07:00", "08:00", "09:00", "10:00"] as const;
-export type TimeSlot = (typeof TIME_SLOTS)[number];
+// Issue #106 ㊗ — 사용자 입력 HH:MM 자유 허용 (★ TimeSlotSelector는 4 옵션 시뮬레이션, 사용자 입력은 외부 string).
+export type TimeSlot = string;
 
 interface TimeSlotSelectorProps {
   value: TimeSlot;

--- a/onday-app/src/components/card/candidate-card.tsx
+++ b/onday-app/src/components/card/candidate-card.tsx
@@ -60,7 +60,7 @@ export function CandidateCard({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-s-2">
             <h3 className="text-title font-bold text-ink">{name}</h3>
-            {isBest && <Badge variant="solid">BEST</Badge>}
+            {isBest && <Badge variant="best">BEST</Badge>}
           </div>
           <p className="mt-0.5 text-caption text-ink-3">
             매칭 점수{" "}

--- a/onday-app/src/components/form/filter-panel.tsx
+++ b/onday-app/src/components/form/filter-panel.tsx
@@ -22,9 +22,11 @@ interface FilterPanelFilter {
 }
 
 interface FilterPanelProps<T extends string> {
-  time: T;
-  onTimeChange: (next: T) => void;
-  timeOptions: { value: T; label: string }[];
+  // Issue #106 ㊘ — 결과 페이지 상단 4 chip 시뮬레이션은 미래 별도 ISSUE 영역.
+  //   현 본 ISSUE = "사용자 입력 → 결과" 자연 흐름 도달 정수 (★ TimeTabs 미박힘 시 조건부 박힘 X).
+  time?: T;
+  onTimeChange?: (next: T) => void;
+  timeOptions?: { value: T; label: string }[];
   filters: FilterPanelFilter[];
   onOpenAdvanced?: () => void;
   className?: string;
@@ -40,12 +42,14 @@ export function FilterPanel<T extends string>({
 }: FilterPanelProps<T>) {
   return (
     <section aria-label="후보 필터" className={cn("space-y-s-3", className)}>
-      <TimeTabs
-        value={time}
-        onChange={onTimeChange}
-        options={timeOptions}
-        ariaLabel="출근 시간대"
-      />
+      {timeOptions && time !== undefined && onTimeChange && (
+        <TimeTabs
+          value={time}
+          onChange={onTimeChange}
+          options={timeOptions}
+          ariaLabel="출근 시간대"
+        />
+      )}
       <div className="flex items-center gap-s-2">
         <div className="flex flex-1 gap-s-2">
           {filters.map((f) => (

--- a/onday-app/src/components/ui/badge.tsx
+++ b/onday-app/src/components/ui/badge.tsx
@@ -23,6 +23,8 @@ const badgeVariants = cva(
       variant: {
         default: "bg-primary-soft text-primary",
         solid: "bg-primary text-primary-foreground",
+        // Issue #106 ㊕ — BEST 뱃지 가독성 정정 (★ white + shadow contrast ↑).
+        best: "bg-primary text-white shadow-sm",
         secondary: "bg-secondary text-secondary-foreground",
         ok: "bg-success-soft text-success",
         info: "bg-info-soft text-info",

--- a/onday-app/src/features/diagnosis/mock-calculator.ts
+++ b/onday-app/src/features/diagnosis/mock-calculator.ts
@@ -217,7 +217,8 @@ export async function runMockDiagnosis(
     // rejected는 production에서 Sentry로
   }
 
-  return candidates.sort((a, b) => b.score - a.score);
+  // Issue #106 ㊓ — 진단 페이지 약속 (후보 6~8개) 정합 (★ top 8개).
+  return candidates.sort((a, b) => b.score - a.score).slice(0, 8);
 }
 
 /**

--- a/tasks/REFACTOR-UI-003-FEEDBACK.md
+++ b/tasks/REFACTOR-UI-003-FEEDBACK.md
@@ -1,0 +1,395 @@
+# REFACTOR-UI-003-FEEDBACK — 결과 페이지 사용자 피드백 5건 정정 + 사용자 검증 + 즉시 반영 워크플로 답습 7회째 + Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증
+
+> **Issue:** [#106](https://github.com/kmh89927a/Onday-design-Project/issues/106)
+> **Branch:** `feature/REFACTOR-UI-003-FEEDBACK`
+> **Wave:** 4 / **Track:** diagnosis-ui / **Complexity:** M (~1~1.5h)
+> **Origin Issues:** [#104 UI-003](https://github.com/kmh89927a/Onday-design-Project/issues/104) (PR #105) 머지 + 7차 Vercel 자동 배포 후 사용자 검증 시점 발견
+
+---
+
+## 1. 🎯 Summary
+
+UI-003 (#104, PR #105) 머지 + 7차 Vercel 자동 배포 후 사용자 검증 시점 발견 5건 정정 (★ MVP 본질 도달 입증 완료 후 자연 후행).
+
+6 파일 정정 — `result-content.tsx` (★ ㊒ 출근시간 chip + ㊔ filter(Boolean) 숨김 + ㊘ FilterPanel time props 미박힘) + `time-slot-selector.tsx` (★ ㊗ TimeSlot string 완화) + `candidate-card.tsx` (★ ㊕ variant="best") + `filter-panel.tsx` (★ ㊘ props optional + 조건부 박힘) + `badge.tsx` (★ ㊕ "best" variant 신규) + `mock-calculator.ts` (★ ㊓ slice 8).
+
+### ★ 본 ISSUE 메타 (메타 8종)
+
+- 사용자 검증 + 즉시 반영 워크플로 답습 7회째 (★ 본 ISSUE 진짜 가치)
+- 진짜 버그 정정 (★ ㊒ 출근시간 데이터 흐름)
+- "사용자 입력 → 결과" 자연 흐름 도달 (★ 르르 짚음 정수)
+- "한 ISSUE 한 본질" 분리 답습 (★ FEAT-DIAGNOSIS-INPUT-FILTERS 별도 ISSUE 사전 명시)
+- Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 (★ 본 ISSUE 진짜 가치 진화 정점)
+- Q3-a (나) 숨김 + Q3-b (3) Badge variant 신규 패턴
+- ISSUE 신설 자동화 답습 7회째 (#94 + #96 + #98 + #100 + #102 + #104 + #106)
+- 가드 30+종 8 영역 사수
+
+### ★ Mismatch ㊒~㊘ 7건 (Phase A 사전 인지 4 + Phase A 시점 새 발견 2 + 본질 분류 결정 1)
+
+- ㊒ 출근시간 데이터 흐름 끊김 (★ 1순위 진짜 버그) → result-content.tsx "출근시간" chip + commuteSchedule.departureTime
+- ㊓ 45개 → 6~8개 → mock-calculator.ts `.slice(0, 8)`
+- ㊔ fallback 숨김 → filter(Boolean) (사용자 입력 X chip 박힘 X)
+- ㊕ BEST 뱃지 색 → Badge "best" variant 신규
+- ㊖ 5건 본질 분류 = (다) 4건 + 별도 ISSUE 분리 결정
+- ★ ㊗ TimeSlot enum 4 옵션 vs 사용자 입력 임의 시간 (★ Phase A 진입 직전 사전 발견) → string 완화
+- ★ ㊘ 결과 페이지 상단 4 chip 진짜 본질 = FilterPanel TimeTabs (★ Phase A 검수 시점 사전 발견) → optional + 조건부 박힘
+
+### 자가 치유 누적
+
+- UI-003 #104 시점: 81건
+- **본 ISSUE 추가: 81 + 7 = 88건** (㊒~㊕ 4건 사전 인지 + ㊗ + ㊘ 2건 Phase A 시점 발견 + ㊖ 1건 본질 분류 결정)
+
+---
+
+## 2. 🔗 References (Spec & Context)
+
+### ★ Issue #106 (본 ISSUE 신설 원본)
+- Title: `[REFACTOR] UI-003 사용자 피드백 반영 — 결과 페이지 데이터 흐름 + 표시 + 가독성 5건 정정`
+- Labels: `track:diagnosis-ui` + `wave:4` + `complexity:m`
+- Origin: PR #105 머지 + 7차 Vercel 자동 배포 후 사용자 검증
+
+### ★ Q1~Q5 결정 표
+
+| Q | 분기 | 결정 | 근거 |
+| --- | --- | --- | --- |
+| Q1 작업 모드 | A/B/C/D + (다) 분기 | (B) 풀세트 + (다) 4건 + 별도 ISSUE 분리 | 답습 27회째 + 사용자 검증 답습 7회째 |
+| Q2 영역 | 4 → 실측 6 파일 | 6 파일 정정 + 가드 8 영역 ⏸ | ★ ㊘ filter-panel.tsx + ㊗ time-slot-selector.tsx Phase A 시점 추가 |
+| Q3-a fallback | (가)/(나) | (나) 숨김 + filter(Boolean) | 사용자 혼란 X + undefined chip 박힘 X |
+| Q3-b BEST 뱃지 | (1)/(2)/(3) | (3) Badge "best" variant 신규 | Badge 전역 영향 0 + 본질 명문화 |
+| Q4 산출 | 정정 / 분할 | 6 정정 + 별도 ISSUE 사전 명시 | 가드 사수 + 단계 분리 |
+| Q5 Phase | A/B/C/D | A → B → C → D | 답습 27회째 |
+
+### ★ Mismatch ㊒~㊘ 7건 추적 표
+
+| Mismatch | 영역 | 본질 | 처리 |
+| --- | --- | --- | --- |
+| ㊒ | 출근시간 데이터 흐름 | 1순위 진짜 버그 (결과 페이지 표시 X) | ✅ result-content.tsx "출근시간" chip + commuteSchedule.departureTime |
+| ㊓ | 45개 → 6~8개 | 사전 약속 vs 실제 충돌 | ✅ mock-calculator.ts L221 `.slice(0, 8)` |
+| ㊔ | fallback 숨김 | "제한 없음"/"전체" 표시 사용자 혼란 | ✅ filter(Boolean) 조건부 박힘 |
+| ㊕ | BEST 뱃지 색 | text-primary-foreground contrast ↓ | ✅ Badge "best" variant 신규 (★ bg-primary text-white shadow-sm) |
+| ㊖ | 5건 본질 분류 | 1 ISSUE vs 5 ISSUE 분기 | ✅ (다) 4건 + 별도 ISSUE 분리 (★ 입력 영역) |
+| ★ ㊗ | TimeSlot enum 4 옵션 vs 사용자 입력 임의 시간 | Phase A 진입 직전 사전 발견 | ✅ time-slot-selector.tsx TimeSlot = string 완화 |
+| ★ ㊘ | 결과 페이지 상단 4 chip 진짜 본질 = FilterPanel TimeTabs | Phase A 검수 시점 사전 발견 | ✅ filter-panel.tsx props optional + 본문 조건부 박힘 + result-content.tsx time props 미박힘 |
+
+→ ★ Phase B 자체 grill 새 Mismatch **0건** = Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증
+
+### ★★ 사용자 검증 + 즉시 반영 워크플로 답습 7회째 § (★ 본 ISSUE 진짜 가치)
+
+본 세션 누적 워크플로:
+1회 #94 / 2회 #96 / 3회 #98 / 4회 #100 / 5회 #102 / 6회 #104 / **7회 본 ISSUE #106**
+
+사용자 검증 → ISSUE 신설 → grill → Phase A~D → 머지 → Vercel 자동 배포 → 다음 검증 순환 7회째 답습.
+
+**미래 작업자 학습:**
+- "사용자 검증 워크플로 = MVP 본질 도달 입증 시점 + 자연 후행"
+
+### ★★ 진짜 버그 정정 § (★ ㊒ 출근시간 데이터 흐름)
+
+**사전:**
+- 진단 입력 `commuteSchedule.departureTime` → 결과 페이지 표시 X (★ 데이터 흐름 끊김)
+- result-content.tsx L127: `time="08:00"` 하드코딩
+
+**본 ISSUE:**
+- FilterPanel time props 미박힘 + filters 배열에 "출근시간" chip 박힘
+- `value: filters.commuteSchedule?.departureTime ?? "08:00"`
+- ★ 진짜 버그 해소 = MVP 본질 도달 답습 완성
+
+### ★★ "사용자 입력 → 결과" 자연 흐름 도달 § (★ 르르 짚음 정수)
+
+**사전 (Claude Code 추천 시점):**
+- FilterPanel TimeTabs (4 chip) = 시뮬레이션 영역 + 사용자 입력 chip 추가
+- 본 ISSUE 본질 = TimeSlot string 완화 + chip 추가
+
+**★ 르르 정정 (진짜 본질):**
+- 결과 페이지 상단 4 chip = 사용자 혼란 = ★ TimeTabs 자체 제거 (★ FilterPanel props optional)
+- "통근시간" 영역에 사용자 진단 입력값 박힘
+- → ★ "사용자 입력 → 결과" 자연 흐름 도달 정수
+
+**미래 작업자 학습:**
+- "사용자 발견 진짜 본질 = 코드 영역 정확 진단 + 사전 案 정직 정정 = 르르 짚음 답습"
+
+### Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 § (★ 본 ISSUE 진짜 가치 진화)
+
+| 회차 | ISSUE | Phase A 시점 새 발견 | Phase B 새 발견 | 결과 |
+| --- | --- | --- | --- | --- |
+| 1회 | #96 | 0건 | 0건 | ✅ |
+| 2회 | #100 | 0건 | 0건 | ✅ |
+| 3회 | #102 | 0건 | ㊿ → Phase A 추가 정정 해소 | ✅ |
+| 4회 | #104 | ㊇ Phase A 진입 직전 | 0건 | ✅ |
+| **5회 (본 ISSUE)** | **#106** | **★ ㊗ + ㊘ 2건** (Phase A 진입 직전 + 검수 시점) | **0건** | **완전 입증** |
+
+→ 본 프로젝트 워크플로 시스템 신뢰성 진화 답습 5회 연속 완전 입증
+
+**미래 작업자 학습:**
+- "Phase A 시점 사전 발견 = 진입 직전 + 검수 시점 = 정확한 시점 정직 답습 + 본 프로젝트 워크플로 시스템 신뢰성 진화"
+
+### Q3-a (나) 숨김 + Q3-b (3) Badge variant 신규 패턴 §
+
+**Q3-a (나) 숨김:**
+```ts
+filters={[
+  filters.maxCommuteTime != null && { label: "통근시간", value: ..., onClick: ... },
+  filters.budget != null && { label: "예산", value: ..., onClick: ... },
+].filter(Boolean) as ...}
+```
+
+**Q3-b (3) Badge "best" variant 신규:**
+```ts
+// badge.tsx cva variants
+best: "bg-primary text-white shadow-sm",
+```
+
+### ★ 사전 검증 baseline (Phase A 진입 시점)
+
+| 검증 | 결과 |
+| --- | --- |
+| `npx prisma validate/generate` | valid + 7.8.0 |
+| `npx tsc --noEmit` | 0 errors |
+| `npx eslint src/` | 0 errors (Warning 10건 = baseline) |
+| `npm run build` | 13/13 static + Middleware 32.5 kB (23번째 baseline) + /diagnosis/result/[id] 7.9 kB 173 kB |
+| git status | untracked 2 (26칸 가드) |
+
+### ★ 본 ISSUE 실측 산출물 표 (+33/-25 6 파일)
+
+| 파일 | 변경 | 라인 |
+| --- | --- | --- |
+| `result-content.tsx` | 정정 | +13/-13 (★ ㊒ + ㊔ + ㊘ 출근시간 chip + filter(Boolean) + TIME_OPTIONS 제거) |
+| `time-slot-selector.tsx` | 정정 | +2/-1 (★ ㊗ string 완화) |
+| `candidate-card.tsx` | 정정 | +1/-1 (★ ㊕ variant="best") |
+| `filter-panel.tsx` | 정정 | +13/-9 (★ ㊘ optional + 조건부 박힘) |
+| `badge.tsx` | 정정 | +2/-0 (★ ㊕ best variant 신규) |
+| `mock-calculator.ts` | 정정 | +2/-1 (★ ㊓ slice 8) |
+| **합계** | **6 파일** | **+33/-25** |
+
+---
+
+## 3. 🛠️ Task Breakdown (✅/⏸ 실측 status markers)
+
+| § | 항목 | status | 사유 |
+| --- | --- | --- | --- |
+| §3.1 | `result-content.tsx` (+13/-13) | ✅ Phase A | ㊒ + ㊔ + ㊘ 출근시간 chip + filter(Boolean) + TIME_OPTIONS 제거 |
+| §3.2 | `time-slot-selector.tsx` (+2/-1) | ✅ Phase A | ★ ㊗ string 완화 |
+| §3.3 | `candidate-card.tsx` (+1/-1) | ✅ Phase A | ★ ㊕ variant="best" |
+| §3.4 | `filter-panel.tsx` (+13/-9) | ✅ Phase A | ★ ㊘ optional + 조건부 박힘 |
+| §3.5 | `badge.tsx` (+2/-0) | ✅ Phase A | ★ ㊕ best variant 신규 |
+| §3.6 | `mock-calculator.ts` (+2/-1) | ✅ Phase A | ㊓ slice 8 |
+| §3.7 | 가드 30+종 8 영역 | ⏸ 변경 0 | page.tsx + types.ts + saved-search.ts + validators + Mock + picker + intersection + KakaoTransport client |
+| §3.8 | dev/page.tsx | ⏸ 변경 0 | ★ optional props 영향 0 입증 |
+
+→ 6 정정 + ⏸ 가드 9 영역
+
+---
+
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+
+| AC | Given | When | Then |
+| --- | --- | --- | --- |
+| AC-1 출근시간 데이터 흐름 | 진단 입력 `commuteSchedule.departureTime = "08:00"` | 결과 페이지 렌더 | "출근시간" chip = "08:00" 박힘 |
+| AC-2 45개 → 8개 | mock-calculator 호출 | `.slice(0, 8)` | candidates.length ≤ 8 |
+| AC-3 fallback 숨김 | `filters.maxCommuteTime = undefined` | filter(Boolean) | chip 박힘 X |
+| AC-4 BEST 뱃지 | candidates[0] | render | `<Badge variant="best">BEST</Badge>` (★ bg-primary text-white) |
+| AC-5 TimeTabs 미박힘 | result-content FilterPanel | render | TimeTabs 컴포넌트 박힘 X (★ optional props 미박힘) |
+| AC-6 dev/page.tsx 영향 0 | dev 페이지 FilterPanel 호출 (time props 박힘) | render | 맞음 유지 (★ optional + 조건부) |
+| AC-7 가드 30+종 8 영역 0 lines | 8 가드 파일 | git diff --stat | 빈 출력 |
+| AC-8 Phase B 자체 grill 새 Mismatch 0건 | 6 파일 정정 + Phase A 시점 ㊗+㊘ 해소 | 자체 grill | 새 발견 0건 |
+
+---
+
+## 5. ⚙️ Non-Functional Constraints (NFR)
+
+- **NFR-PERF:** /diagnosis/result/[id] 7.9 → 7.93 kB (+0.03 kB 미세 증가 정직 인정) + /diagnosis 11.3 kB baseline 답습
+- **NFR-SEC:** client component (`use server` 0 / `createSupabaseServerClient` 0 / `AbortSignal.timeout` 0)
+- **NFR-A11y:** FilterPanel `aria-label="후보 필터"` 보존 + TimeTabs 미박힘 시 영향 0
+- **NFR-BACKWARD:** FilterPanel props optional = dev/page.tsx 영향 0 입증
+- **NFR-BUNDLE:** Middleware 32.5 kB 24번째 답습 (회귀 0)
+
+---
+
+## 6. 📦 Deliverables
+
+### Phase A ✅ (6 파일 정정)
+- result-content.tsx + time-slot-selector.tsx + candidate-card.tsx + filter-panel.tsx + badge.tsx + mock-calculator.ts
+
+### Phase B ✅ (자체 grill 7 영역 + AC-6 grep)
+- 자체 grill: 출근시간 흐름 / slice / fallback 숨김 / BEST variant / TimeSlot string / FilterPanel optional / 가드+빌드
+- 추가 검증: AC-6 1차 가드 3 + 2차 입증 4
+
+### Phase C ✅ (명세 신설)
+- `tasks/REFACTOR-UI-003-FEEDBACK.md` (본 파일)
+
+### Phase D (★ feat+docs 커밋 분리 + Draft PR Refs #106)
+- 커밋 1 `feat`: 코드 6 정정
+- 커밋 2 `docs`: 명세 1 파일
+- Draft PR → Ready → 머지 → Vercel 자동 배포 → Issue #106 Close
+
+### Follow-up 5 (★ FEAT-DIAGNOSIS-INPUT-FILTERS + FEAT-RESULT-WHAT-IF-SIMULATION 박힘)
+
+1. 8차 Vercel 확인 (★ 5건 정정 입증 + 사용자 검증 워크플로 7회째)
+2. **★ FEAT-DIAGNOSIS-INPUT-FILTERS 별도 ISSUE 신설** (★ 본 ISSUE 머지 후, 르르 약속 답습)
+   - 진단 페이지 maxCommuteTime + budget 입력 영역 신규
+   - 결과 페이지 "통근시간" + "예산" chip 박힘 (★ 본 ISSUE = filter(Boolean) 숨김)
+3. FEAT-RESULT-WHAT-IF-SIMULATION 별도 ISSUE 후보 (★ 미래)
+4. CMD-DIAG-003 (Scoring + mapper.ts)
+5. ★ Issue #106 Close 정정 댓글 (★ ㊒~㊘ 7건 명문화 + Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증)
+
+### ★ 정직성 8 (§9.1~§9.8)
+1. 사용자 검증 + 즉시 반영 워크플로 답습 7회째 (§9.1)
+2. 진짜 버그 정정 (§9.2)
+3. "사용자 입력 → 결과" 자연 흐름 도달 (§9.3, ★ 르르 짚음 정수)
+4. "한 ISSUE 한 본질" 분리 답습 (§9.4)
+5. ★★★ Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 (§9.5, ★ 본 ISSUE 진짜 가치 진화 정점)
+6. Q3-a (나) 숨김 + Q3-b (3) Badge variant 신규 패턴 (§9.6)
+7. ISSUE 신설 자동화 답습 7회째 (§9.7)
+8. 가드 30+종 8 영역 사수 (§9.8)
+
+---
+
+## 7. 🔗 Dependencies
+
+### 선행 (모두 ✅ 충족):
+- UI-003 (#104, PR #105) 머지 (★ MVP 본질 도달)
+- DTO-COMMUTE-TIME (#98) + REFACTOR-DTO-COMMUTE-TIME-FEEDBACK (#100) + REFACTOR-COMMUTE-LEGACY (#102) 머지
+- 7차 Vercel 자동 배포 + 사용자 검증
+
+### 후행 5종:
+
+| 후행 | 트리거 | 산출 |
+| --- | --- | --- |
+| 8차 Vercel 확인 | 본 ISSUE 머지 후 자동 배포 | ★ 5건 정정 입증 + 사용자 검증 7회째 |
+| ★ FEAT-DIAGNOSIS-INPUT-FILTERS | 본 ISSUE 머지 후 신설 | 진단 페이지 maxCommuteTime + budget 입력 영역 |
+| FEAT-RESULT-WHAT-IF-SIMULATION | 미래 사용자 의지 | 4 chip what-if 시뮬레이션 |
+| CMD-DIAG-003 | Scoring + mapper.ts | 후행 ISSUE |
+| ★ Issue #106 Close 정정 댓글 | PR 머지 직후 | ㊒~㊘ 7건 명문화 + 사전 案 vs 실측 차이 + Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 |
+
+---
+
+## 8. 🧪 Test Plan
+
+### ★ Phase A ✅ (실측) — 검증 7종
+
+| # | 검증 | 결과 |
+| --- | --- | --- |
+| 1 | prisma validate/generate | valid + 7.8.0 |
+| 2 | tsc --noEmit | 0 errors |
+| 3 | eslint src/ | 0 errors |
+| 4 | npm run build | 13/13 static + Middleware 32.5 kB |
+| 5 | 가드 30+종 8 영역 | git diff --stat 빈 출력 |
+| 6 | dev/page.tsx 영향 0 | git diff --stat 빈 출력 |
+| 7 | git status | M 6 + untracked 2 (26칸 가드) |
+
+### ★ Phase B 자체 grill ✅ (실측) — 7 영역
+
+| # | 영역 | 결과 |
+| --- | --- | --- |
+| 1 | ㊒ 출근시간 데이터 흐름 | ✅ "출근시간" chip + commuteSchedule.departureTime 박힘 |
+| 2 | ㊓ slice 8 | ✅ mock-calculator.ts L221 |
+| 3 | ㊔ filter(Boolean) 숨김 | ✅ undefined 시 chip 박힘 X |
+| 4 | ㊕ Badge "best" variant | ✅ badge.tsx + candidate-card.tsx 맞음 |
+| 5 | ㊗ TimeSlot string | ✅ time-slot-selector.tsx + tsc 0 errors |
+| 6 | ㊘ FilterPanel optional + 조건부 | ✅ filter-panel.tsx + dev/page.tsx 영향 0 |
+| 7 | 가드+빌드 | ✅ Middleware 24번째 + bundle 7.93 kB |
+
+### ★ AC-6 정적 grep 7행 표 (1차 가드 3 + 2차 입증 4)
+
+| 영역 | 명령 | 기대 | 실측 |
+| --- | --- | --- | --- |
+| 1차 ① `use server` | grep | 0 | 0 |
+| 1차 ② `createSupabaseServerClient` | grep | 0 | 0 |
+| 1차 ③ `AbortSignal.timeout` | grep | 0 | 0 |
+| 2차 ① TIME_OPTIONS 부재 (result-content.tsx) | grep | 0 | 0 |
+| 2차 ② FilterPanel time props 미박힘 | grep | 0 | 0 |
+| 2차 ③ "출근시간" chip 박힘 | grep | 1+ | L127 + L129 |
+| 2차 ④ candidate-card variant="best" | grep | 1 | L63 |
+
+### 타입 / 빌드 검증
+
+- TypeScript strict: 0 errors
+- ESLint: 0 errors (Warning 10건 = baseline)
+- Next build: 13/13 static + Middleware 32.5 kB (★ 24번째)
+- /diagnosis/result/[id] 7.93 kB (+0.03 kB 미세 증가 정직 인정)
+
+### TEST-001 spec.tsx 위임 (선택)
+- `filter-panel.spec.tsx` optional props 시나리오 (선택, 후행 ISSUE)
+
+---
+
+## 9. 🚧 Open Questions / Risks + ★ Phase C 정직 기록 § (8종)
+
+### §9.A — Open Questions / Risks
+
+- FEAT-DIAGNOSIS-INPUT-FILTERS 별도 ISSUE 신설 시점 = 본 ISSUE 머지 후 즉시
+- FEAT-RESULT-WHAT-IF-SIMULATION 미래 사용자 의지 시점 위임
+- npm audit baseline 정확 검증 위임 (★ SEC-001/TEST-001 후행)
+
+### ★ §9.B — Phase C 정직 기록 § (8종)
+
+#### §9.1 사용자 검증 + 즉시 반영 워크플로 답습 7회째 § (★ 본 ISSUE 진짜 가치)
+- 1회 #94 / 2회 #96 / 3회 #98 / 4회 #100 / 5회 #102 / 6회 #104 / 7회 본 ISSUE #106
+- 미래 작업자 학습: "사용자 검증 워크플로 = MVP 본질 도달 입증 시점 + 자연 후행"
+
+#### §9.2 진짜 버그 정정 § (★ ㊒ 출근시간 데이터 흐름)
+- 사전: result-content.tsx L127 `time="08:00"` 하드코딩 = 데이터 흐름 끊김
+- 본 ISSUE: filters 배열 "출근시간" chip + commuteSchedule.departureTime
+- MVP 본질 도달 답습 완성
+
+#### §9.3 "사용자 입력 → 결과" 자연 흐름 도달 § (★ 르르 짚음 정수)
+- Claude Code 사전 추천: FilterPanel TimeTabs + chip 추가
+- ★ 르르 정정: TimeTabs 자체 제거 + 사용자 입력값만 chip 박힘 = ★ 진짜 본질
+- 미래 작업자 학습: "사용자 발견 진짜 본질 = 코드 영역 정확 진단 + 사전 案 정직 정정"
+
+#### §9.4 "한 ISSUE 한 본질" 분리 답습 §
+- 본 ISSUE = 결과 페이지 4건 정정
+- 별도 ISSUE = 진단 페이지 입력 영역 추가 (FEAT-DIAGNOSIS-INPUT-FILTERS)
+- 단계 분리 = 사용자 약속 답습 + 본 ISSUE 본질 명확
+
+#### ★★★ §9.5 Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 § (★ 본 ISSUE 진짜 가치 진화 정점)
+- 1회 (#96): 첫 등장 ✅
+- 2회 (#100): ㊵ 자가 치유 ✅
+- 3회 (#102): ㊿ 본 ISSUE 내 해소 ✅
+- 4회 (#104): ㊇ Phase A 진입 직전 ✅
+- **5회 (본 ISSUE):** ★ ㊗ + ㊘ 2건 Phase A 시점 발견 + 해소 + Phase B 0건 = 완전 입증
+- 미래 작업자 학습: "Phase A 시점 사전 발견 = 진입 직전 + 검수 시점 = 정확한 시점 정직 답습"
+
+#### §9.6 Q3-a (나) 숨김 + Q3-b (3) Badge variant 신규 패턴 §
+- Q3-a (나): filter(Boolean) (사용자 입력 X chip 박힘 X)
+- Q3-b (3): Badge "best" variant 신규 (전역 영향 0)
+- 미래 작업자 학습: "사용자 입력 X 표시 = 숨김 + 디자인 토큰 정정 = 신규 variant"
+
+#### §9.7 ISSUE 신설 자동화 답습 7회째 § (#94+#96+#98+#100+#102+#104+#106)
+- 본 세션 신설 = #106
+- 라벨 3종 (track:diagnosis-ui + wave:4 + complexity:m) + 보드 Todo 자동 박힘
+- 7회째 신뢰성 입증
+
+#### §9.8 가드 30+종 8 영역 사수 §
+- page.tsx + types.ts + saved-search.ts + validators + Mock + picker + intersection + KakaoTransport client
+- git diff --stat 빈 출력 입증
+
+### ★ §9.C — 사전 案 vs 실측 정직 인정 §
+
+| 항목 | 사전 案 | 실측 | 차이 | 사유 |
+| --- | --- | --- | --- | --- |
+| 파일 수 | 4 (사전 案) | 6 | +2 | ★ ㊗ time-slot-selector.tsx + ㊘ filter-panel.tsx Phase A 시점 추가 |
+| insertions | ~+13 | +33 | +20 | ★ ㊘ filter-panel.tsx optional 본문 + result-content.tsx FilterPanel 정정 + "출근시간" chip + 코멘트 |
+| deletions | ~-4 | -25 | -21 | TIME_OPTIONS 제거 + initialTime 정리 + handleTimeSlotChange 사용 0 |
+| /diagnosis/result bundle | 7.9 kB | 7.93 kB | +0.03 kB | 미세 증가 정직 인정 |
+
+→ 차이 본질 = ★ ㊗ + ㊘ Phase A 시점 발견 + 정정
+
+### ★ §9.D — 별도 ISSUE 사전 명시 § (★ 르르 약속 답습)
+
+| ISSUE | 시점 | 본질 |
+| --- | --- | --- |
+| **★ FEAT-DIAGNOSIS-INPUT-FILTERS** | 본 ISSUE 머지 후 즉시 | 진단 페이지 maxCommuteTime + budget 입력 영역 신규 + 결과 페이지 "통근시간" + "예산" chip 박힘 |
+| FEAT-RESULT-WHAT-IF-SIMULATION | 미래 사용자 의지 시점 | 4 chip what-if 시뮬레이션 재박힘 |
+
+### Follow-up 5
+
+1. 8차 Vercel 확인 (★ 사용자 검증 워크플로 7회째)
+2. **★ FEAT-DIAGNOSIS-INPUT-FILTERS 별도 ISSUE 신설** (★ 본 ISSUE 머지 후 즉시)
+3. FEAT-RESULT-WHAT-IF-SIMULATION 별도 ISSUE 후보 (★ 미래)
+4. CMD-DIAG-003 (Scoring + mapper.ts)
+5. ★ Issue #106 Close 시 정정 댓글 — ㊒~㊘ 7건 명문화 + 사전 案 vs 실측 차이 정직 인정 + Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 + "사용자 입력 → 결과" 자연 흐름 도달 명문화
+
+---
+
+**문서 끝.** Phase C 명세 신설 ✅. Phase D 진입 대기 (르르 검수 + 컨디션 답 후).


### PR DESCRIPTION
Refs #106

## 산출물 요약

| 종류 | 파일 | 변경 |
| --- | --- | --- |
| 정정 | `result-content.tsx` | +13/-13 (★ ㊒ 출근시간 chip + ㊔ filter(Boolean) + ㊘ FilterPanel time props 미박힘) |
| 정정 | `time-slot-selector.tsx` | +2/-1 (★ ㊗ TimeSlot string 완화) |
| 정정 | `candidate-card.tsx` | +1/-1 (★ ㊕ variant="best") |
| 정정 | `filter-panel.tsx` | +13/-9 (★ ㊘ props optional + 조건부 박힘) |
| 정정 | `badge.tsx` | +2/-0 (★ ㊕ "best" variant 신규) |
| 정정 | `mock-calculator.ts` | +2/-1 (★ ㊓ slice 8) |
| 신규 | `tasks/REFACTOR-UI-003-FEEDBACK.md` | +395 |
| **합계** | **7 파일** | **+428/-25** |

- 코드 6 파일 (commit `8692754` feat, +33/-25)
- 명세 1 파일 (commit `e593dc8` docs, +395)
- ★ feat ↔ docs 커밋 분리 20회째 답습

## Q1~Q5 결정 표

| Q | 결정 | 근거 |
| --- | --- | --- |
| Q1 작업 모드 | (B) 풀세트 + (다) 4건 + 별도 ISSUE 분리 | 답습 27회째 + 사용자 검증 답습 7회째 |
| Q2 영역 | 4 → 실측 6 파일 | ★ ㊗ + ㊘ Phase A 시점 추가 |
| Q3-a fallback | (나) 숨김 + filter(Boolean) | 사용자 혼란 X |
| Q3-b BEST 뱃지 | (3) Badge "best" variant 신규 | Badge 전역 영향 0 |
| Q4 산출 | 6 정정 + 별도 ISSUE 사전 명시 | 가드 사수 + 단계 분리 |
| Q5 Phase | A → B → C → D | 답습 27회째 |

## 메타 가치 7종

- 사용자 검증 + 즉시 반영 워크플로 답습 7회째 (★ 본 ISSUE 진짜 가치)
- 진짜 버그 정정 (★ ㊒ 출근시간 데이터 흐름)
- "사용자 입력 → 결과" 자연 흐름 도달 (★ 르르 짚음 정수)
- "한 ISSUE 한 본질" 분리 답습 (★ FEAT-DIAGNOSIS-INPUT-FILTERS 별도 ISSUE 사전 명시)
- ★★★ Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 (★ 본 ISSUE 진짜 가치 진화 정점)
- ISSUE 신설 자동화 답습 7회째 (#94+#96+#98+#100+#102+#104+#106)
- 가드 30+종 8 영역 사수

## §9.1~§9.8 (정직 기록)

1. §9.1 사용자 검증 + 즉시 반영 워크플로 답습 7회째 § (★ 본 ISSUE 진짜 가치)
2. §9.2 진짜 버그 정정 § (★ ㊒)
3. §9.3 "사용자 입력 → 결과" 자연 흐름 도달 § (★ 르르 짚음 정수)
4. §9.4 "한 ISSUE 한 본질" 분리 답습 §
5. ★★★ §9.5 Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 § (본 ISSUE 진짜 가치 진화 정점)
6. §9.6 Q3-a (나) 숨김 + Q3-b (3) Badge variant 신규 패턴 §
7. §9.7 ISSUE 신설 자동화 답습 7회째 §
8. §9.8 가드 30+종 8 영역 사수 §

## Mismatch ㊒~㊘ 7건 추적 표

| Mismatch | 영역 | 처리 |
| --- | --- | --- |
| ㊒ | 출근시간 데이터 흐름 끊김 | ✅ result-content.tsx "출근시간" chip + commuteSchedule.departureTime |
| ㊓ | 45개 → 6~8개 | ✅ mock-calculator.ts L221 `.slice(0, 8)` |
| ㊔ | fallback 숨김 | ✅ filter(Boolean) 조건부 박힘 |
| ㊕ | BEST 뱃지 색 | ✅ Badge "best" variant 신규 |
| ㊖ | 5건 본질 분류 | ✅ (다) 4건 + 별도 ISSUE 분리 |
| **★ ㊗** | **TimeSlot enum vs 사용자 입력** | ✅ **Phase A 진입 직전 사전 발견 → string 완화** |
| **★ ㊘** | **상단 4 chip = FilterPanel TimeTabs** | ✅ **Phase A 검수 시점 사전 발견 → optional + 조건부 박힘** |

→ ★ Phase B 자체 grill 새 Mismatch **0건** = Phase A 사전 박힘 정수 진화 답습 5회째 **완전 입증**

## 가드 30+종 8 영역 0 lines 표

| 영역 | 파일 | 변경 |
| --- | --- | --- |
| 1 | `app/diagnosis/page.tsx` | 0 |
| 2 | `lib/types.ts` | 0 |
| 3 | `lib/types/saved-search.ts` | 0 |
| 4 | `lib/validators/diagnosis.ts` | 0 |
| 5 | `lib/mocks/diagnosis/get-diagnosis.ts` | 0 |
| 6 | `components/form/commute-schedule-picker.tsx` | 0 |
| 7 | `lib/diagnosis/intersection.ts` | 0 |
| 8 | `lib/external/kakao-transport/client.ts` | 0 |
| ★ | `app/dev/page.tsx` (★ optional props 영향 0 입증) | 0 |

## Phase A~D 검증 표

| Phase | 검증 | 결과 |
| --- | --- | --- |
| A.1 baseline | prisma + tsc + eslint + build + git | 6/6 통과 |
| A.2 정정 | 4 파일 (사전 案) → ㊗ Phase A 진입 직전 발견 + 5 파일 정정 | ✅ |
| A.3 검수 시점 | ★ ㊘ FilterPanel TimeTabs 진짜 본질 사전 발견 | ✅ |
| A.5 추가 정정 | filter-panel.tsx + result-content.tsx 정정 = 6 파일 | ✅ |
| A.6 후속 검증 | tsc + eslint + build + 가드 + dev/page.tsx 영향 0 | 6/6 통과 |
| B 자체 grill | 출근시간 흐름 / slice / fallback / BEST / TimeSlot / FilterPanel / 가드+빌드 | 7/7 통과, 새 Mismatch 0건 |
| C 명세 | tasks/REFACTOR-UI-003-FEEDBACK.md (395 lines) | ✅ |
| D 검증 | prisma + tsc + eslint + build + 격리 | 모두 통과 |

## Middleware 32.5 kB 24번째 + bundle 정직

- 23번째 (#104) → 24번째 (본 ISSUE) baseline 답습
- ★ /diagnosis/result/[id] 7.93 kB (★ baseline 7.9 → +0.03 kB 미세 증가 정직 인정)
- /diagnosis 11.3 kB (baseline 답습)

## AC-6 정적 grep 7행

| 영역 | 결과 |
| --- | --- |
| 1차 ① `use server` | 0 |
| 1차 ② `createSupabaseServerClient` | 0 |
| 1차 ③ `AbortSignal.timeout` | 0 |
| 2차 ① TIME_OPTIONS 부재 (result-content.tsx) | 0 |
| 2차 ② FilterPanel time props 미박힘 | 0 |
| 2차 ③ "출근시간" chip 박힘 | L127 + L129 |
| 2차 ④ candidate-card variant="best" | L63 |

## Follow-up 5

1. 8차 Vercel 확인 (★ 사용자 검증 워크플로 7회째 + 5건 정정 입증)
2. **★ FEAT-DIAGNOSIS-INPUT-FILTERS 별도 ISSUE 신설** (★ 본 ISSUE 머지 후 즉시, 르르 약속 답습 — 진단 페이지 maxCommuteTime + budget 입력 영역 추가)
3. FEAT-RESULT-WHAT-IF-SIMULATION 별도 ISSUE 후보 (★ 미래 사용자 의지)
4. CMD-DIAG-003 (Scoring + mapper.ts)
5. ★ Issue #106 Close 시 정정 댓글 — ㊒~㊘ 7건 명문화 + 사전 案 vs 실측 차이 정직 + Phase A 사전 박힘 정수 진화 답습 5회째 완전 입증 + "사용자 입력 → 결과" 자연 흐름 도달 명문화

## ★ 27칸 도달

본 ISSUE = #106 = 본 세션 27칸 머지 도달 (PR #105 머지 26칸 → 본 PR 머지 27칸).

## ★ 르르 약속 답습 명문화

- 본 ISSUE = 예산 영역 임시 숨김 (filter(Boolean)) = ★ "전체" 텍스트 박힘 X
- 별도 ISSUE FEAT-DIAGNOSIS-INPUT-FILTERS = 진단 페이지 입력칸 추가 + 결과 페이지 진짜 박힘
- ★ ★ 예산 영역 사라짐 X = 단계 분리만 (★ 르르 약속 답습)

## 명세 링크

[`tasks/REFACTOR-UI-003-FEEDBACK.md`](../blob/feature/REFACTOR-UI-003-FEEDBACK/tasks/REFACTOR-UI-003-FEEDBACK.md) (395 lines)