### PR TITLE
feat(monitoring): MON-001 — REQ-NF-011/012 v1.4 확장

### DIFF
--- a/onday-app/sentry.client.config.ts
+++ b/onday-app/sentry.client.config.ts
@@ -1,9 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { maskPIIBeforeSend } from "@/lib/helpers/sentry-pii-mask";
+
 // DSN 미설정 시 Sentry SDK 가 자동 비활성 (silent skip).
-// MON-001 에서 DSN 연결 후 실제 활성화.
+// MON-001 v1.4 (Issue #73) — PII 마스킹 이중 방어: sendDefaultPii: false + beforeSend 정규식.
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 1.0,
   debug: false,
+  sendDefaultPii: false,
+  beforeSend: maskPIIBeforeSend,
 });

--- a/onday-app/sentry.edge.config.ts
+++ b/onday-app/sentry.edge.config.ts
@@ -1,8 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { maskPIIBeforeSend } from "@/lib/helpers/sentry-pii-mask";
+
 // Edge runtime (middleware, edge route handlers) 용.
+// MON-001 v1.4 (Issue #73) — PII 마스킹 이중 방어: sendDefaultPii: false + beforeSend 정규식.
 Sentry.init({
   dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 1.0,
   debug: false,
+  sendDefaultPii: false,
+  beforeSend: maskPIIBeforeSend,
 });

--- a/onday-app/sentry.server.config.ts
+++ b/onday-app/sentry.server.config.ts
@@ -1,9 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 
-// SENTRY_DSN (server-only) 우선, NEXT_PUBLIC_SENTRY_DSN fallback.
-// 둘 다 미설정 시 silent skip.
+import { maskPIIBeforeSend } from "@/lib/helpers/sentry-pii-mask";
+
+// SENTRY_DSN (server-only) 우선, NEXT_PUBLIC_SENTRY_DSN fallback. 둘 다 미설정 시 silent skip.
+// MON-001 v1.4 (Issue #73) — PII 마스킹 이중 방어: sendDefaultPii: false + beforeSend 정규식.
 Sentry.init({
   dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 1.0,
   debug: false,
+  sendDefaultPii: false,
+  beforeSend: maskPIIBeforeSend,
 });

--- a/onday-app/src/app/api/health/route.ts
+++ b/onday-app/src/app/api/health/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+// MON-001 v1.4 (Issue #73) — REQ-NF-011 Uptime 핑 엔드포인트.
+// Sentry Uptime Monitor 5분 주기 핑 대상 (Sentry Dashboard 설정 = 르르 영역).
+// mock 모드 + Vercel 서버리스 = DB ping 환경 부적합 → 단순 200 OK 사수.
+// 차후 Production DB(PostgreSQL) 연결 시점 Prisma $queryRaw SELECT 1 확장 답습.
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    {
+      status: "ok",
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/onday-app/src/app/api/sentry-test/route.ts
+++ b/onday-app/src/app/api/sentry-test/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+
+// MON-001 v1.4 (Issue #73) — Sentry 캡처 검증용 라우트.
+// AC-3 "의도 에러 → Sentry Dashboard 캡처" 검증.
+// ★ env 가드: production 노출 시 Sentry 5K errors/mo 티어 소모 + 5xx 인위 발생 리스크 = 404 박힘.
+// dev/preview 한정 throw → Preview URL에서 르르 1회 호출 → Sentry Dashboard 캡처 확인.
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+
+  const error = new Error("MON-001 sentry-test intentional error");
+  Sentry.captureException(error, {
+    tags: { domain: "monitoring", task: "MON-001", purpose: "test" },
+  });
+  throw error;
+}

