### PR TITLE
fix(FEAT-RESULT-WHAT-IF-SIMULATION): label "시간대 변경" + disabled flag 제거 (★ PR #116 후속 정정)

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -68,8 +68,6 @@ export function ResultContent({
   // Issue #111 β — 출근시간 chip 클릭 시 what-if 입력 inline 박힘 토글.
   const [showTimeOptions, setShowTimeOptions] = React.useState(false);
   const currentDepartureTime = filters.commuteSchedule?.departureTime ?? "08:00";
-  // 시나리오 B (페이지 reload / 직접 URL) fallback — store coordinateA null 시 비활성 (★ #108 답습).
-  const whatIfDisabled = !coordinateA;
 
   const handleTimeWhatIf = async (time: string) => {
     if (!coordinateA) {
@@ -191,12 +189,11 @@ export function ResultContent({
         ].filter(Boolean) as { label: string; value: string; onClick: () => void }[]}
       />
 
-      {/* Issue #111 β — what-if 시뮬레이션 입력 (★ <input type="time"> + 시나리오 B fallback). */}
+      {/* Issue #111 β — what-if 시뮬레이션 입력 (★ <input type="time"> + 시나리오 B handler fallback). */}
       {showTimeOptions && (
         <TimeChipOptions
           baseTime={currentDepartureTime}
           onChange={handleTimeWhatIf}
-          disabled={whatIfDisabled}
         />
       )}
 

--- a/onday-app/src/app/diagnosis/result/[id]/time-chip-options.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/time-chip-options.tsx
@@ -21,7 +21,7 @@ export function TimeChipOptions({
   return (
     <div className="pt-s-2" role="group" aria-label="다른 시간대 입력">
       <label className="flex items-center gap-s-2 text-caption font-bold text-ink-2">
-        다른 시간대 시뮬레이션
+        시간대 변경
         <input
           type="time"
           value={baseTime}


### PR DESCRIPTION
## 배경

PR #116 (FEAT-RESULT-WHAT-IF-SIMULATION) 머지 후속 정정 — 사용자 직관 정정 + 르르 의지 답습.

## 정정 2종

1. **label 정정:** `time-chip-options.tsx`
   - "다른 시간대 시뮬레이션" → **"시간대 변경"**

2. **whatIfDisabled flag 제거:** `result-content.tsx`
   - `const whatIfDisabled = !coordinateA;` 제거
   - JSX `disabled={whatIfDisabled}` 제거
   - ★ 시나리오 B 영역도 입력 활성 + `handleTimeWhatIf` handler 내 fallback toast **그대로 유지** (★ `coordinateA` null → toast "페이지 새로고침 후 다시 시도해주세요" + early return)

## 검증 5종 통과

- `npx prisma validate` → exit 0 ✅
- `npx prisma generate` → exit 0 (Prisma Client 7.8.0) ✅
- `npx tsc --noEmit` → 0 errors ✅
- `npx eslint src/` → 0 errors (10 warnings 기존) ✅
- `npm run build` → exit 0 (★ Middleware 32.5 kB **25번째** + /diagnosis/result/[id] **9.34 kB** = 9.35 → 9.34 -0.01 kB 미세 감소)

## 산출

- 1 commit (a0546b8)
- 2 파일 (time-chip-options.tsx + result-content.tsx)
- +2/-5 = 3 lines 절제

## Refs

#111 (FEAT-RESULT-WHAT-IF-SIMULATION 후속 정정)