### PR TITLE
feat(perf): NFR-PERF-PAGE-LOAD — REQ-NF-002 측정 셋업

### DIFF
--- a/docs/perf/baseline-2026-05.md
+++ b/docs/perf/baseline-2026-05.md
@@ -1,0 +1,133 @@
+---
+title: "Lighthouse baseline — 2026-05 (REQ-NF-002 측정 셋업 시점)"
+issue: "#126"
+task: "NFR-PERF-PAGE-LOAD"
+measurement_date: "(르르 Phase D 측정 시 갱신)"
+production_url: "(르르 Phase D 측정 시 확정 — memory `onday-design-project.vercel.app` vs `onday-prototype-claude-design.vercel.app` 정합 확인)"
+---
+
+# Lighthouse baseline — 2026-05
+
+## 1. Background
+
+**SRS REQ-NF-002 (v1.7 §4.2.1):** "일반 페이지 로딩 시간 — p95 ≤ 1,500ms (3G 모바일 환경 기준). 측정 방법: Lighthouse/WebPageTest + Vercel Speed Insights"
+
+**본 문서 영역:** Issue #126 NFR-PERF-PAGE-LOAD Phase D 측정 셋업 시점 baseline 기록. Speed Insights 셋업 + Lighthouse 1회 측정 결과.
+
+**Phase B 한계 §:** 본 baseline = lab 측정 1회. 실 p95 = Vercel Speed Insights Dashboard 1주 데이터 수집 후 확인 답습 (실 사용자 트래픽 의존).
+
+---
+
+## 2. 측정 방법
+
+### 2.1 Lighthouse (lab 측정)
+
+**도구:** Chrome DevTools Lighthouse 탭 (또는 `npx lighthouse <URL> --view`)
+
+**환경:**
+- 모바일 + 3G throttling (Slow 4G 또는 Fast 3G)
+- 시크릿 창 (확장 프로그램 영향 격리)
+- Performance + Best Practices + SEO + Accessibility 카테고리
+
+**대상 페이지 (일반 페이지 = REQ-NF-002 정합):**
+- `/` (또는 `/landing`) — 랜딩
+- `/login` — 인증 진입
+- `/diagnosis` — 진단 입력 폼
+
+> 동적 페이지 (`/diagnosis/result/[id]`, `/share/[uuid]`) = 측정 가능하나 본 baseline 영역 외 (REQ-NF-003 영역 = 공유 페이지 p95 ≤ 2,000ms 별도).
+
+### 2.2 Vercel Speed Insights (runtime 측정)
+
+**도구:** `@vercel/speed-insights` (본 PR 셋업)
+
+**측정 지표 (Google 2024-03 표준):**
+- **LCP** (Largest Contentful Paint) — 목표 ≤ 2.5s
+- **INP** (Interaction to Next Paint) — 목표 ≤ 200ms (★ 2024-03 FID Deprecated → INP 정직 정정)
+- **CLS** (Cumulative Layout Shift) — 목표 ≤ 0.1
+
+**확인 위치:** Vercel Dashboard → 프로젝트 → Speed Insights 탭 (배포 + 1주 트래픽 후 데이터 들어옴)
+
+---
+
+## 3. 측정 결과 (Phase D — 르르 측정 후 갱신)
+
+### 3.1 Lighthouse 점수 — 랜딩 (`/` 또는 `/landing`)
+
+| 카테고리 | 점수 | 비고 |
+|---|---:|---|
+| Performance | TBD | |
+| Accessibility | TBD | |
+| Best Practices | TBD | |
+| SEO | TBD | |
+
+**Core Web Vitals:**
+
+| 지표 | 측정값 | 목표 | 평가 |
+|---|---:|---:|---|
+| LCP | TBD ms | ≤ 2,500 ms | TBD |
+| INP | TBD ms | ≤ 200 ms | TBD |
+| CLS | TBD | ≤ 0.1 | TBD |
+
+**페이지 로딩 (REQ-NF-002 p95 ≤ 1,500ms):**
+
+| 시점 | 측정값 | 목표 | 평가 |
+|---|---:|---:|---|
+| FCP (First Contentful Paint) | TBD ms | — | TBD |
+| Speed Index | TBD ms | — | TBD |
+| TTI (Time to Interactive) | TBD ms | — | TBD |
+
+### 3.2 Lighthouse 점수 — 진단 입력 (`/diagnosis`)
+
+(동일 표 형태 — 르르 측정 후 갱신)
+
+### 3.3 Lighthouse 점수 — 로그인 (`/login`)
+
+(동일 표 형태 — 르르 측정 후 갱신)
+
+---
+
+## 4. 측정 결과 해석
+
+### 4.1 p95 ≤ 1,500ms 달성 여부
+
+(르르 측정 후 갱신 — 미달 시 별도 PERF-OPTIMIZE-* ISSUE 신설 답습)
+
+### 4.2 핫스팟 사전 영역 (Phase B 정적 점검 — 차후 최적화 후보)
+
+| 영역 | 현재 박힘 | 차후 최적화 ISSUE 후보 |
+|---|---|---|
+| `next/image` 사용 | ❌ 0건 (Phase B grep) | **PERF-OPTIMIZE-IMAGES** 후보 — `<img>` → `<Image>` 전환 = LCP 점수 영향 |
+| `loading="lazy"` / `priority` | ❌ 0건 | 같이 PERF-OPTIMIZE-IMAGES 영역 |
+| `public/` 자산 | 48K (작음) | 영향 X |
+| 동적 import / Code splitting | (Phase D 빌드 측정 후 확인) | 차후 영역 |
+
+★ 본 ISSUE = 측정 셋업만 = 위 영역 최적화 X. 측정 결과 미달 시 별도 ISSUE 답습.
+
+---
+
+## 5. Vercel Speed Insights 실 데이터 (1주 후 갱신)
+
+배포 후 1주 트래픽 수집 후 Vercel Dashboard Speed Insights 탭 데이터 박힘:
+
+| 페이지 | p75 LCP | p95 LCP | p75 INP | p95 INP | p75 CLS | p95 CLS | 페이지뷰 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `/` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| `/login` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| `/diagnosis` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+★ Phase B 한계 § 답습: 1인 MVP = 실 사용자 트래픽 제한 = 르르 본인/지인 데이터 위주 = 통계적 유의미성 한계.
+
+---
+
+## 6. 차후 작업 영역
+
+| 후속 ISSUE 후보 | 영역 | 트리거 |
+|---|---|---|
+| **PERF-LIGHTHOUSE-CI-AUTOMATION** | GitHub Actions + lighthouserc.json + PR 코멘트 자동화 | Issue #126 본문 AC-1/AC-4 분리 영역 (㊧ Mismatch 8번째) |
+| **PERF-OPTIMIZE-IMAGES** | `<img>` → `next/image` 전환 + lazy/priority | 본 baseline LCP 미달 시 |
+| **PERF-OPTIMIZE-FONTS** | Pretendard 폰트 preload + display=swap | 본 baseline FCP 미달 시 |
+| **MON-003 Mixpanel** | 페이지뷰/이벤트 분석 (analytics 영역) | CLAUDE.md §2 답습 = 본 ISSUE 영역 외 |
+
+---
+
+_본 문서 신설: 2026-05-28 (Issue #126 NFR-PERF-PAGE-LOAD 측정 셋업 시점). Phase D 측정 후 르르가 TBD 영역 갱신 박힘._

--- a/onday-app/package-lock.json
+++ b/onday-app/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.105.4",
         "@tanstack/react-query": "^5.100.6",
+        "@vercel/speed-insights": "^2.0.0",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.9.0",
         "class-variance-authority": "^0.7.1",
@@ -5212,6 +5213,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.6",

--- a/onday-app/package.json
+++ b/onday-app/package.json
@@ -23,6 +23,7 @@
     "@supabase/ssr": "^0.10.3",
     "@supabase/supabase-js": "^2.105.4",
     "@tanstack/react-query": "^5.100.6",
+    "@vercel/speed-insights": "^2.0.0",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.9.0",
     "class-variance-authority": "^0.7.1",

--- a/onday-app/src/app/layout.tsx
+++ b/onday-app/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 import { Toaster } from "@/components/layout/toaster";
 import { QueryProvider } from "@/providers/query-provider";
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body>
         <QueryProvider>{children}</QueryProvider>
         <Toaster />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/tasks/ISSUE_REGISTER_LOG.md
+++ b/tasks/ISSUE_REGISTER_LOG.md
@@ -922,3 +922,74 @@ MOCK_DATA_SOURCES (카카오 모빌리티 API / 국토교통부 / 경찰청) 는
 | 23 | **UI-007 v1.4 확장** | **#45** | **(신설 예정)** | **진행중** | **★ ★ ★ Phase A ~70% 사전 박힘 답습 + Q4 전제 오류 정직 인정 (인라인 복제 정정) + Issue 본문 AC-4 vs SSoT mismatch 정직 § + Q5 부착 layer 정상 상태 한정 (#125 EmptyState 충돌 회피) + Phase B 한계 § 12번째 누적 진화** |
 
 _본 § 신설: 2026-05-28 (Issue #45 UI-007 v1.4 확장 진입). ★ Phase B 한계 § 12번째 누적 = #114→#125→#52→#45 4단계 진화 답습 정수 정점._
+
+---
+
+## 24. NFR-PERF-PAGE-LOAD — REQ-NF-002 측정 셋업 (2026-05-28 신설)
+
+### 본 ISSUE 영역
+
+**Issue #126 [NFR-PERF-PAGE-LOAD]** = REQ-NF-002 "일반 페이지 로딩 p95 ≤ 1,500ms (3G 모바일)" 측정 도구 셋업. 성능 최적화 X (미달 시 별도 PERF-OPTIMIZE-* ISSUE 신설 답습).
+
+### Phase A 사전 박힘 점검 (0건 — 완전 신설 영역)
+
+| 영역 | 박힘 여부 | 본 작업 영향 |
+|---|---|---|
+| `@vercel/speed-insights` 패키지 | ❌ 0건 | 본 작업 = 설치 |
+| `SpeedInsights` 컴포넌트 박힘 | ❌ 0건 | 본 작업 = layout.tsx 배치 |
+| `@vercel/analytics` 패키지 | ❌ 0건 | 본 작업 영역 외 (MON-003 Mixpanel 영역) |
+| `tasks/NFR-PERF-PAGE-LOAD.md` 명세 | ❌ 0건 | 본 작업 = 신설 |
+| `docs/perf/` 폴더 | ❌ 0건 | 본 작업 = 신설 |
+| `next/image` 사용 | ❌ 0건 | ★ 차후 PERF-OPTIMIZE-IMAGES 후보 영역 (정직 인정) |
+| `loading="lazy"` / `priority` | ❌ 0건 | 같이 PERF-OPTIMIZE-IMAGES 영역 |
+
+### ★ ㊧ Mismatch 8번째 영역 진화 — Lighthouse CI 자동화 분리
+
+| 영역 | Issue #126 본문 AC | 본 ISSUE 영역 합의 |
+|---|---|---|
+| AC-1 | Lighthouse CI 활성 (GitHub Actions) | @vercel/speed-insights 설치 + layout.tsx 배치 |
+| AC-4 | PR 본문 Lighthouse 점수 자동 노출 | Core Web Vitals (LCP/INP/CLS) 측정 가능 |
+
+★ **정직 인정 + 분리 정합:**
+- Issue 본문 = Lighthouse CI GitHub Actions + lighthouserc.json + PR 코멘트 자동화 영역
+- 본 ISSUE = Speed Insights(runtime) 셋업 + Lighthouse 수동 baseline만
+- 분리 근거: Speed Insights(runtime) vs Lighthouse CI(lab) = 영역 분리 자연 + 1인 MVP 작업량 제한 + "한 ISSUE 한 본질" 답습
+- 차후 영역 = **PERF-LIGHTHOUSE-CI-AUTOMATION** 별도 ISSUE 신설 답습
+
+### ★ FID → INP 정직 정정 NEW (Google 2024-03 표준)
+
+- 르르 prompt AC-4 = "LCP/**FID**/CLS"
+- **★ FID 2024-03 Deprecated → INP (Interaction to Next Paint) 공식 대체** (Google 표준)
+- Vercel Speed Insights = INP 측정 (FID 측정 X)
+- 본 명세 AC-4 = LCP / **INP** / CLS 정정 박힘
+
+### ★ @vercel/analytics 제외 (CLAUDE.md §2 답습)
+
+- 르르 prompt = "(선택) @vercel/analytics도 함께"
+- CLAUDE.md §2 분석 도구 = **Mixpanel / Amplitude** 명시
+- analytics 영역 = MON-003(#127) 영역 = 본 ISSUE 영역 외 사수
+- 본 명세 = `@vercel/speed-insights` 단독 설치
+
+### Phase B 한계 § 13번째 누적 진화 (★ 측정 셋업 vs 실 데이터 수집 분리 영역 NEW)
+
+| 누적 | ISSUE | 본질 |
+|---|---|---|
+| 11번째 | #52 UI-009 | HTML5 min attribute clamp 진짜 본질 (시각 검증 정수) |
+| 12번째 | #45 UI-007 | 부착 layer + source pool mismatch + Issue 본문 vs SSoT mismatch |
+| **13번째** | **#126 NFR-PERF-PAGE-LOAD** | **★ 측정 셋업 vs 실 데이터 수집 분리 영역 NEW + 1주 데이터 의존 + 1인 MVP 실 사용자 트래픽 제한 + FID→INP 정직 정정 + ㊧ Mismatch 8번째 영역 (Lighthouse CI 분리) + 차후 PERF-OPTIMIZE-IMAGES 핫스팟 사전 발견 (next/image 0건)** |
+
+**본 ISSUE Phase B 한계 본질 NEW:**
+- 정적 grep = `SpeedInsights` 박힘 박힘 확인 만 가능
+- 실 p95 데이터 = Vercel Dashboard 1주 트래픽 후 = 본 ISSUE 완료 시점 측정 X
+- 1인 MVP = 실 사용자 트래픽 제한 = 통계적 유의미성 한계
+- Lighthouse baseline = lab 측정 1회 = 실 사용자 환경 미반영
+
+### 본 세션 누적 24건 § 박힘 표 (★ Phase B 한계 § 13번째 누적 정수 정점)
+
+| # | Task ID | Issue # | PR # | 상태 | 본질 (한 줄) |
+| --- | ---:| ---:| ---:| --- | --- |
+| 1~22 | (이전 § 누적) | — | — | — | (이전 § 표 참조) |
+| 23 | **UI-007 v1.4 확장** | **#45** | **#131 머지 완료** | **완료** | **Phase A ~70% 사전 박힘 + Q4 전제 오류 정정 + Issue 본문 AC-4 vs SSoT mismatch + Q5 부착 layer 정상 상태 한정 + Phase B 한계 § 12번째 누적** |
+| 24 | **NFR-PERF-PAGE-LOAD** | **#126** | **(신설 예정)** | **진행중** | **★ 측정 셋업 vs 실 데이터 수집 분리 영역 NEW + ㊧ Mismatch 8번째 (Lighthouse CI 분리) + FID→INP 정직 정정 + @vercel/analytics 제외 (CLAUDE.md §2 답습) + 차후 PERF-OPTIMIZE-IMAGES 핫스팟 사전 발견 + Phase B 한계 § 13번째 누적 정점** |
+
+_본 § 신설: 2026-05-28 (Issue #126 NFR-PERF-PAGE-LOAD 진입). ★ Phase B 한계 § 13번째 누적 = #114→#125→#52→#45→#126 5단계 진화 답습 정수 정점 + ㊧ Mismatch 8번째 영역 진화 NEW (Issue 본문 AC vs 본 ISSUE 영역 합의 mismatch — Lighthouse CI 분리 정직 §)._

--- a/tasks/NFR-PERF-PAGE-LOAD.md
+++ b/tasks/NFR-PERF-PAGE-LOAD.md
@@ -1,0 +1,216 @@
+---
+name: NFR Task
+title: "[NFR] NFR-PERF-PAGE-LOAD: 일반 페이지 로딩 p95 ≤ 1500ms 측정 셋업 (REQ-NF-002)"
+labels: ['nfr', 'priority:must', 'type:nfr', 'area:perf', 'epic:Measurement', 'wave:5', 'complexity:m']
+assignees: []
+---
+
+## 0. 🎯 본 ISSUE 영역 (2026-05-28 신설)
+
+**Issue #126 NFR-PERF-PAGE-LOAD** = REQ-NF-002 "일반 페이지 로딩 p95 ≤ 1,500ms (3G 모바일)" 측정 셋업.
+
+**범위:** 측정 도구 통합만. 성능 최적화 X (미달 시 별도 PERF-OPTIMIZE-* ISSUE 신설 답습).
+
+**삭제 영역 (정직 인정 박힘):**
+- ❌ ~~Lighthouse CI GitHub Actions 자동화~~ → **PERF-LIGHTHOUSE-CI-AUTOMATION 별도 ISSUE 분리** (㊧ Mismatch 8번째 영역 진화 정직 §)
+- ❌ ~~`@vercel/analytics` 동시 설치~~ → MON-003 Mixpanel 영역 (CLAUDE.md §2 답습)
+
+---
+
+## 1. 🎯 Summary
+
+- **기능명:** [NFR-PERF-PAGE-LOAD] Vercel Speed Insights 셋업 + Lighthouse baseline 측정 (REQ-NF-002)
+- **목적 (Why):**
+  - **비즈니스:** 3G 모바일 사용자 (3040 맞벌이 부부 페르소나) 경험 보호 = 페이지 로딩 p95 ≤ 1,500ms SLA 모니터링 셋업
+  - **사용자 가치:** 느린 페이지 = 이탈 = 진단 완료 KPI 미달. 측정 가능 상태 = 운영 의사결정 기반
+- **범위 (What):**
+  - ✅ 만드는 것: `@vercel/speed-insights` 설치 + `<SpeedInsights />` layout.tsx 배치 + Lighthouse 수동 baseline + `docs/perf/baseline-2026-05.md` 기록
+  - ❌ 만들지 않는 것: Lighthouse CI 자동화 (별도 ISSUE), 성능 최적화 (이미지/폰트/번들), @vercel/analytics
+- **복잡도:** M
+- **Wave:** 5 (Measurement 트랙)
+
+---
+
+## 2. 🔗 References (Spec & Context)
+
+### SRS 인용
+
+- **REQ-NF-002** (§4.2.1, v1.7): "일반 페이지 로딩 시간 — p95 ≤ 1,500ms (3G 모바일 환경 기준). 측정 방법: Lighthouse/WebPageTest + Vercel Speed Insights"
+
+### PRD 인용
+
+- PRD §5-1 비기능 요구사항 — 페이지 로딩 성능 SLA
+
+### TASK_LIST 매핑
+
+- `tasks/06_TASK_LIST_v1_4.md` Step 4-D (성능 측정 — v1.4 신설) NFR-PERF-PAGE-LOAD 행
+- v1.4 audit 정합 회복 (v1.3까지 REQ-NF-002 측정 task 0건)
+
+---
+
+## 3. 🛠️ Task Breakdown (실행 체크리스트)
+
+- [ ] **3.1** `@vercel/speed-insights` 설치
+  ```bash
+  cd onday-app && npm install @vercel/speed-insights
+  ```
+
+- [ ] **3.2** `app/layout.tsx`에 `<SpeedInsights />` 배치
+  ```tsx
+  import { SpeedInsights } from "@vercel/speed-insights/next";
+  // ...
+  <body>
+    <QueryProvider>{children}</QueryProvider>
+    <Toaster />
+    <SpeedInsights />
+  </body>
+  ```
+
+- [ ] **3.3** `npm run build` 통과 검증 (TypeScript + Next.js 빌드)
+
+- [ ] **3.4** Lighthouse 수동 baseline 측정 (르르 영역)
+  - Chrome DevTools Lighthouse 탭 또는 `npx lighthouse <URL> --view`
+  - 환경: 모바일 + 3G throttling + 시크릿 창
+  - 대상: `/` (또는 `/landing`), `/login`, `/diagnosis` 3개 페이지
+  - Production URL = 르르 확정 (memory `onday-design-project.vercel.app` vs `onday-prototype-claude-design.vercel.app` 정합 확인)
+
+- [ ] **3.5** `docs/perf/baseline-2026-05.md` 측정 결과 기록
+  - Performance / Accessibility / Best Practices / SEO 점수
+  - Core Web Vitals: LCP / **INP** / CLS (★ 2024-03 FID Deprecated → INP 정직 정정)
+  - FCP / Speed Index / TTI
+
+- [ ] **3.6** Vercel Dashboard Speed Insights 활성 확인
+  - 배포 후 (1주 트래픽 수집) Vercel Dashboard → 프로젝트 → Speed Insights 탭 데이터 들어오는지 확인
+
+- [ ] **3.7** Phase B 한계 § 명시 (시각 검증 + 1주 데이터 수집 한계)
+  - 측정 셋업 시점 = 실 p95 데이터 X
+  - 1인 MVP = 실 사용자 트래픽 제한 = 르르 본인/지인 데이터 위주
+
+---
+
+## 4. ✅ Acceptance Criteria (GWT 패턴, BDD)
+
+**AC-1 (도구 통합 — Speed Insights):**
+- **Given** Next.js App
+- **When** `@vercel/speed-insights` 통합 + `<SpeedInsights />` layout.tsx 배치
+- **Then** Production 배포 후 Vercel Dashboard Speed Insights 탭 활성 + p75/p95 LCP/INP/CLS 측정 데이터 1주 후 들어옴
+
+**AC-2 (도구 통합 — Lighthouse):**
+- **Given** Production URL 확정
+- **When** Chrome DevTools Lighthouse 측정 (모바일 + 3G throttling)
+- **Then** Performance/Accessibility/Best Practices/SEO 점수 + Core Web Vitals 측정 + `docs/perf/baseline-2026-05.md` 기록
+
+**AC-3 (목표 모니터링):**
+- **Given** AC-1 + AC-2 활성
+- **When** Vercel Speed Insights Dashboard 1주 후 확인
+- **Then** 주요 페이지 p95 페이지 로딩 시간 표시. 목표 1,500ms 대비 모니터링 가능
+
+**AC-4 (Core Web Vitals 측정):**
+- **Given** AC-1 활성
+- **When** Speed Insights 측정
+- **Then** **LCP / INP / CLS** 측정 가능 (★ 르르 prompt FID → INP 정직 정정, Google 2024-03 표준)
+
+**AC-N1 (영역 한정):**
+- **Given** 본 ISSUE = 측정 셋업
+- **When** Lighthouse baseline 미달 (p95 > 1,500ms 또는 CWV 미달)
+- **Then** **별도 PERF-OPTIMIZE-* ISSUE 신설** (예: PERF-OPTIMIZE-IMAGES, PERF-OPTIMIZE-FONTS). 본 ISSUE에서 최적화 작업 X
+
+**AC-N2 (Lighthouse CI 자동화 영역 한정):**
+- **Given** Issue #126 본문 AC-1/AC-4 = Lighthouse CI GitHub Actions + lighthouserc.json + PR 코멘트
+- **When** 본 ISSUE 작업 영역 판정
+- **Then** **별도 PERF-LIGHTHOUSE-CI-AUTOMATION ISSUE 신설 영역**. 본 ISSUE는 Speed Insights 셋업 + 수동 baseline만
+
+---
+
+## 5. ⚙️ Non-Functional Constraints (NFR 강제 인용)
+
+| NFR ID | SRS 본문 인용 | 검증 방법 |
+|---|---|---|
+| REQ-NF-002 | "일반 페이지 로딩 p95 ≤ 1,500ms (3G)" (§4.2.1) | Speed Insights Dashboard p95 + Lighthouse baseline |
+
+---
+
+## 6. 📦 Deliverables (산출물 명시)
+
+- `onday-app/package.json` + `package-lock.json` — `@vercel/speed-insights` dependency 추가
+- `onday-app/src/app/layout.tsx` — `<SpeedInsights />` 컴포넌트 배치
+- `docs/perf/baseline-2026-05.md` — Lighthouse baseline 기록 (SSoT 영역)
+- `tasks/NFR-PERF-PAGE-LOAD.md` — 본 명세 (신설)
+- `tasks/ISSUE_REGISTER_LOG.md` — #126 § +1 (Phase B 한계 § 13번째 누적)
+
+---
+
+## 7. 🔗 Dependencies (의존성)
+
+### 선행
+- **INFRA-001** ✅ (Next.js 15 + Vercel 배포)
+
+### 후행 (별도 ISSUE 영역)
+- **PERF-LIGHTHOUSE-CI-AUTOMATION** (신설 예정) — Issue #126 본문 AC-1/AC-4 영역
+- **PERF-OPTIMIZE-IMAGES** (신설 후보) — baseline 미달 시
+- **PERF-OPTIMIZE-FONTS** (신설 후보) — baseline 미달 시
+- **MON-003** (#127) — Mixpanel/Amplitude (analytics 영역, 본 ISSUE 영역 외)
+
+---
+
+## 8. 🧪 Test Plan (검증 절차)
+
+- **빌드 검증:** `npm run build` 통과 (TypeScript strict + Next.js 빌드)
+- **layout.tsx 박힘 검증:** `grep -n "SpeedInsights" src/app/layout.tsx` → 2건 (import + JSX)
+- **Production 배포 후 검증 (르르 영역):**
+  1. Vercel 자동 배포 완료 확인
+  2. Production URL 접속 → Network 탭에서 `_vercel/speed-insights/script.js` 로딩 확인
+  3. 1주 후 Vercel Dashboard Speed Insights 탭 데이터 확인
+- **Lighthouse 수동 측정 (르르 영역):**
+  1. Production URL Chrome DevTools Lighthouse 측정 (모바일 + 3G)
+  2. 결과를 `docs/perf/baseline-2026-05.md` TBD 영역에 갱신
+
+---
+
+## 9. 🚧 Phase B 한계 § (13번째 누적 진화)
+
+**누적 영역:**
+- 11번째 = #52 UI-009 = HTML5 min attribute clamp 진짜 본질 정점 (시각 검증 박힘 정수)
+- 12번째 = #45 UI-007 = 부착 layer 분기 + source pool mismatch + Issue 본문 vs SSoT mismatch
+- **13번째 = #126 NFR-PERF-PAGE-LOAD = 측정 셋업 vs 실 데이터 수집 분리 + 1주 데이터 의존 + 1인 MVP 실 사용자 트래픽 제한 + FID→INP 정직 정정 + ㊧ Mismatch 8번째 영역 (Lighthouse CI 분리)**
+
+**본 ISSUE Phase B 한계:**
+- 정적 검증 = `grep "SpeedInsights" layout.tsx` 박힘 확인 만 가능
+- 실 p95 데이터 = Vercel Dashboard Speed Insights 1주 트래픽 수집 후 = 본 ISSUE 완료 시점 측정 X
+- 1인 MVP = 실 사용자 트래픽 제한 = 통계적 유의미성 한계 답습
+- Lighthouse baseline = lab 측정 1회 = 실 사용자 환경 (네트워크/디바이스/배경 작업) 미반영
+
+---
+
+## 10. ⚠️ 정직 § (Issue 본문 vs 본 명세 mismatch)
+
+### 10.1 Lighthouse CI 자동화 영역 (㊧ Mismatch 8번째 영역 진화)
+
+| 영역 | Issue #126 본문 AC | 본 명세 (르르 grill 합의) |
+|---|---|---|
+| AC-1 | Lighthouse CI 활성 (GitHub Actions) | @vercel/speed-insights 설치 + layout.tsx 배치 |
+| AC-4 | PR 본문 Lighthouse 점수 자동 노출 | Core Web Vitals (LCP/INP/CLS) 측정 가능 |
+
+★ **정직 인정 박힘:**
+- Issue #126 본문 = Lighthouse CI 자동화 영역 박힘
+- 본 명세 = Speed Insights 셋업 + 수동 baseline 영역만
+- **차후 영역 = PERF-LIGHTHOUSE-CI-AUTOMATION 별도 ISSUE 신설** 답습
+- 분리 근거: Speed Insights(runtime) vs Lighthouse CI(lab) = 영역 분리 자연 + 1인 MVP 작업량 제한
+
+### 10.2 르르 prompt AC-4 FID → INP 정직 정정
+
+- 르르 prompt AC-4 = "Core Web Vitals 측정 가능 (LCP/**FID**/CLS)"
+- **★ FID 2024-03 Deprecated → INP 공식 대체** (Google 표준)
+- Vercel Speed Insights = INP 측정 (FID 측정 X)
+- 본 명세 AC-4 = LCP / **INP** / CLS 박힘 (정직 정정)
+
+### 10.3 르르 prompt @vercel/analytics 제외 (CLAUDE.md §2 답습)
+
+- 르르 prompt = "(선택) @vercel/analytics도 함께"
+- **★ CLAUDE.md §2 분석 도구 = Mixpanel / Amplitude** 명시
+- analytics(페이지뷰/이벤트) = MON-003 영역 = 본 ISSUE 영역 외
+- 본 명세 = `@vercel/speed-insights` 단독 설치
+
+---
+
+_본 명세 신설: 2026-05-28 (Issue #126 NFR-PERF-PAGE-LOAD 진입 시점). v1.4 audit Step 4-D (성능 측정 신설) 정합._


### PR DESCRIPTION
## Summary

Issue #126 NFR-PERF-PAGE-LOAD — REQ-NF-002 "일반 페이지 로딩 p95 ≤ 1,500ms (3G 모바일)" 측정 도구 셋업. Vercel Speed Insights 통합 + Lighthouse baseline 템플릿 + 명세 신설.

**본 작업 영역 (3파일 수정 + 3파일 신설):**

| 영역 | 변경 | 본질 |
|---|---|---|
| `onday-app/package.json` + `package-lock.json` | M | `@vercel/speed-insights ^2.0.0` 설치 |
| `onday-app/src/app/layout.tsx` | M | `<SpeedInsights />` import + JSX 배치 (Toaster 다음) |
| `tasks/NFR-PERF-PAGE-LOAD.md` | NEW | 본 ISSUE 명세 (§0~§10) |
| `docs/perf/baseline-2026-05.md` | NEW | Lighthouse baseline 템플릿 (르르 수동 측정 후 TBD 영역 갱신) |
| `tasks/ISSUE_REGISTER_LOG.md` | M | §24 신설 + 누적 24건 § 갱신 |

## ★ ★ Phase A 사전 박힘 0건 완전 신설 영역

| 영역 | 박힘 여부 |
|---|---|
| `@vercel/speed-insights` 패키지 | ❌ 0건 → 신설 |
| `SpeedInsights` 컴포넌트 박힘 | ❌ 0건 → 신설 |
| `tasks/NFR-PERF-PAGE-LOAD.md` 명세 | ❌ 0건 → 신설 |
| `docs/perf/` 폴더 | ❌ 0건 → 신설 |

## ★ ㊧ Mismatch 8번째 영역 진화 NEW — Lighthouse CI 자동화 분리

| 영역 | Issue #126 본문 AC | 본 ISSUE 영역 합의 |
|---|---|---|
| AC-1 | Lighthouse CI 활성 (GitHub Actions) | @vercel/speed-insights 설치 + layout.tsx 배치 |
| AC-4 | PR 본문 Lighthouse 점수 자동 노출 | Core Web Vitals (LCP/INP/CLS) 측정 가능 |

★ **정직 인정 + 분리 정합:**
- 분리 근거: Speed Insights(runtime) vs Lighthouse CI(lab) = 영역 분리 자연 + 1인 MVP 작업량 제한 + "한 ISSUE 한 본질" 답습
- 차후 영역 = **PERF-LIGHTHOUSE-CI-AUTOMATION** 별도 ISSUE 신설 답습

## ★ FID → INP 정직 정정 NEW (Google 2024-03 표준)

- 르르 prompt AC-4 = "LCP/**FID**/CLS" (구식 지표)
- **★ FID 2024-03 Deprecated → INP (Interaction to Next Paint) 공식 대체**
- Vercel Speed Insights = INP 측정 (FID 측정 X)
- 본 명세 AC-4 = LCP/**INP**/CLS 정정 박힘

## ★ @vercel/analytics 제외 (CLAUDE.md §2 답습)

- analytics 영역 = MON-003(#127) Mixpanel 영역 = 본 ISSUE 영역 외
- 본 PR = speed-insights 단독 설치

## ★ 차후 PERF-OPTIMIZE-IMAGES 핫스팟 사전 발견 (Phase B grep)

- `next/image` 0건 = 이미지 최적화 부재 = LCP 점수 영향 가능
- `loading="lazy"` / `priority` 0건
- baseline 미달 시 별도 PERF-OPTIMIZE-IMAGES ISSUE 신설 답습 (`docs/perf/baseline-2026-05.md §6` 사전 등록)

## Phase B 한계 § 13번째 누적 진화 정점 NEW

| 누적 | ISSUE | 본질 |
|---|---|---|
| 11번째 | #52 UI-009 | HTML5 min attribute clamp 진짜 본질 정점 |
| 12번째 | #45 UI-007 | 부착 layer + source pool mismatch 정직 인정 |
| **13번째** | **#126 NFR-PERF-PAGE-LOAD** | **★ 측정 셋업 vs 실 데이터 수집 분리 영역 NEW + 1주 데이터 의존 + 1인 MVP 실 사용자 트래픽 제한 + FID→INP 정직 정정 + ㊧ Mismatch 8번째 + 차후 PERF-OPTIMIZE-IMAGES 핫스팟 사전 발견** |

5단계 진화 답습: #114 → #125 → #52 → #45 → **#126 정점**

## Test plan

★ Preview URL 영역 (Vercel 자동 배포 후):
- [ ] Production 배포 후 Network 탭에서 `_vercel/speed-insights/script.js` 로딩 확인
- [ ] 1주 트래픽 후 Vercel Dashboard → 프로젝트 → Speed Insights 탭 데이터 들어오는지 확인 (★ 본 ISSUE 완료 시점 측정 X — Phase B 한계 § 답습)

르르 영역 Phase D 수동 측정:
- [ ] **Production URL 확정** (memory `onday-design-project.vercel.app` vs `onday-prototype-claude-design.vercel.app` 정합 확인 박힘)
- [ ] Chrome DevTools Lighthouse 측정 (모바일 + 3G throttling, 시크릿 창)
- [ ] 대상 페이지 3개: `/` (또는 `/landing`), `/login`, `/diagnosis`
- [ ] 측정 결과를 `docs/perf/baseline-2026-05.md` TBD 영역 갱신 (Performance/LCP/INP/CLS/FCP/Speed Index/TTI)

정적 검증 (Phase B/D 완료):
- [x] TypeScript strict (`npx tsc --noEmit`) — 통과
- [x] ESLint (`npx eslint src/app/layout.tsx`) — 통과
- [x] `npm run build` — 통과 (Middleware 32.5kB 회귀 0건 사수)
- [x] `grep -n "SpeedInsights" src/app/layout.tsx` — 2건 (import + JSX) ✅
- [x] grep 7행 검증 — 사전 박힘 0건 확인

★ ★ Phase B 한계 § 13번째 누적 정수: **측정 셋업 vs 실 데이터 수집 분리 영역 NEW**. 본 ISSUE = 셋업 완료. 실 p95 데이터는 1주 트래픽 후 Vercel Dashboard에서 르르 확인 답습.

★ 자동 머지 X, ISSUE Close X — 르르 직접 처리.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)