--- a/onday-app/src/lib/helpers/sentry-pii-mask.ts
+++ b/onday-app/src/lib/helpers/sentry-pii-mask.ts
@@ -1,0 +1,29 @@
+import type { ErrorEvent } from "@sentry/nextjs";
+
+// MON-001 v1.4 (Issue #73) — Sentry PII 마스킹 (REQ-NF-012-A AC).
+// 이중 방어 영역:
+//   (1) sendDefaultPii: false (Sentry.init 옵션) — ip/cookies/headers 자동 제거
+//   (2) beforeSend 정규식 마스킹 — event 본문의 이메일/전화 [REDACTED] 치환
+// client + server + edge 3종 config 동일 import (helper 분리 = 차후 주소 마스킹 확장 시 단일 영역 갱신).
+
+const EMAIL_REGEX = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+const PHONE_REGEX = /010-?\d{3,4}-?\d{4}/g;
+
+function maskPII(text: string): string {
+  return text.replace(EMAIL_REGEX, "[REDACTED]").replace(PHONE_REGEX, "[REDACTED]");
+}
+
+export function maskPIIBeforeSend(event: ErrorEvent): ErrorEvent {
+  if (event.message) {
+    event.message = maskPII(event.message);
+  }
+  if (event.exception?.values) {
+    for (const ex of event.exception.values) {
+      if (ex.value) ex.value = maskPII(ex.value);
+    }
+  }
+  if (event.request?.data && typeof event.request.data === "string") {
+    event.request.data = maskPII(event.request.data);
+  }
+  return event;
+}

