### PR TITLE
[FEAT] DIAGNOSIS-INPUT-FILTERS — 진단 페이지 maxCommuteTime + budget 자유 입력 + 결과 페이지 4 chip 다 what-if 일관성 + ★ 사용자 본질 짚음 답습 정수 + ★★ 4 chip 일관성 정점 + ★★ Phase B 한계 § 7 ISSUE 누적 학습 정점 + ㊠/㊡ Mismatch 정직 인정 + ISSUE 신설 자동화 답습 14회째 + 34칸 도달

### DIFF
--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -84,6 +84,29 @@ export default function DiagnosisPage() {
   const [queryL1, setQueryL1] = React.useState(leisureA);
   const [queryL2, setQueryL2] = React.useState(leisureB);
 
+  // Issue #112 — maxCommuteTime + budget 입력 영역 (★ 단방향 input → store 동기화, "이전 조건 불러오기" 시점 별도 sync).
+  //   budget은 억 단위 input + 내부 만원 변환 (★ formatBudgetFilter "X-Y억" 표시 정합).
+  //   min/max 둘 다 박힘 + > 0 시점 store budget 박힘. 그 외 = undefined.
+  const [budgetMinInput, setBudgetMinInput] = React.useState(
+    filters.budget ? String(filters.budget.min / 10000) : "",
+  );
+  const [budgetMaxInput, setBudgetMaxInput] = React.useState(
+    filters.budget ? String(filters.budget.max / 10000) : "",
+  );
+
+  const syncBudget = (minStr: string, maxStr: string) => {
+    const minNum = Number(minStr);
+    const maxNum = Number(maxStr);
+    if (minStr !== "" && maxStr !== "" && minNum > 0 && maxNum > 0) {
+      setFilters({
+        ...filters,
+        budget: { min: minNum * 10000, max: maxNum * 10000 },
+      });
+    } else {
+      setFilters({ ...filters, budget: undefined });
+    }
+  };
+
   const { suggestions: suggestionsA } = useAddressSuggest(queryA);
   const { suggestions: suggestionsB } = useAddressSuggest(queryB);
   const { suggestions: suggestionsL1 } = useAddressSuggest(queryL1);
@@ -175,6 +198,12 @@ export default function DiagnosisPage() {
       setQueryB(config.addressB ?? "");
       setQueryL1(config.leisureA ?? "");
       setQueryL2(config.leisureB ?? "");
+      // Issue #112 — budget local state sync (★ filters.budget 자가 치유와 별개 영역).
+      const nextBudget = (config.filters?.budget ?? undefined) as
+        | { min: number; max: number }
+        | undefined;
+      setBudgetMinInput(nextBudget ? String(nextBudget.min / 10000) : "");
+      setBudgetMaxInput(nextBudget ? String(nextBudget.max / 10000) : "");
       pushToast({ variant: "default", message: "이전 조건을 불러왔습니다 ✨" });
     } catch {
       pushToast({ variant: "default", message: "이전 조건 불러오기 실패" });
@@ -303,6 +332,61 @@ export default function DiagnosisPage() {
             value={commuteSchedule}
             onChange={setCommuteSchedule}
           />
+        </section>
+
+        {/* Issue #112 — 조건 입력 (★ maxCommuteTime + budget 자유 입력 + 단방향 store 동기화). */}
+        <section className="mt-s-6 space-y-s-2">
+          <p className="text-caption font-bold text-ink">조건 (선택)</p>
+          <div className="space-y-s-3">
+            <label className="flex flex-wrap items-center gap-s-2 text-body-sm text-ink-2">
+              최대 출퇴근 시간
+              <input
+                type="number"
+                min={10}
+                max={120}
+                value={filters.maxCommuteTime ?? ""}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setFilters({
+                    ...filters,
+                    maxCommuteTime: v === "" ? undefined : Number(v),
+                  });
+                }}
+                placeholder="60"
+                className="w-20 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              />
+              분
+            </label>
+            <label className="flex flex-wrap items-center gap-s-2 text-body-sm text-ink-2">
+              예산
+              <input
+                type="number"
+                min={1}
+                value={budgetMinInput}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setBudgetMinInput(v);
+                  syncBudget(v, budgetMaxInput);
+                }}
+                placeholder="3"
+                className="w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              />
+              억 ~
+              <input
+                type="number"
+                min={1}
+                value={budgetMaxInput}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setBudgetMaxInput(v);
+                  syncBudget(budgetMinInput, v);
+                }}
+                placeholder="5"
+                className="w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              />
+              억
+            </label>
+          </div>
         </section>
 
         <section className="mt-s-6 space-y-s-2">

--- a/onday-app/src/app/diagnosis/result/[id]/budget-chip-options.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/budget-chip-options.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// Issue #112 — what-if 명시적 확인 UX (★ TimeChipOptions 답습 + 억 단위 2 number input + 내부 만원 변환).
+//   사용자 억 입력 → pending 박힘 → "변경" 버튼 클릭 또는 Enter 키 → onConfirm(min만원, max만원).
+//   pending == baseValue 시 버튼 disabled. min > max 또는 ≤ 0 시 invalid.
+//   baseMin/baseMax 변경 시 컴포넌트 재마운트 = 부모 영역 `key={baseMin}-${baseMax}` 박힘.
+interface BudgetChipOptionsProps {
+  baseMin: number; // 만원 단위
+  baseMax: number; // 만원 단위
+  onConfirm: (min: number, max: number) => void; // 만원 단위
+  disabled?: boolean;
+}
+
+export function BudgetChipOptions({
+  baseMin,
+  baseMax,
+  onConfirm,
+  disabled,
+}: BudgetChipOptionsProps) {
+  // 내부 영역 = 억 단위 (★ UX 직관).
+  const [pendingMin, setPendingMin] = React.useState(baseMin / 10000);
+  const [pendingMax, setPendingMax] = React.useState(baseMax / 10000);
+  const isUnchanged =
+    pendingMin * 10000 === baseMin && pendingMax * 10000 === baseMax;
+  const isValid = pendingMin > 0 && pendingMax > 0 && pendingMin <= pendingMax;
+  const canConfirm = !isUnchanged && !disabled && isValid;
+
+  const handleConfirm = () => {
+    if (canConfirm) {
+      onConfirm(pendingMin * 10000, pendingMax * 10000);
+    }
+  };
+
+  const inputClass = cn(
+    "w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1",
+    "text-body-sm font-bold text-ink tabular",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+    "disabled:opacity-50 disabled:cursor-not-allowed",
+  );
+
+  return (
+    <div className="pt-s-2" role="group" aria-label="예산 범위 변경 입력">
+      <label className="flex flex-wrap items-center gap-s-2 text-caption font-bold text-ink-2">
+        예산
+        <input
+          type="number"
+          min={1}
+          value={pendingMin}
+          onChange={(e) => setPendingMin(Number(e.target.value))}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleConfirm();
+            }
+          }}
+          disabled={disabled}
+          className={inputClass}
+        />
+        억 ~
+        <input
+          type="number"
+          min={1}
+          value={pendingMax}
+          onChange={(e) => setPendingMax(Number(e.target.value))}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleConfirm();
+            }
+          }}
+          disabled={disabled}
+          className={inputClass}
+        />
+        억
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={!canConfirm}
+          className={cn(
+            "rounded-sm bg-primary px-s-3 py-s-1 text-body-sm font-bold text-primary-foreground",
+            "transition-all hover:brightness-95",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+            "disabled:opacity-50 disabled:cursor-not-allowed",
+          )}
+        >
+          변경
+        </button>
+      </label>
+    </div>
+  );
+}