--- a/tasks/ISSUE_REGISTER_LOG.md
+++ b/tasks/ISSUE_REGISTER_LOG.md
@@ -993,3 +993,98 @@ _본 § 신설: 2026-05-28 (Issue #45 UI-007 v1.4 확장 진입). ★ Phase B �
 | 24 | **NFR-PERF-PAGE-LOAD** | **#126** | **(신설 예정)** | **진행중** | **★ 측정 셋업 vs 실 데이터 수집 분리 영역 NEW + ㊧ Mismatch 8번째 (Lighthouse CI 분리) + FID→INP 정직 정정 + @vercel/analytics 제외 (CLAUDE.md §2 답습) + 차후 PERF-OPTIMIZE-IMAGES 핫스팟 사전 발견 + Phase B 한계 § 13번째 누적 정점** |
 
 _본 § 신설: 2026-05-28 (Issue #126 NFR-PERF-PAGE-LOAD 진입). ★ Phase B 한계 § 13번째 누적 = #114→#125→#52→#45→#126 5단계 진화 답습 정수 정점 + ㊧ Mismatch 8번째 영역 진화 NEW (Issue 본문 AC vs 본 ISSUE 영역 합의 mismatch — Lighthouse CI 분리 정직 §)._
+
+---
+
+## 25. MON-001 v1.4 확장 — REQ-NF-011 Uptime + REQ-NF-012 5xx 흡수 (2026-05-28 신설)
+
+### 본 ISSUE 영역
+
+**Issue #73 [MON-001]** = Sentry 기본 통합 (v1.3) + v1.4 확장 (REQ-NF-011 Uptime + REQ-NF-012 5xx 흡수). v1.4 audit 결정 = 별도 ISSUE 신설 X, MON-001로 흡수.
+
+### ★ ★ ★ Phase A 사전 박힘 ~85% 정수 정점 (UI-007 70% / #126 0% 초과 정점)
+
+| 영역 | 박힘 위치 | 본 작업 영향 |
+|---|---|---|
+| `@sentry/nextjs ^10.53.1` | `onday-app/package.json` | ✅ 사수 |
+| Sentry config 3종 | `sentry.client.config.ts` + `server.config.ts` + `edge.config.ts` (Sentry.init + DSN env + tracesSampleRate 1.0) | ✅ 사수 + PII 마스킹 추가 |
+| withSentryConfig (silent skip 가드) | `next.config.ts` | ✅ 사수 |
+| `Sentry.captureException` 호출처 4건 | `lib/helpers/sentry-error.ts` + `lib/diagnosis/geocoding.ts` + `lib/diagnosis/use-intersection.ts` + `lib/types/errors/index.ts` | ✅ 사수 |
+| `.env.example` SENTRY 영역 | `NEXT_PUBLIC_SENTRY_DSN` + `SENTRY_AUTH_TOKEN` | ✅ 사수 |
+| **`/api/health` 엔드포인트** | ❌ 0건 | **본 작업 영역 1** |
+| **`/api/sentry-test` 엔드포인트** | ❌ 0건 | **본 작업 영역 2** |
+| **`beforeSend` / `sendDefaultPii`** | ❌ 0건 | **본 작업 영역 3 — config 3종 동일 적용** |
+
+★ **본 작업 영역 = 5파일 (2 신설 + 3 수정)**. 사전 박힘 ~85% 답습 정수 정점.
+
+### ★ ㊧ Mismatch 9번째 영역 진화 NEW — DB ping mismatch
+
+| 영역 | 응답 본질 |
+|---|---|
+| Issue #73 본문 AC-NF-011-A (SSoT) | 단순 `{ status: "ok", timestamp }` |
+| 르르 prompt AC-6 | "200 OK + DB ping" (Prisma) |
+| 현 코드 상태 | mock 모드 + Vercel 서버리스 = SQLite 쓰기 X = DB ping 환경 부적합 |
+
+★ **르르 prompt AC-6 vs SSoT mismatch 정직 인정 + SSoT 사수:**
+- 르르 prompt = DB ping = mock 모드 부적합 (OnDay 실제 제약 미고려 경솔)
+- SSoT(Issue 본문) = 단순 응답 = mock + 서버리스 정합
+- 차후 영역 = Production DB(PostgreSQL) 연결 시점(Step 13+) DB ping 확장 답습
+- 누적: ㊧ Mismatch 영역 = 1(#108) → 2(#110) → 3(#114) → 4(#125) → 5(#52) → 6(UI-009) → 7(#45 Issue 본문 AC-4) → 8(#126 Lighthouse CI 분리) → **9(#73 DB ping mismatch)**
+
+### ★ 르르 prompt env 가드 누락 경솔 정정 정직 §
+
+- 르르 prompt = "/api/sentry-test 신설 (의도 throw)" — 가드 X 영역 박힘
+- ★ Production 노출 시 Sentry 5K errors/mo 티어 소모 + 5xx 인위 발생 리스크
+- **정정 = `process.env.NODE_ENV === 'production'` 시 404 가드 추가**
+- dev/preview 한정 throw = Preview URL에서 르르 1회 검증
+
+### ★ AC 자동 정합 정수 답습 NEW (5xx 자동 캡처)
+
+- AC-4 "Server Action + API Route 5xx 자동 캡처" = `withSentryConfig` 사전 박힘 = **추가 코드 0건**
+- 사전 박힘 captureException 4곳 사수
+- 명세/LOG 명시 = 미래 작업자 "5xx 캡처 코드 어디?" 찾을 때 = "자동 동작 사수" 명시로 해소
+- AC 자동 정합 정수 영역 = #52 UI-009 (Server Action 부재) → **#73 (withSentryConfig 자동 동작) 답습 진화**
+
+### ★ Sentry PII 마스킹 이중 방어 영역 (Sentry 공식 권장)
+
+- (1) `sendDefaultPii: false` = ip/cookies/headers/sensitive headers 자동 제거 (Sentry SDK 옵션)
+- (2) `beforeSend` 정규식 마스킹 = 이메일(`\w+@\w+\.\w+`) / 전화(`010-\d{4}-\d{4}`) `[REDACTED]` 치환
+- client + server + edge 3곳 동일 적용 = PII 노출 영역 격리 = 외부 서비스 PII 전송 0건 사수
+- 차후 영역 = 주소 정보 마스킹 확장 (출퇴근 주소 = 민감) — 별도 ISSUE 후보
+
+### ★ 르르 영역 정직 § (클로드코드 영역 X)
+
+| 영역 | 르르 영역 작업 |
+|---|---|
+| `NEXT_PUBLIC_SENTRY_DSN` + `SENTRY_AUTH_TOKEN` | `.env.local` 등록 + Vercel Dashboard 환경변수 등록 (Production + Preview + Development) |
+| Sentry Uptime Monitor 5분 핑 | Sentry Dashboard 영역 설정 (코드 영역 X) |
+| AC-3 의도 에러 검증 | Preview URL → `/api/sentry-test` 1회 호출 → Sentry Dashboard 캡처 확인 |
+| 5xx 비율 1주 데이터 수집 | Sentry Dashboard 1주 트래픽 후 확인 |
+
+### Phase B 한계 § 14번째 누적 진화 정수 정점 NEW
+
+| 누적 | ISSUE | 본질 |
+|---|---|---|
+| 11번째 | #52 UI-009 | HTML5 min attribute clamp 진짜 본질 (시각 검증 정수) |
+| 12번째 | #45 UI-007 | 부착 layer + source pool mismatch |
+| 13번째 | #126 NFR-PERF-PAGE-LOAD | 측정 셋업 vs 실 데이터 수집 분리 + Lighthouse cold/warm 편차 정수 |
+| **14번째** | **#73 MON-001 v1.4** | **★ ★ 사전 박힘 ~85% 정수 정점 + Sentry 무료 티어 5K 제한 + Uptime 실 데이터 수집 차후 + 외부 서비스 환경변수 의존 (DSN 등록 = 르르 영역) + ㊧ Mismatch 9번째 영역 진화 NEW + env 가드 경솔 정정 + AC 자동 정합 정수 답습 (5xx)** |
+
+**6단계 진화 답습:** #114 → #125 → #52 → #45 → #126 → **#73 정점**
+
+**본 ISSUE Phase B 한계 본질 NEW:**
+- 정적 grep = config 3종 `beforeSend` 박힘 확인 + `/api/health` `route.ts` 박힘 확인만 가능
+- 실 5xx 비율 = Sentry Dashboard 1주 트래픽 후 박힘 = 본 ISSUE 완료 시점 측정 X
+- Uptime 핑 5분 주기 활성 = Sentry Dashboard 설정 = 르르 영역
+- ★ DSN 환경변수 등록 = `.env.local` + Vercel = 르르 영역 = 클로드코드 영역 X
+- ★ Sentry 무료 티어 5K errors/mo 제한 = 트래픽 증가 시 별도 plan 영역 차후
+
+### 본 세션 누적 25건 § 박힘 표 (★ Phase B 한계 § 14번째 누적 정수 정점)
+
+| # | Task ID | Issue # | PR # | 상태 | 본질 (한 줄) |
+| --- | ---:| ---:| ---:| --- | --- |
+| 1~23 | (이전 § 누적) | — | — | — | (이전 § 표 참조) |
+| 24 | NFR-PERF-PAGE-LOAD | #126 | #132 (Draft) | 진행중 | 측정 셋업 vs 실 데이터 분리 + Lighthouse cold/warm 편차 + ㊧ Mismatch 8번째 |
+| 25 | **MON-001 v1.4 확장** | **#73** | **(신설 예정)** | **진행중** | **★ ★ ★ Phase A 사전 박힘 ~85% 정수 정점 (UI-007 70% / #126 0% 초과 정점) + ㊧ Mismatch 9번째 (DB ping) + env 가드 경솔 정정 + AC 자동 정합 정수 답습 (5xx withSentryConfig 자동 동작) + Sentry PII 마스킹 이중 방어 + 르르 영역 정직 § (DSN 등록 + Sentry Uptime 설정) + Phase B 한계 § 14번째 누적 정점** |
+
+_본 § 신설: 2026-05-28 (Issue #73 MON-001 v1.4 확장 진입). ★ Phase B 한계 § 14번째 누적 = #114→#125→#52→#45→#126→#73 6단계 진화 답습 정수 정점 + ㊧ Mismatch 9번째 영역 진화 NEW (DB ping mismatch) + ★ ★ ★ Phase A 사전 박힘 ~85% 정수 정점 (UI-007 70% / #126 0% 초과 정점)._

--- a/tasks/MON-001.md
+++ b/tasks/MON-001.md
@@ -31,6 +31,84 @@ assignees: []
 
 ---
 
+## 0.5 ⚠️ Phase A/B 점검 결과 + 정직 § (2026-05-28 신설)
+
+### 사전 박힘 영역 ~85% 정수 정점 (★ UI-007 70% / #126 0% 초과)
+
+| 영역 | 박힘 위치 | 본 작업 영향 |
+|---|---|---|
+| `@sentry/nextjs ^10.53.1` | `onday-app/package.json` | ✅ 사수 |
+| Sentry config 3종 | `sentry.client.config.ts` + `server.config.ts` + `edge.config.ts` (Sentry.init + DSN env + tracesSampleRate 1.0 + debug false) | ✅ 사수 + PII 마스킹 영역 추가 |
+| withSentryConfig (silent skip 가드) | `next.config.ts` (SENTRY_DSN 미설정 시 wrapper skip) | ✅ 사수 |
+| `Sentry.captureException` 호출처 4건 | `lib/helpers/sentry-error.ts` + `lib/diagnosis/geocoding.ts` + `lib/diagnosis/use-intersection.ts` + `lib/types/errors/index.ts` | ✅ 사수 |
+| `.env.example` | `NEXT_PUBLIC_SENTRY_DSN` + `SENTRY_AUTH_TOKEN` 영역 박힘 | ✅ 사수 |
+| `/api/health` 엔드포인트 | ❌ 0건 | **본 작업 영역 1** |
+| `/api/sentry-test` 엔드포인트 | ❌ 0건 | **본 작업 영역 2** |
+| `beforeSend` / `sendDefaultPii` (PII 마스킹) | ❌ 0건 (Sentry.init 기본 옵션만 박힘) | **본 작업 영역 3** |
+
+★ **본 작업 영역 = 5파일** (2 신설 + 3 수정). 사전 박힘 ~85% 답습 정수 정점.
+
+### Q1 `/api/health` 응답 영역 (Issue 본문 SSoT 사수)
+
+| 영역 | 응답 본질 |
+|---|---|
+| Issue #73 본문 AC-NF-011-A (SSoT) | `GET → 200 + { status: "ok", timestamp }` (단순) |
+| 르르 prompt AC-6 | "200 OK + DB ping" (Prisma) — ★ mismatch |
+| 현 코드 상태 | mock 모드 + 서버리스 = DB ping 환경 부적합 (SQLite 쓰기 X) |
+
+★ **르르 prompt AC-6 vs SSoT mismatch 정직 § (㊧ Mismatch 9번째 영역 진화 NEW):**
+- 르르 prompt = DB ping 포함 (Prisma) = mock 모드 부적합 (SQLite + 서버리스 제약)
+- SSoT(Issue 본문) = 단순 `{ status: "ok", timestamp }`
+- ★ SSoT 우선순위 답습 사수 = 단순 응답 박힘
+- 차후 영역 = Production DB(PostgreSQL) 연결 시점(Step 13+) DB ping 확장 답습
+
+### Q2 PII 마스킹 영역 (Sentry 공식 권장 이중 방어)
+
+- **(1) `sendDefaultPii: false`** — ip/cookies/headers/sensitive headers 자동 제거 (Sentry SDK 옵션)
+- **(2) `beforeSend` 정규식 마스킹** — event 본문의 이메일(`\w+@\w+\.\w+`) / 전화(`010-\d{4}-\d{4}`) `[REDACTED]` 치환
+- **client + server + edge 3곳 동일 적용** (PII 노출 영역 격리 = 외부 서비스 PII 전송 0건 사수)
+- 차후 영역 = 주소 정보 마스킹 확장 (출퇴근 주소 = 민감 정보) — 별도 ISSUE 후보
+
+### Q3 `/api/sentry-test` env 가드 정직 §
+
+- 르르 prompt = "/api/sentry-test 신설 (의도 throw)" — ★ 가드 X 영역 박힘
+- ★ **르르 prompt 가드 누락 경솔 정직 인정** = production 노출 시 Sentry 5K errors/mo 티어 소모 리스크
+- **정정 = env 가드 추가** (`process.env.NODE_ENV === 'production'` 시 404 박힘)
+- dev/preview 한정 throw + Sentry.captureException = Preview URL에서 르르 1회 호출 → Sentry Dashboard 캡처 검증
+
+### Q4 5xx 자동 캡처 = AC 자동 정합 정수 (UI-009 답습)
+
+- AC-4 "Server Action + API Route 5xx 자동 캡처" = `withSentryConfig` 사전 박힘으로 **자동 동작 충족**
+- 추가 코드 0건. 사전 박힘 captureException 4곳 사수
+- ★ **명세/LOG 명시 박힘** = 미래 작업자가 "5xx 캡처 코드 어디?" 찾을 때 = "자동 동작 사수" 명시로 해소
+- = AC 자동 정합 정수 답습 (#52 UI-009 Server Action 부재 자동 정합 답습)
+
+### Q5 르르 영역 정직 § (클로드코드 영역 X)
+
+- `NEXT_PUBLIC_SENTRY_DSN` + `SENTRY_AUTH_TOKEN` `.env.local` 등록
+- Vercel Dashboard 환경변수 등록 (Production + Preview + Development)
+- Sentry Uptime Monitor 5분 주기 핑 설정 (Sentry Dashboard 영역)
+- Preview URL → `/api/sentry-test` 1회 호출 → Sentry Dashboard 캡처 검증
+
+---
+
+## 0.6 ⚠️ Phase B 한계 § (14번째 누적 — 2026-05-28 신설)
+
+**누적 영역:**
+- 11번째 = #52 UI-009 = HTML5 min attribute clamp 진짜 본질 정점
+- 12번째 = #45 UI-007 = 부착 layer + source pool mismatch + Issue 본문 vs SSoT mismatch
+- 13번째 = #126 NFR-PERF-PAGE-LOAD = 측정 셋업 vs 실 데이터 수집 분리 영역 + Lighthouse cold/warm 편차 정수 NEW
+- **14번째 = #73 MON-001 v1.4 확장 = ★ ★ 사전 박힘 ~85% 정수 정점 + Sentry 무료 티어 5K 제한 + Uptime 실 데이터 수집 차후 + 외부 서비스 환경변수 의존 (DSN 등록 = 르르 영역) + ㊧ Mismatch 9번째 영역 진화 (DB ping mismatch) + env 가드 경솔 정정 + AC 자동 정합 정수 답습 (5xx)**
+
+**본 ISSUE Phase B 한계:**
+- 정적 grep = config 3종 `beforeSend` 박힘 확인 + `/api/health` `route.ts` 박힘 확인만 가능
+- 실 5xx 비율 데이터 = Sentry Dashboard 1주 트래픽 후 박힘 = 본 ISSUE 완료 시점 측정 X
+- Uptime 핑 5분 주기 활성 = Sentry Dashboard 설정 영역 = 르르 영역
+- ★ DSN 환경변수 등록 = `.env.local` + Vercel = 르르 영역 = 클로드코드 영역 X
+- ★ Sentry 무료 티어 5K errors/mo 제한 = 트래픽 증가 시 별도 plan 영역 차후
+
+---
+
 ## 1. 🎯 Summary
 
 - **기능명:** [MON-001] Sentry 기본 통합 — 에러 추적 + Performance 모니터링 + 기본 알림 설정


### PR DESCRIPTION
## Summary

Issue #73 MON-001 v1.4 확장 — Sentry 기본 통합(v1.3) + REQ-NF-011 Uptime + REQ-NF-012 5xx 흡수. v1.4 audit 결정 = 별도 ISSUE 신설 X, MON-001로 흡수.

**본 작업 영역 (6 파일 — 3 신설 + 3 수정 + 2 명세):**

| 영역 | 변경 | 본질 |
|---|---|---|
| `onday-app/src/app/api/health/route.ts` | NEW | `{ status: "ok", timestamp }` 200 응답 (Uptime 핑) |
| `onday-app/src/app/api/sentry-test/route.ts` | NEW | Sentry 캡처 검증 + ★ env 가드 (production 404) |
| `onday-app/src/lib/helpers/sentry-pii-mask.ts` | NEW | PII 마스킹 helper (이메일/전화 정규식) |
| `onday-app/sentry.client.config.ts` | M | `sendDefaultPii: false` + `beforeSend` 추가 |
| `onday-app/sentry.server.config.ts` | M | 동일 |
| `onday-app/sentry.edge.config.ts` | M | 동일 |
| `tasks/MON-001.md` | M | §0.5 + §0.6 신설 |
| `tasks/ISSUE_REGISTER_LOG.md` | M | §25 신설 |

## ★ ★ ★ Phase A 사전 박힘 ~85% 정수 정점 (UI-007 70% / #126 0% 초과 정점)

| 영역 | 사전 박힘 |
|---|---|
| `@sentry/nextjs ^10.53.1` | ✅ 사전 설치 |
| Sentry config 3종 (client/server/edge) | ✅ Sentry.init + DSN env + tracesSampleRate |
| `next.config.ts` withSentryConfig (silent skip 가드) | ✅ 박힘 |
| `Sentry.captureException` 호출처 4건 | ✅ 박힘 (geocoding/use-intersection/sentry-error helper/types/errors) |
| `.env.example` NEXT_PUBLIC_SENTRY_DSN + SENTRY_AUTH_TOKEN | ✅ 박힘 |

본 작업 영역 = 6파일 (3 신설 + 3 수정). 누적 진화: UI-007 70% → #126 0% → **#73 85% 정점**.

## ★ ㊧ Mismatch 9번째 영역 진화 NEW — DB ping mismatch

| 영역 | 응답 본질 |
|---|---|
| Issue #73 본문 AC-NF-011-A (SSoT) | 단순 `{ status: "ok", timestamp }` |
| 르르 prompt AC-6 | "200 OK + DB ping" (Prisma) |
| 현 코드 상태 | mock 모드 + 서버리스 = SQLite 쓰기 X = DB ping 환경 부적합 |

★ **SSoT 사수 + 르르 prompt 정직 인정:**
- 르르 prompt DB ping = OnDay 실제 제약(mock + SQLite + 서버리스) 미고려 경솔
- SSoT = 단순 응답 = 정합
- 차후 영역 = Production DB(PostgreSQL) 연결 시점 DB ping 확장 답습
- 누적: 1(#108)→2(#110)→3(#114)→4(#125)→5(#52)→6(UI-009)→7(#45)→8(#126)→**9(#73 DB ping)**

## ★ 르르 prompt env 가드 누락 경솔 정정 정직 §

- 르르 prompt = "/api/sentry-test 신설" — 가드 X 영역 박힘
- ★ Production 노출 시 Sentry 5K errors/mo 티어 소모 + 5xx 인위 발생 리스크
- **정정 = `process.env.NODE_ENV === 'production'` 시 404 박힘** + dev/preview 한정 throw

## ★ AC 자동 정합 정수 답습 NEW (5xx 자동 캡처)

- AC-4 "Server Action + API Route 5xx 자동 캡처" = `withSentryConfig` 사전 박힘 = **추가 코드 0건**
- 사전 박힘 captureException 4곳 사수
- AC 자동 정합 정수 영역: #52 UI-009 (Server Action 부재) → **#73 (withSentryConfig 자동 동작)** 진화

## ★ Sentry PII 마스킹 이중 방어 (Sentry 공식 권장)

- (1) `sendDefaultPii: false` = ip/cookies/headers 자동 제거 (Sentry SDK 옵션)
- (2) `beforeSend` 정규식 = 이메일(`[\w.+-]+@[\w-]+\.[\w.-]+`) / 전화(`010-?\d{3,4}-?\d{4}`) `[REDACTED]` 치환
- client + server + edge 3곳 동일 적용 = 외부 서비스 PII 전송 0건 사수
- ★ helper 분리 (`sentry-pii-mask.ts`) = CLAUDE.md "같은 코드 2번 이상 → 추출" 답습 = 차후 주소 마스킹 확장 시 단일 영역 갱신

## Phase B 한계 § 14번째 누적 진화 정수 정점 NEW

| 누적 | ISSUE | 본질 |
|---|---|---|
| 11번째 | #52 UI-009 | HTML5 min attribute clamp 진짜 본질 |
| 12번째 | #45 UI-007 | 부착 layer + source pool mismatch |
| 13번째 | #126 NFR-PERF-PAGE-LOAD | 측정 셋업 vs 실 데이터 분리 + Lighthouse cold/warm 편차 |
| **14번째** | **#73 MON-001 v1.4** | **★ ★ 사전 박힘 ~85% 정수 정점 + Sentry 무료 티어 5K 제한 + Uptime 실 데이터 차후 + 외부 서비스 환경변수 의존 (DSN = 르르 영역) + ㊧ Mismatch 9번째 + env 가드 경솔 정정 + AC 자동 정합 정수 답습 (5xx)** |

**6단계 진화 답습:** #114 → #125 → #52 → #45 → #126 → **#73 정점**

## Test plan

★ 정적 검증 (Phase D 완료):
- [x] TypeScript strict (`npx tsc --noEmit`) — 통과
- [x] ESLint 6파일 — 통과
- [x] `npm run build` — 통과 (Middleware 32.5kB 회귀 0건 사수)
- [x] `/api/health` + `/api/sentry-test` build output 박힘 (ƒ Dynamic)
- [x] `grep "beforeSend"` config 3종 — 3건 박힘 ✅
- [x] `grep "sendDefaultPii: false"` config 3종 — 3건 박힘 ✅

★ ★ 르르 영역 검증 (클로드코드 영역 X — Phase B 한계 §):

**1. 환경변수 등록 (필수):**
- [ ] `.env.local` 파일에 `NEXT_PUBLIC_SENTRY_DSN=<발급받은 DSN>` 박힘
- [ ] `.env.local` 파일에 `SENTRY_AUTH_TOKEN=<발급받은 token>` 박힘 (source map upload용)
- [ ] Vercel Dashboard → Settings → Environment Variables 등록 (Production + Preview + Development 3 환경)

**2. Sentry Dashboard 설정 (필수):**
- [ ] Sentry Uptime Monitor 5분 주기 핑 활성 (`/api/health` URL 등록)
- [ ] PII 마스킹 적용 확인 (Settings → Security & Privacy → Data Scrubbing)

**3. AC-3 의도 에러 검증 (필수):**
- [ ] Preview URL → `/api/sentry-test` GET 호출 (NODE_ENV=preview/development 한정)
- [ ] Sentry Dashboard → Issues 탭에서 "MON-001 sentry-test intentional error" 캡처 확인
- [ ] tags: `domain: monitoring, task: MON-001, purpose: test` 박힘 확인

**4. AC-NF-012-A PII 마스킹 검증:**
- [ ] 의도 에러 메시지에 이메일 포함시켜 throw → Dashboard에서 `[REDACTED]` 치환 확인

**5. 1주 후 데이터 수집:**
- [ ] Sentry Dashboard 5xx 비율 위젯 활성
- [ ] Uptime Monitor 5분 핑 결과 확인 (다운타임 0 사수)

★ ★ Phase B 한계 § 14번째 누적 정수: **사전 박힘 ~85% 정수 정점 + 외부 서비스 환경변수 의존**. 본 ISSUE = 셋업 완료. 실 5xx 비율 + Uptime 데이터는 르르의 DSN 등록 + Sentry Dashboard 설정 + 1주 트래픽 후 박힘.

★ 자동 머지 X, ISSUE Close X — 르르 직접 처리.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)