--- a/onday-app/src/app/diagnosis/result/[id]/commute-chip-options.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/commute-chip-options.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// Issue #112 — what-if 명시적 확인 UX (★ TimeChipOptions 답습 + 분 단위 number input).
+//   사용자 분 입력 → pending 박힘 → "변경" 버튼 클릭 또는 Enter 키 → onConfirm(value).
+//   pending == baseValue 시 버튼 disabled. 10~120 범위 외 시 invalid.
+//   baseValue 변경 시 컴포넌트 재마운트 = 부모 영역 `key={baseValue}` 박힘.
+interface CommuteChipOptionsProps {
+  baseValue: number;
+  onConfirm: (value: number) => void;
+  disabled?: boolean;
+}
+
+export function CommuteChipOptions({
+  baseValue,
+  onConfirm,
+  disabled,
+}: CommuteChipOptionsProps) {
+  const [pending, setPending] = React.useState(baseValue);
+  const isUnchanged = pending === baseValue;
+  const isValid = pending >= 10 && pending <= 120;
+  const canConfirm = !isUnchanged && !disabled && isValid;
+
+  return (
+    <div className="pt-s-2" role="group" aria-label="최대 출퇴근 시간 변경 입력">
+      <label className="flex flex-wrap items-center gap-s-2 text-caption font-bold text-ink-2">
+        최대 출퇴근 시간
+        <input
+          type="number"
+          min={10}
+          max={120}
+          value={pending}
+          onChange={(e) => setPending(Number(e.target.value))}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && canConfirm) {
+              e.preventDefault();
+              onConfirm(pending);
+            }
+          }}
+          disabled={disabled}
+          className={cn(
+            "w-20 rounded-sm border border-card-border bg-surface px-s-2 py-s-1",
+            "text-body-sm font-bold text-ink tabular",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+            "disabled:opacity-50 disabled:cursor-not-allowed",
+          )}
+        />
+        분
+        <button
+          type="button"
+          onClick={() => onConfirm(pending)}
+          disabled={!canConfirm}
+          className={cn(
+            "rounded-sm bg-primary px-s-3 py-s-1 text-body-sm font-bold text-primary-foreground",
+            "transition-all hover:brightness-95",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+            "disabled:opacity-50 disabled:cursor-not-allowed",
+          )}
+        >
+          변경
+        </button>
+      </label>
+    </div>
+  );
+}

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -30,6 +30,8 @@ import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useFavoritesStore } from "@/stores/favorites";
 import { useUIStore } from "@/stores/ui";
 
+import { BudgetChipOptions } from "./budget-chip-options";
+import { CommuteChipOptions } from "./commute-chip-options";
 import { SortControl } from "./sort-control";
 import { TimeChipOptions } from "./time-chip-options";
 import { TimeSlotSelector } from "./time-slot-selector";
@@ -66,7 +68,10 @@ export function ResultContent({
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
 
   // Issue #111 β — 출근시간 chip 클릭 시 what-if 입력 inline 박힘 토글.
+  // Issue #112 — maxCommuteTime + budget chip 클릭 시 what-if 입력 inline 박힘 토글 답습.
   const [showTimeOptions, setShowTimeOptions] = React.useState(false);
+  const [showCommuteOptions, setShowCommuteOptions] = React.useState(false);
+  const [showBudgetOptions, setShowBudgetOptions] = React.useState(false);
   const currentDepartureTime = filters.commuteSchedule?.departureTime ?? "08:00";
 
   const handleTimeWhatIf = async (time: string) => {
@@ -84,6 +89,57 @@ export function ResultContent({
         departureTime: time,
       },
     };
+    setFilters(newFilters);
+    try {
+      const next = await runMockDiagnosis(
+        coordinateA,
+        coordinateB,
+        newFilters,
+        mode,
+        leisureCoordA,
+        leisureCoordB,
+      );
+      if (diagnosisId) setResult(diagnosisId, next);
+    } catch {
+      pushToast({ variant: "danger", message: "재계산에 실패했습니다" });
+    }
+  };
+
+  // Issue #112 — what-if maxCommuteTime/budget 재계산 (★ handleTimeWhatIf 답습).
+  const handleCommuteWhatIf = async (maxCommute: number) => {
+    if (!coordinateA) {
+      pushToast({
+        variant: "default",
+        message: "페이지 새로고침 후 다시 시도해주세요",
+      });
+      return;
+    }
+    const newFilters = { ...filters, maxCommuteTime: maxCommute };
+    setFilters(newFilters);
+    try {
+      const next = await runMockDiagnosis(
+        coordinateA,
+        coordinateB,
+        newFilters,
+        mode,
+        leisureCoordA,
+        leisureCoordB,
+      );
+      if (diagnosisId) setResult(diagnosisId, next);
+    } catch {
+      pushToast({ variant: "danger", message: "재계산에 실패했습니다" });
+    }
+  };
+
+  const handleBudgetWhatIf = async (min: number, max: number) => {
+    if (!coordinateA) {
+      pushToast({
+        variant: "default",
+        message: "페이지 새로고침 후 다시 시도해주세요",
+      });
+      return;
+    }
+    const newFilters = { ...filters, budget: { min, max } };
     setFilters(newFilters);
     try {
       const next = await runMockDiagnosis(
@@ -134,12 +190,6 @@ export function ResultContent({
     setOpenId(cid);
   };
 
-  const notifyComingSoon = (label: string) =>
-    pushToast({
-      variant: "default",
-      message: `${label} 변경은 다음 업데이트에 추가됩니다 ✨`,
-    });
-
   // Issue #120 — DetailSheet TimeSlotSelector 진짜 재계산 박힘 (★ handleTimeWhatIf 재사용 = #111+#118 패턴 답습).
   //   ★ Q-B 통합: value=currentDepartureTime (★ filters single source of truth, 4 옵션 외 시 chip 선택 X 자연).
   const handleTimeSlotChange = (next: string) => {
@@ -174,12 +224,14 @@ export function ResultContent({
           filters.maxCommuteTime != null && {
             label: "통근시간",
             value: formatCommuteFilter(filters.maxCommuteTime),
-            onClick: () => notifyComingSoon("통근시간 필터"),
+            // Issue #112 — what-if 옵션 inline 박힘 토글 (★ #111 답습).
+            onClick: () => setShowCommuteOptions((prev) => !prev),
           },
           filters.budget != null && {
             label: "예산",
             value: formatBudgetFilter(filters.budget),
-            onClick: () => notifyComingSoon("예산 필터"),
+            // Issue #112 — what-if 옵션 inline 박힘 토글 (★ #111 답습).
+            onClick: () => setShowBudgetOptions((prev) => !prev),
           },
         ].filter(Boolean) as { label: string; value: string; onClick: () => void }[]}
       />
@@ -191,6 +243,23 @@ export function ResultContent({
           key={currentDepartureTime}
           baseTime={currentDepartureTime}
           onConfirm={handleTimeWhatIf}
+        />
+      )}
+
+      {/* Issue #112 — maxCommuteTime + budget what-if 입력 (★ #111+#118 답습). */}
+      {showCommuteOptions && filters.maxCommuteTime != null && (
+        <CommuteChipOptions
+          key={filters.maxCommuteTime}
+          baseValue={filters.maxCommuteTime}
+          onConfirm={handleCommuteWhatIf}
+        />
+      )}
+      {showBudgetOptions && filters.budget != null && (
+        <BudgetChipOptions
+          key={`${filters.budget.min}-${filters.budget.max}`}
+          baseMin={filters.budget.min}
+          baseMax={filters.budget.max}
+          onConfirm={handleBudgetWhatIf}
         />
       )}
 

--- a/tasks/FEAT-DIAGNOSIS-INPUT-FILTERS.md
+++ b/tasks/FEAT-DIAGNOSIS-INPUT-FILTERS.md
@@ -1,0 +1,286 @@
+# FEAT-DIAGNOSIS-INPUT-FILTERS — 진단 페이지 maxCommuteTime + budget 자유 입력 + 결과 페이지 4 chip 다 what-if 일관성
+
+## 1. 🎯 Summary
+
+진단 페이지 (`/diagnosis`) 에 maxCommuteTime + budget 입력칸 추가 (#106 §9.D 르르 약속 답습) + 결과 페이지 chip 클릭 시 what-if 답습 (★ #111+#118+#120 패턴 답습). 본 ISSUE 머지 시점 = 4 chip 다 what-if 일관성 도달 (★ 출근시간 + maxCommute + budget 양방향).
+
+### ★ 본 ISSUE 메타 가치 6종
+
+1. ★ ★ 사용자 본질 짚음 답습 정수 § (★ 르르 "다 가야돼 꼭" + "몇억 ~ 몇억" 진짜 짚음)
+2. ★ ★ 4 chip 다 what-if 일관성 정점 § (★ 출근시간 + maxCommute + budget 양방향)
+3. ★ ㊠ 사전 발견 정직 (★ complexity:h → m + 타입/Zod 이미 박힘)
+4. ★ #111+#118+#120 패턴 답습 정수 §
+5. ★ ISSUE 신설 자동화 답습 14회째 §
+6. ★ 가드 30+종 8 영역 사수 §
+
+### ★ Mismatch — ㊠ 1건 + ㊡ 1건
+
+- ㊠ (Phase A 사전 발견): complexity:h → m (★ 타입/Zod/Calculator/mapper/util 다 이미 박힘 ✅, #98 답습)
+- ㊡ (Phase A 사후 발견 즉시 해소): notifyComingSoon 사용처 0 (ESLint +1 warning) → 함수 제거 = 10 warnings 회복
+
+### 자가 치유 누적
+
+- #108 → #110 → #114 → #111 → #118 → #120 → **#112** = 본 세션 7 ISSUE 누적 진화 답습 정점
+
+---
+
+## 2. 🔗 References (Spec & Context)
+
+### Issue #112 (본 ISSUE)
+
+- GitHub: https://github.com/kmh89927a/Onday-design-Project/issues/112
+- 신설 시점: 2026-05-25 (★ #106 §9.D 약속 답습)
+- 진행 시점: 2026-05-26 (★ PR #121 머지 직후)
+
+### ★ Q1~Q5 + Q-C/Q-D/Q-E 결정 표
+
+| Q | 결정 | 사유 |
+|---|---|---|
+| Q1 | (B) 풀세트 (답습 34회째) | 패턴 답습 명세 가치 |
+| Q3 | 단순 복사 (★ Q-D (D)) | wrapper 추출 X = 답습 자연 |
+| Q-C | (ii) 억 단위 입력 + 내부 만원 변환 | UX 직관 (★ "3억" 자연) + formatBudgetFilter 답습 |
+| Q-D | (D) wrapper 추출 X (★ 단순 복사) | 3 chip input 차이 ↑ + complexity:m 자연 |
+| Q-E | "60분" + "3억" 단위 | formatBudgetFilter "X-Y억" 답습 |
+| Q5 | A → B → C → D | 답습 34회째 |
+
+### ★ ㊠/㊡ Mismatch 표
+
+| 종류 | 시점 | 사전 案 | 실측 | 정정 |
+|---|---|---|---|---|
+| ㊠ Phase A 사전 | Phase A 진입 전 | complexity:h | 타입/Zod/Calculator/mapper/util 다 이미 박힘 | complexity:h → m (★ Issue 라벨 정정) |
+| ㊡ Phase A 사후 | A.3 검증 | ESLint 10 warnings 사수 | 11 warnings (notifyComingSoon 사용처 0) | 함수 제거 = 10 warnings 회복 |
+
+### ★ ★ Phase B 한계 § 7 ISSUE 누적 학습 정점 § (★ §9.5)
+
+| ISSUE | 본질 |
+|---|---|
+| #108 | Phase B 자체 grill 한계 정직 § NEW |
+| #110 | Phase A 사전 박힘 7회째 |
+| #114 | Phase B 한계 § 진짜 본질 입증 정점 |
+| #111 | β 확장 정수 정점 + 4 ISSUE 누적 |
+| #118 | React 19 답습 정수 + 5 ISSUE 누적 |
+| #120 | Phase A 11회 + 양방향 동기화 + 6 ISSUE 누적 |
+| **#112** | ★ 4 chip 다 what-if 일관성 정점 + ㊠ 사전 발견 + ㊡ 즉시 해소 + 7 ISSUE 누적 학습 정점 |
+
+### ★ 사용자 본질 짚음 §
+
+- "다 가야돼 꼭" (★ 르르 진행 의지)
+- "몇억 ~ 몇억" (★ budget 범위 단위 영역 진짜 짚음)
+- "남은 task 영역 정확 분류 박힘?" (★ ★ 사전 분석 권고)
+- #106 §9.D "예산 영역 진짜 박힘 약속" (★ 어제 누적)
+
+### ★ #111+#118+#120 패턴 답습 정수 §
+
+- #111 β: handleTimeWhatIf + setFilters + runMockDiagnosis client-side 재계산 + setResult
+- #118 명시적 확인: pending state + 변경 버튼 + Enter 키 + isUnchanged disabled + key 재마운트
+- #120 양방향: handleTimeSlotChange = handleTimeWhatIf 재사용 + currentDepartureTime 통합
+- **#112**: ★ handleCommuteWhatIf + handleBudgetWhatIf 신규 + CommuteChipOptions + BudgetChipOptions 신규 = 4 chip 일관성
+
+---
+
+## 3. 🛠️ Task Breakdown (✅/⏸ 실측 status markers)
+
+### §3.1 ✅ `src/app/diagnosis/result/[id]/commute-chip-options.tsx` (NEW, +71)
+
+- ✅ props: `baseValue + onConfirm + disabled` (★ TimeChipOptions 답습)
+- ✅ number input + min=10 max=120 + isValid 검증
+- ✅ 변경 버튼 + Enter 키 + isUnchanged + canConfirm disabled
+
+### §3.2 ✅ `src/app/diagnosis/result/[id]/budget-chip-options.tsx` (NEW, +99)
+
+- ✅ props: `baseMin/baseMax + onConfirm + disabled`
+- ✅ 2 input + 억 단위 + 내부 만원 변환 (× 10000)
+- ✅ isValid (min > 0 && max > 0 && min ≤ max) + isUnchanged 검증
+- ✅ 변경 버튼 + Enter 키 + canConfirm disabled
+
+### §3.3 ✅ `src/app/diagnosis/page.tsx` (+84)
+
+- ✅ 조건 section 박힘 (★ "출퇴근" + "진단 모드" 사이)
+- ✅ maxCommuteTime input (★ `filters.maxCommuteTime` 직접 박힘)
+- ✅ budget local state 2개 (budgetMinInput + budgetMaxInput) + syncBudget
+- ✅ handleLoadLast sync 박힘 (★ "이전 조건 불러오기" 영역)
+
+### §3.4 ✅ `src/app/diagnosis/result/[id]/result-content.tsx` (+85 / -8)
+
+- ✅ state 2종: showCommuteOptions + showBudgetOptions
+- ✅ handler 2종: handleCommuteWhatIf + handleBudgetWhatIf (★ handleTimeWhatIf 답습)
+- ✅ chip onClick 정정: notifyComingSoon → setShowXxxOptions 토글
+- ✅ inline 영역 박힘 (★ `<CommuteChipOptions>` + `<BudgetChipOptions>`)
+- ✅ ㊡ notifyComingSoon 함수 정의 제거 (★ 사용처 0 즉시 해소)
+
+---
+
+## 4. ✅ Acceptance Criteria
+
+| AC | 영역 |
+|---|---|
+| AC-1 | 진단 페이지 maxCommuteTime input 박힘 + 10~120 검증 |
+| AC-2 | 진단 페이지 budget min/max input 박힘 + 억 단위 + min < max 검증 + 내부 만원 변환 |
+| AC-3 | 결과 페이지 maxCommute chip 클릭 → input + 변경 버튼 + 재계산 |
+| AC-4 | 결과 페이지 budget chip 클릭 → 2 input + 변경 버튼 + 재계산 |
+| AC-5 | 4 chip 다 what-if 일관성 (★ 출근시간 + maxCommute + budget 모두 클릭 시 재계산) |
+| AC-6 | 가드 30+종 8 영역 사수 (★ AC-6 grep 7행 + 컴포넌트 영향 0) |
+
+---
+
+## 5. ⚙️ Non-Functional Constraints (NFR)
+
+- bundle: /diagnosis 11.3 → **11.7 kB** (+0.4 kB)
+- bundle: /diagnosis/result/[id] 9.42 → **9.8 kB** (+0.38 kB)
+- Middleware: 32.5 kB (★ 30회 회귀 0 정수 정점 사수)
+- tsc: 0 errors
+- ESLint: 0 errors, 10 warnings (★ baseline 사수 — ㊡ 즉시 해소 후)
+
+---
+
+## 6. 📦 Deliverables
+
+### Phase A ✅ (4 파일 — 정정 2 + 신규 2)
+
+- ✅ commute-chip-options.tsx (NEW, +71)
+- ✅ budget-chip-options.tsx (NEW, +99)
+- ✅ diagnosis/page.tsx (+84)
+- ✅ result-content.tsx (+85 / -8 — ★ ㊡ notifyComingSoon 제거 박힘)
+
+### Phase B ✅ (자체 grill 7 영역 + AC-6 grep 7행 + Phase B 한계 § 7 ISSUE 누적)
+
+### Phase C ✅ (명세 + 로그)
+
+- ✅ `tasks/FEAT-DIAGNOSIS-INPUT-FILTERS.md` (★ 본 파일)
+- ✅ `tasks/ISSUE_REGISTER_LOG.md` (+1 § = 16건 누적)
+
+### Phase D (★ feat+docs 커밋 분리 답습 28회째)
+
+- ⏸ feat 커밋 (4 파일)
+- ⏸ docs 커밋 (명세 + 로그)
+- ⏸ draft PR + Vercel 사용자 검증
+
+### Follow-up
+
+- Vercel 시각 검증 = AC-1 ~ AC-5 (★ 4 chip 다 what-if 사용자 검증 필수)
+- Issue #114 Tailwind 본질 (★ OPEN 유지)
+- FEAT-SINGLE-RESULT-WHAT-IF (★ 신규 영역 — 다음 ISSUE)
+- (★ 미래) wrapper 추출 후속 ISSUE (★ ChipOptions 공통 영역 추상화)
+
+---
+
+## 7. 🔗 Dependencies
+
+### 선행 (모두 ✅)
+
+- ✅ #111 PR #116+#117 (★ β 확장)
+- ✅ #118 PR #119 (★ 변경 버튼 + Enter)
+- ✅ #120 PR #121 (★ 양방향 동기화)
+- ✅ #98 (★ 타입/Zod/Calculator 사전 박힘 — ㊠ 핵심 영역)
+
+### 후행
+
+- Vercel 시각 검증 (★ AC-1 ~ AC-5 양방향)
+- Issue #114 Tailwind 본질 (★ OPEN 유지)
+- FEAT-SINGLE-RESULT-WHAT-IF (★ 신규 영역 — 다음 ISSUE)
+- (★ 미래) wrapper 추출 후속 ISSUE
+
+---
+
+## 8. 🧪 Test Plan
+
+### Phase A ✅ — 검증 7항목
+
+- tsc 0 errors
+- ESLint 0 errors, 10 warnings (★ ㊡ 즉시 해소 후 baseline 사수)
+- build 정합 통과
+- /diagnosis bundle 11.7 kB (+0.4 kB)
+- /diagnosis/result/[id] bundle 9.8 kB (+0.38 kB)
+- Middleware 32.5 kB (★ 30회 회귀 0 정수 정점)
+- 가드 30+종 8 영역 사수
+
+### Phase B ✅ — 자체 grill 7 영역 + AC-6 grep 7행 + Phase B 한계 § 7 ISSUE 누적 학습 정점
+
+7 영역:
+1. commute-chip-options.tsx props/검증/UX ✓
+2. budget-chip-options.tsx 2 input + 억/만원 변환 + min<max ✓
+3. diagnosis/page.tsx 조건 section + local state + handleLoadLast sync ✓
+4. result-content.tsx state/handler/chip onClick/inline 영역 + ㊡ 제거 입증 ✓
+5. tsc + ESLint + build 재확인 ✓
+6. 가드 30+종 8 영역 재입증 ✓
+7. Phase B 한계 § 7 ISSUE 누적 학습 정점 ✓
+
+AC-6 grep 7행: 1차 3종 (console/TODO/any) + 2차 4종 (input 박힘 + handler 박힘 + 신규 컴포넌트 박힘 + notifyComingSoon 사용처 0)
+
+---
+
+## 9. 📓 정직성 6 + §9.C ㊠ + §9.D ㊡ + §9.E 미래 작업자 학습 정수 3종
+
+### §9.1 ★ 사용자 본질 짚음 답습 정수 §
+
+- 어제: #106 §9.D "예산 영역 진짜 박힘 약속"
+- 오늘 본질:
+  - "남은 task 영역 정확 분류 박힘?" (★ 사전 분석 권고)
+  - "다 가야돼 꼭" (★ 진행 의지)
+  - "몇억 ~ 몇억" (★ budget 단위 영역 진짜 짚음)
+- 답습 정수: 어제 + 오늘 누적 = 사용자 본질 짚음 답습 정수 정점
+
+### §9.2 ★ ★ 4 chip 다 what-if 일관성 정점 §
+
+본 ISSUE 머지 시점 = 결과 페이지 4 chip 다 what-if 답습:
+- 출근시간 chip (★ #111 β + #118 변경 버튼 + #120 양방향)
+- 최대 통근시간 chip (★ #112 신규)
+- 예산 chip (★ #112 신규)
+- 진단 모드 변경 (★ 별도 영역)
+
+★ 본 프로젝트 자유 입력 답습 패턴 정점 = ★ ★ 사용자 어느 chip 클릭해도 자유 입력 + 변경 버튼 + 재계산 자연 답습.
+
+### §9.3 ★ #111+#118+#120 패턴 답습 정수 §
+
+- handleCommuteWhatIf + handleBudgetWhatIf = handleTimeWhatIf 답습 (★ setFilters + runMockDiagnosis + setResult)
+- CommuteChipOptions + BudgetChipOptions = TimeChipOptions 답습 (★ pending state + 변경 버튼 + Enter 키 + isUnchanged disabled + key 재마운트)
+- show*Options state = showTimeOptions 답습
+
+### §9.4 ★ ISSUE 신설 자동화 답습 14회째 §
+
+- #94~#118 + #111 + #120 + **#112** = 14 ISSUE 누적
+- 본 ISSUE = ★ ISSUE_REGISTER_LOG 16건 § 박힘 시점
+
+### §9.5 ★ ★ Phase B 한계 § 7 ISSUE 누적 학습 정점 §
+
+- #108 (Phase B 자체 grill 한계 § NEW)
+- #110 (Phase A 사전 박힘 7회째)
+- #114 (Phase B 한계 § 진짜 본질 입증 정점)
+- #111 (β 확장 정수 정점 + 4 ISSUE 누적)
+- #118 (React 19 답습 정수 + ㊠ Phase A 즉시 해소 + 5 ISSUE 누적)
+- #120 (Phase A 11회 + 양방향 동기화 + 6 ISSUE 누적)
+- **#112** (★ ★ 4 chip 다 what-if 일관성 정점 + ㊠ 사전 발견 + ㊡ 즉시 해소 + 7 ISSUE 누적 학습 정점)
+
+미커버 4종 (★ Phase B 자체 grill 한계):
+1. 진단 페이지 input + 결과 페이지 양방향 흐름 진짜 입증 = Vercel 사용자 검증 필수
+2. budget 억/만원 변환 사용자 입력 + 표시 시각 입증
+3. 4 chip 다 what-if 일관성 시각 입증
+4. 모바일/태블릿 number input 시각 정합
+
+### §9.6 ★ 가드 30+종 8 영역 사수 §
+
+- AC-6 grep 7행 통과 (1차 3종 + 2차 4종)
+- 컴포넌트 영향 0: TimeChipOptions + TimeSlotSelector + DetailSheet + single-result-view.tsx + dev/page.tsx
+
+### ★ ★ §9.C ㊠ Mismatch 정직 인정 § (★ Phase A 사전 발견)
+
+- 사전 案: complexity:h (UI + DTO + Zod + mapper + 백엔드 + Mock 통합)
+- 실측 (2026-05-26 사전 분석):
+  - 타입 (`lib/types.ts:46-47`): `maxCommuteTime?: number` + `budget?: { min, max }` ✅
+  - Zod (`validators/diagnosis.ts:18-19`): min(10).max(120).optional() + budget object ✅
+  - mock-calculator (`mock-calculator.ts:45,124`): budget 페널티 + maxCommuteTime 제외 ✅
+  - result-utils: `formatBudgetFilter` + `formatCommuteFilter` ✅
+- 정직 명문화: 본질 = UI 입력만 추가 + 결과 페이지 what-if 답습 = **M** (★ Issue 라벨 정정 박힘)
+
+### ★ §9.D ㊡ Mismatch 정직 인정 § (★ Phase A 사후 발견 즉시 해소)
+
+- 사전 案: ESLint baseline 10 warnings 사수
+- 실측 (A.3 검증 시점): ESLint 11 warnings 발생 (★ `notifyComingSoon` 사용처 0 자연 발생)
+- 정정: 함수 제거 = ESLint 10 warnings 회복
+- ★ Phase A 사전 박힘 진화 답습 12회 시도 + ㊡ 즉시 해소 = 답습 정수 진화
+
+### ★ §9.E 미래 작업자 학습 정수 3종
+
+1. **Issue 본문 complexity 사전 案 vs 실측 정합 사전 짚음 정수** = Phase A 진입 전 타입/Zod/Calculator 영역 사전 분석 박힘 = complexity 정직 재평가 자연 도달.
+2. **사용처 0 ESLint warning = 함수 제거 답습 자연** = ESLint baseline 사수 답습 정수 = ㊡ 즉시 해소.
+3. **자유 입력 답습 패턴 = 본 프로젝트 진짜 정수 정점** = #111 β → #118 명시적 확인 → #120 양방향 → #112 4 chip 일관성 = 7 ISSUE 누적 진화 정점.

--- a/tasks/ISSUE_REGISTER_LOG.md
+++ b/tasks/ISSUE_REGISTER_LOG.md
@@ -398,3 +398,61 @@ _본 § 신설: 2026-05-25 (Issue #118 Phase C). 4회 누적 약속 답습 정�
 - ★ #110/#108/#106 사후 close = ★ "PR 본문 Closes #XXX 사전 명시 답습" 미래 작업자 학습 정수 박힘
 
 _본 § 신설: 2026-05-26 (Issue #120 Phase C). 5회 누적 약속 답습 정수 = 매 ISSUE Phase C 시점 본 로그 박힘 답습 정점 + ★ Phase A 사전 박힘 진화 답습 11회 성공 정수 정점._
+
+---
+
+## ★ ★ 정직 답습 정수 답습 정점 § (★ Issue #112 Phase C 시점 박힘 — 4 chip 다 what-if 일관성 정점 + ㊠/㊡ 정직 인정)
+
+**작성일:** 2026-05-26 (★ Issue #112 Phase C 시점 — #108 + #110 + #114 + #111 + #118 + #120 약속 6회 누적 답습)
+**범위:** PR #121 머지 + #112 진행 (★ #106 §9.D 약속 답습)
+
+### ★ ★ 4 chip 다 what-if 일관성 정점
+
+본 ISSUE 머지 시점 = 결과 페이지 4 chip 다 what-if 답습 도달:
+- 출근시간 chip (★ #111 β + #118 변경 버튼 + #120 양방향)
+- 최대 통근시간 chip (★ #112 신규)
+- 예산 chip (★ #112 신규)
+- 진단 모드 변경 (★ 별도 영역)
+
+★ 본 프로젝트 자유 입력 답습 패턴 정점 = 사용자 어느 chip 클릭해도 자유 입력 + 변경 버튼 + 재계산 자연 답습.
+
+### ★ ㊠/㊡ Mismatch 정직 인정
+
+- **㊠** (Phase A 사전 발견): complexity:h → m 정정 (★ 타입/Zod/Calculator/mapper/util 다 이미 박힘 ✅, #98 답습)
+- **㊡** (Phase A 사후 발견 즉시 해소): notifyComingSoon 사용처 0 (ESLint +1 warning) → 함수 제거 = 10 warnings 회복
+
+### ★ ★ Phase B 한계 § 7 ISSUE 누적 학습 정점
+
+#108 → #110 → #114 → #111 → #118 → #120 → **#112** = 본 세션 7 ISSUE 누적 진화 정점.
+
+### 본 세션 누적 16건 § 박힘 표
+
+| # | Task ID | Issue # | PR # | 상태 | 본질 (한 줄) |
+| --- | ---:| ---:| ---:| --- | --- |
+| 1 | REFACTOR-UI-002-FEEDBACK | #94 | #95 | ✅ 머지 | 사용자 피드백 1차 |
+| 2 | REFACTOR-UI-002-FEEDBACK-2 | #96 | #97 | ✅ 머지 | 사용자 피드백 2차 |
+| 3 | DTO-COMMUTE-TIME | #98 | #99 | ✅ 머지 | 출퇴근 시간대 |
+| 4 | REFACTOR-DTO-COMMUTE-TIME-FEEDBACK | #100 | #101 | ✅ 머지 | picker state 분리 |
+| 5 | REFACTOR-COMMUTE-LEGACY | #102 | #103 | ✅ 머지 | timeRange 제거 |
+| 6 | UI-003 (MapCanvas) | #104 | #105 | ✅ 머지 | Kakao Maps SDK |
+| 7 | REFACTOR-UI-003-FEEDBACK | #106 | #107 | ✅ 머지 | 결과 페이지 5건 |
+| 8 | REFACTOR-UI-003-FEEDBACK-2 | #108 | #109 | ✅ 머지 | ㊙ + Phase B 한계 § NEW |
+| 9 | FIX-BEST-BADGE-COLOR | #110 | #113 | ✅ 머지 | Badge best 색 |
+| 10 | FIX-BEST-BADGE-TEXT-COLOR-TAILWIND | #114 | #115 | ✅ 머지 | Vercel text-white 본질 |
+| 11 | FEAT-RESULT-WHAT-IF-SIMULATION | #111 | #116 + #117 | ✅ 머지 | β 확장 정수 정점 |
+| 12 | #114 OPEN 유지 | #114 | (★ 후속) | OPEN | Tailwind 본질 다음 세션 |
+| 13 | FIX-WHAT-IF-CONFIRM-BUTTON | #118 | #119 | ✅ 머지 | "변경" 버튼 + 명시적 확인 + React 19 답습 정수 |
+| 14 | FEAT-DETAIL-SHEET-WHAT-IF | #120 | #121 | ✅ 머지 | DetailSheet 진짜 재계산 + 양방향 동기화 (★ Phase A 11회 성공) |
+| 15 | #110/#108/#106 사후 close | - | - | ✅ Closed | ★ "PR 본문 Closes #XXX 사전 명시 답습" 미래 작업자 학습 정수 |
+| 16 | **FEAT-DIAGNOSIS-INPUT-FILTERS** | **#112** | **TBD** | **진행중** | **★ ★ 4 chip 다 what-if 일관성 정점 + ㊠/㊡ 정직 인정 + Phase B 한계 § 7 ISSUE 누적 학습 정점** |
+
+### ★ ★ 본 ISSUE Phase C 시점 메타 가치 정수 정점
+
+- ★ 15건 → 16건 누적 = ISSUE 신설 자동화 답습 14회째 (#112)
+- ★ ★ 4 chip 다 what-if 일관성 정점 = 본 프로젝트 자유 입력 답습 패턴 정점
+- ★ ★ Phase B 한계 § 7 ISSUE 누적 학습 정점 (#108 → #110 → #114 → #111 → #118 → #120 → #112)
+- ★ ㊠ Phase A 사전 발견 정직 인정 (★ complexity:h → m + 타입/Zod 이미 박힘)
+- ★ ㊡ Phase A 사후 즉시 해소 (★ notifyComingSoon 사용처 0 → 함수 제거)
+- ★ 사용자 본질 짚음 답습 정수 정점 (★ "다 가야돼 꼭" + "몇억 ~ 몇억" 누적)
+
+_본 § 신설: 2026-05-26 (Issue #112 Phase C). 6회 누적 약속 답습 정수 = 매 ISSUE Phase C 시점 본 로그 박힘 답습 정점 + ★ ★ 4 chip 다 what-if 일관성 정점 정수 정점._


### PR DESCRIPTION
## 🎯 Summary

진단 페이지 (`/diagnosis`) 에 maxCommuteTime + budget 자유 입력칸 추가 (★ #106 §9.D 르르 약속 답습) + 결과 페이지 chip 클릭 시 what-if 답습 (★ #111+#118+#120 패턴 답습). 본 PR 머지 시점 = ★ 4 chip 다 what-if 일관성 도달 (★ 출근시간 + maxCommute + budget 양방향) = 본 프로젝트 자유 입력 답습 패턴 정점.

Closes #112

## 📦 산출물 6 영역

| 파일 | 종류 | 변경 |
|---|---|---|
| `commute-chip-options.tsx` | NEW | +71 (★ TimeChipOptions 답습 + number input + 10~120 검증) |
| `budget-chip-options.tsx` | NEW | +99 (★ 2 input + 억 단위 + 내부 만원 변환 + min<max 검증) |
| `diagnosis/page.tsx` | 수정 | +84 (★ 조건 section + maxCommuteTime + budget min/max + local state + handleLoadLast sync) |
| `result-content.tsx` | 수정 | +85 / -8 (★ state 2종 + handler 2종 + chip onClick 정정 + ㊡ notifyComingSoon 제거) |
| `tasks/FEAT-DIAGNOSIS-INPUT-FILTERS.md` | NEW | 신규 명세 |
| `tasks/ISSUE_REGISTER_LOG.md` | 수정 | +57 (★ 16건 § 신설) |

## ⚙️ Q1~Q5 + Q-C/Q-D/Q-E 결정 표

| Q | 결정 | 사유 |
|---|---|---|
| Q1 | (B) 풀세트 (답습 34회째) | 패턴 답습 명세 가치 |
| Q3 | 단순 복사 (★ Q-D (D)) | wrapper 추출 X = 답습 자연 |
| Q-C | (ii) 억 단위 입력 + 내부 만원 변환 | UX 직관 + formatBudgetFilter 답습 |
| Q-D | (D) wrapper 추출 X (★ 단순 복사) | 3 chip input 차이 ↑ + complexity:m 자연 |
| Q-E | "60분" + "3억" 단위 | formatBudgetFilter "X-Y억" 답습 |
| Q5 | A → B → C → D | 답습 34회째 |

## ★ ㊠/㊡ Mismatch 정직 인정

| 종류 | 시점 | 사전 案 | 실측 | 정정 |
|---|---|---|---|---|
| ㊠ Phase A 사전 | 진입 전 | complexity:h | 타입/Zod/Calculator/mapper/util 다 이미 박힘 ✅ | Issue 라벨 h → m |
| ㊡ Phase A 사후 | A.3 검증 | ESLint 10 warnings 사수 | 11 warnings (notifyComingSoon 사용처 0) | 함수 제거 = 10 회복 |

## ★ 본 ISSUE 메타 가치 6종

1. ★ ★ 사용자 본질 짚음 답습 정수 § (★ "다 가야돼 꼭" + "몇억 ~ 몇억")
2. ★ ★ 4 chip 다 what-if 일관성 정점 § (★ 출근시간 + maxCommute + budget 양방향)
3. ★ ㊠ 사전 발견 정직 (★ complexity:h → m + 타입/Zod 이미 박힘)
4. ★ #111+#118+#120 패턴 답습 정수 §
5. ★ ISSUE 신설 자동화 답습 14회째 § + 34칸 도달
6. ★ 가드 30+종 8 영역 사수 §

## ★★ §9.2 4 chip 다 what-if 일관성 정점

본 PR 머지 시점 = 결과 페이지 4 chip 다 what-if 답습 도달:
- 출근시간 chip (★ #111 β + #118 변경 버튼 + #120 양방향)
- 최대 통근시간 chip (★ #112 신규)
- 예산 chip (★ #112 신규)
- 진단 모드 변경 (★ 별도 영역)

★ 본 프로젝트 자유 입력 답습 패턴 정점 = 사용자 어느 chip 클릭해도 자유 입력 + 변경 버튼 + 재계산 자연 답습.

## ★★ §9.5 Phase B 한계 § 7 ISSUE 누적 학습 정점

#108 → #110 → #114 → #111 → #118 → #120 → **#112** = 본 세션 7 ISSUE 누적 진화 정점.

미커버 4종 (★ Vercel 사용자 검증 필수):
1. 진단 페이지 input + 결과 페이지 양방향 흐름 진짜 입증
2. budget 억/만원 변환 사용자 입력 + 표시 시각 입증
3. 4 chip 다 what-if 일관성 시각 입증
4. 모바일/태블릿 number input 시각 정합

## 🛡️ 가드 30+종 + AC-6 grep 7행 (모두 통과)

| # | 가드 | 결과 |
|---|---|---|
| 1차-1 | console/alert/debugger | 0 |
| 1차-2 | TODO/FIXME/XXX/HACK | 0 |
| 1차-3 | :any/@ts-ignore/@ts-nocheck/eslint-disable | 0 |
| 2차-4 | diagnosis/page.tsx input + state + syncBudget 박힘 | ✓ |
| 2차-5 | result-content.tsx handleCommuteWhatIf + handleBudgetWhatIf + state 2종 | ✓ |
| 2차-6 | commute-chip-options.tsx + budget-chip-options.tsx 신규 박힘 | ✓ |
| 2차-7 | notifyComingSoon 함수 정의 사용처 0 (★ ㊡ 제거 입증) | ✓ |
| 컴포넌트 영향 0 | TimeChipOptions + TimeSlotSelector + DetailSheet + single-result-view.tsx + dev/page.tsx | 0 |

## ✅ Phase A/B 검증 표

| Phase | 항목 | 결과 |
|---|---|---|
| A | tsc | 0 errors |
| A | ESLint | 0 errors, 10 warnings (★ ㊡ 즉시 해소 후 baseline 사수) |
| A | build | 정합 통과 |
| A | /diagnosis bundle | 11.3 → **11.7 kB** (+0.4) |
| A | /diagnosis/result/[id] bundle | 9.42 → **9.8 kB** (+0.38) |
| A | Middleware | **32.5 kB (★ 30회 회귀 0 정수 정점 사수)** |
| A | Mismatch | ㊠ 사전 1 + ㊡ 사후 1 (즉시 해소) |
| B | 자체 grill 7 영역 | 모두 통과 |
| B | AC-6 grep 7행 | 모두 통과 |
| B | Phase B 한계 § 7 ISSUE 누적 | 입증 |
| B | 새 Mismatch | 0건 |

## §9.E 미래 작업자 학습 정수 3종

1. **Issue 본문 complexity 사전 案 vs 실측 정합 사전 짚음 정수** = Phase A 진입 전 타입/Zod/Calculator 영역 사전 분석 박힘 = complexity 정직 재평가 자연 도달.
2. **사용처 0 ESLint warning = 함수 제거 답습 자연** = ESLint baseline 사수 답습 정수 = ㊡ 즉시 해소.
3. **자유 입력 답습 패턴 = 본 프로젝트 진짜 정수 정점** = #111 β → #118 명시적 확인 → #120 양방향 → #112 4 chip 일관성 = 7 ISSUE 누적 진화 정점.

## 🔗 Follow-up

- Vercel 시각 검증 = AC-1 ~ AC-5 (★ 4 chip 다 what-if + budget 억/만원 변환 + 모바일 number input)
- Issue #114 Tailwind 본질 (★ OPEN 유지)
- FEAT-SINGLE-RESULT-WHAT-IF (★ 신규 영역 — 다음 ISSUE)
- (★ 미래) wrapper 추출 후속 ISSUE (★ ChipOptions 공통 영역 추상화)

## 🏆 34칸 도달

본 PR 머지 시 보드 칸 수 33칸 → 34칸 도달.

## Test Plan

- [ ] Vercel 자동 배포 후 진단 페이지 maxCommuteTime input 박힘 확인
- [ ] 진단 페이지 budget min/max input 박힘 + 억 단위 표시 확인
- [ ] 진단 시작 → 결과 페이지 chip 표시 확인 (4 chip 모두)
- [ ] 결과 페이지 maxCommute chip 클릭 → input + 변경 버튼 + 재계산 확인
- [ ] 결과 페이지 budget chip 클릭 → 2 input + 변경 버튼 + 재계산 확인
- [ ] 가드 30+종 회귀 0 사수