### PR TITLE
feat(diagnosis): #27+#30+#33 W2 — 대중교통 실 통근시간 (ODsay transit)

### DIFF
--- a/onday-app/.env.example
+++ b/onday-app/.env.example
@@ -15,6 +15,12 @@ KAKAO_MOBILITY_API_KEY=
 # CMD-DIAG-001: 브라우저 직접 호출 (Vercel 10초 timeout 우회) — Kakao Developers Console 도메인 제한 필수
 NEXT_PUBLIC_KAKAO_REST_API_KEY=YOUR_KAKAO_REST_API_KEY_HERE
 
+# === ODsay 대중교통 (W2 — REAL-API-W2-ODSAY-TRANSIT) ===
+# 통근시간 "대중교통" 데이터 소스 (카카오 모빌리티는 자동차 전용 → 자차 후속).
+# ★ Server key (Web key 아님) — 서버 /api/commute 에서만 사용 (브라우저 직접=CORS 차단).
+# ★ ODsay Server = 공인 IP 화이트리스트 강제: 로컬=내 공인 IP 등록 / Vercel=고정 IP(유료) flip 시.
+ODSAY_API_KEY=
+
 # AI
 AI_PROVIDER=google
 GOOGLE_GENERATIVE_AI_API_KEY=

--- a/onday-app/src/app/api/commute/route.ts
+++ b/onday-app/src/app/api/commute/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { OdsayTransitClient } from "@/lib/external/odsay-transit";
+
+// ★ B2 얇은 프록시 — 클라가 동네별로 Promise.all 로 호출. 함수당 ODsay 1회라
+//   Vercel 10초 timeout 무관 (REQ-FUNC-003). ODsay Server key 는 서버에서만 사용.
+// GET /api/commute?olat=&olng=&dlat=&dlng=  → { commute: CommuteInfo }
+const ODSAY_API_KEY = process.env.ODSAY_API_KEY ?? "";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const olat = Number(searchParams.get("olat"));
+  const olng = Number(searchParams.get("olng"));
+  const dlat = Number(searchParams.get("dlat"));
+  const dlng = Number(searchParams.get("dlng"));
+
+  if ([olat, olng, dlat, dlng].some((n) => Number.isNaN(n))) {
+    return NextResponse.json({ error: "좌표가 올바르지 않습니다" }, { status: 400 });
+  }
+  if (!ODSAY_API_KEY) {
+    return NextResponse.json({ error: "ODSAY_API_KEY 미설정" }, { status: 503 });
+  }
+
+  try {
+    const client = new OdsayTransitClient({ apiKey: ODSAY_API_KEY });
+    const commute = await client.getTransitCommute(
+      { lat: olat, lng: olng },
+      { lat: dlat, lng: dlng },
+    );
+    return NextResponse.json({ commute });
+  } catch (error) {
+    // 경로 없음/ODsay 에러 → 클라가 해당 동네를 후보에서 제외하도록 404.
+    console.error("[API] GET /api/commute error:", error);
+    return NextResponse.json({ error: "대중교통 경로를 찾을 수 없습니다" }, { status: 404 });
+  }
+}

--- a/onday-app/src/app/api/diagnosis/route.ts
+++ b/onday-app/src/app/api/diagnosis/route.ts
@@ -58,8 +58,38 @@ export async function POST(request: Request) {
       });
     }
 
-    // Production: TODO — Kakao Mobility API + AI scoring
-    return NextResponse.json({ error: "Production mode not implemented" }, { status: 501 });
+    // Production (B2): 클라가 ODsay 로 계산한 candidates 를 받아 저장만 한다
+    //   (외부 API 반복 호출은 클라 /api/commute Promise.all — Vercel 10초 timeout 회피).
+    const candidates = body.candidates;
+    if (!Array.isArray(candidates)) {
+      return NextResponse.json(
+        { error: "candidates 가 필요합니다 (production)" },
+        { status: 400 },
+      );
+    }
+
+    const userId = await getEffectiveUserId();
+    const diagnosis = await prisma.diagnosis.create({
+      data: {
+        userId,
+        addressA: input.addressA,
+        addressB: input.addressB ?? null,
+        filters: JSON.stringify(input.filters),
+        candidates: JSON.stringify(candidates),
+        mode: input.mode,
+        deadlineMode: !!input.deadlineDate,
+        deadline: input.deadlineDate ? new Date(input.deadlineDate) : null,
+        status: "completed",
+      },
+    });
+
+    return NextResponse.json({
+      diagnosisId: diagnosis.id,
+      candidates,
+      timeline: input.deadlineDate
+        ? { daysLeft: Math.ceil((new Date(input.deadlineDate).getTime() - Date.now()) / 86400000) }
+        : null,
+    });
   } catch (error) {
     console.error("[API] POST /api/diagnosis error:", error);
     return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -37,6 +37,10 @@ import { SortControl } from "./sort-control";
 import { TimeChipOptions } from "./time-chip-options";
 import { TimeSlotSelector } from "./time-slot-selector";
 
+// ★ W2: production(USE_MOCK=false) = 통근 실 데이터 ODsay 대중교통.
+//   mock = Haversine 추정. 출처 배지를 모드에 맞춰 정직 표기.
+const IS_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
+
 interface ResultContentProps {
   candidates: CandidateArea[];
   filters: DiagnosisFilters;
@@ -271,24 +275,38 @@ export function ResultContent({
         aria-label="진단 결과 데이터 출처"
         className="flex flex-wrap gap-s-2"
       >
+        {/* 안전 — 실 데이터(공공데이터)는 W3 야간안전. 현재는 mock. */}
         <DataSourceBadge
           kind="official"
           source="공공데이터포털"
           updatedAt="2026.04"
           tone="on-light"
         />
-        <DataSourceBadge
-          kind="aggregated"
-          source="카카오 모빌리티"
-          updatedAt="2026.04.01"
-          tone="on-light"
-        />
-        <DataSourceBadge
-          kind="estimate"
-          source="통근 추정"
-          updatedAt="—"
-          tone="on-light"
-        />
+        {IS_MOCK ? (
+          <>
+            {/* mock = Haversine 추정 (실 통근 데이터 미연동) */}
+            <DataSourceBadge
+              kind="aggregated"
+              source="카카오 모빌리티"
+              updatedAt="2026.04.01"
+              tone="on-light"
+            />
+            <DataSourceBadge
+              kind="estimate"
+              source="통근 추정"
+              updatedAt="—"
+              tone="on-light"
+            />
+          </>
+        ) : (
+          /* production = 실 ODsay 대중교통 (자차=카카오는 후속) */
+          <DataSourceBadge
+            kind="aggregated"
+            source="ODsay 대중교통"
+            updatedAt="실시간"
+            tone="on-light"
+          />
+        )}
       </section>
 
       <MapCanvas markers={markers} onMarkerClick={open} height={320} />

--- a/onday-app/src/app/share/[uuid]/share-report-view.tsx
+++ b/onday-app/src/app/share/[uuid]/share-report-view.tsx
@@ -12,6 +12,20 @@ import { splitForPreview } from "@/features/diagnosis/mock-calculator";
 import { buildReportStats } from "@/features/share/preview-stats";
 import type { CandidateArea } from "@/lib/types";
 
+// ★ W2: production = 통근 실 ODsay 대중교통 / mock = Haversine 추정.
+//   개인(result-content) ↔ 공유(본 뷰) 출처 배지 일관성 사수.
+const IS_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
+const SOURCE_BADGES = IS_MOCK
+  ? [
+      { kind: "official" as const, source: "공공데이터포털", updatedAt: "2026.04" },
+      { kind: "aggregated" as const, source: "카카오 모빌리티", updatedAt: "2026.04.01" },
+      { kind: "estimate" as const, source: "통근 추정", updatedAt: "—" },
+    ]
+  : [
+      { kind: "official" as const, source: "공공데이터포털", updatedAt: "2026.04" },
+      { kind: "aggregated" as const, source: "ODsay 대중교통", updatedAt: "실시간" },
+    ];
+
 interface ShareData {
   uniqueUrl: string;
   diagnosisId: string;
@@ -72,23 +86,7 @@ export function ShareReportView({ data }: ShareReportViewProps) {
               후보 동네 {total}곳이 도착했어요
             </>
           }
-          badges={[
-            {
-              kind: "official",
-              source: "공공데이터포털",
-              updatedAt: "2026.04",
-            },
-            {
-              kind: "aggregated",
-              source: "카카오 모빌리티",
-              updatedAt: "2026.04.01",
-            },
-            {
-              kind: "estimate",
-              source: "통근 추정",
-              updatedAt: "—",
-            },
-          ]}
+          badges={SOURCE_BADGES}
         />
       </div>
 

--- a/onday-app/src/features/diagnosis/mock-calculator.ts
+++ b/onday-app/src/features/diagnosis/mock-calculator.ts
@@ -10,52 +10,8 @@ import {
   estimateTransfers,
 } from "@/lib/haversine";
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
-
-interface ScoreInput {
-  neighborhood: (typeof MOCK_NEIGHBORHOODS)[number];
-  commuteA: number;
-  commuteB: number | null;
-  leisureA: number | null;
-  leisureB: number | null;
-}
-
-// 여가거점 가산 (Figma 비전 — single 모드, 0~5점/거점)
-function leisureBonus(minutes: number | null): number {
-  if (minutes == null) return 0;
-  // 0분 → +5, 30분 → 0, 그 이상 → 0
-  return Math.max(0, 5 - minutes / 6);
-}
-
-function scoreCandidate({
-  neighborhood,
-  commuteA,
-  commuteB,
-  leisureA,
-  leisureB,
-}: ScoreInput): number {
-  let score = 100;
-
-  // 통근 패널티 (가장 큰 요인)
-  const avgCommute = commuteB != null ? (commuteA + commuteB) / 2 : commuteA;
-  score -= Math.min(40, avgCommute * 0.8);
-
-  // Issue #123 — 예산 범위 외 제외는 computeOneCandidate 영역 박힘 (★ maxCommuteTime 답습 정합).
-  //   score 영역 페널티 폐기 = ★ 범위 외 카드 score X = 결과 카드 X 자연.
-
-  // 안전등급 가산
-  const safetyBonus: Record<string, number> = { A: 10, B: 5, C: 0, D: -10 };
-  score += safetyBonus[neighborhood.safetyGrade] ?? 0;
-
-  // 편의시설 가산
-  const facilityScore =
-    (neighborhood.facilities.convenience + neighborhood.facilities.cafes) / 10;
-  score += Math.min(10, facilityScore);
-
-  // 여가거점 가산 (single 모드 — Figma 비전)
-  score += leisureBonus(leisureA) + leisureBonus(leisureB);
-
-  return Math.max(0, Math.min(100, Math.round(score)));
-}
+// ScoringEngine (#27) — 점수 로직은 공용 모듈로 추출. client(실 ODsay) + server(mock) 공유.
+import { scoreCandidate } from "@/lib/diagnosis/scoring";
 
 interface ComputeResult {
   status: "fulfilled";

--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import type {
+  CandidateArea,
+  CommuteInfo,
+  Coordinate,
+  DiagnosisInput,
+} from "@/lib/types";
+import { haversineDistance } from "@/lib/haversine";
+import { scoreCandidate } from "@/lib/diagnosis/scoring";
+import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
+
+// ★ B2 클라 오케스트레이션 (production 모드 = USE_MOCK=false).
+//   1) Haversine 사전필터 top N (가까운 동네만) → ODsay 호출 수 감축 (10~12)
+//   2) /api/commute 프록시 Promise.all (각 함수 1 호출 → Vercel 10초 무관)
+//   3) 필터 + 점수(transit) → 후보 → /api/diagnosis 저장(POST)
+//   후보 풀 = 22 mock 동네 유지 (행정동/실 데이터 = v1.5+).
+
+const PREFILTER_TOP_N = 12;
+const RESULT_TOP_N = 8;
+
+/** /api/commute 1회 — 경로 없음/에러면 null (해당 동네 제외). */
+async function fetchCommute(
+  origin: Coordinate,
+  destination: Coordinate,
+): Promise<CommuteInfo | null> {
+  const params = new URLSearchParams({
+    olat: String(origin.lat),
+    olng: String(origin.lng),
+    dlat: String(destination.lat),
+    dlng: String(destination.lng),
+  });
+  const res = await fetch(`/api/commute?${params.toString()}`);
+  if (!res.ok) return null;
+  const data = (await res.json()) as { commute: CommuteInfo };
+  return data.commute;
+}
+
+export async function runRealDiagnosis(input: DiagnosisInput) {
+  const {
+    coordinateA,
+    coordinateB,
+    leisureCoordA,
+    leisureCoordB,
+    filters,
+    mode,
+  } = input;
+
+  // 1) Haversine 사전필터 — 직장 A(+B) 합산 직선거리 기준 가까운 top N.
+  const prefiltered = MOCK_NEIGHBORHOODS.map((n) => {
+    const dA = haversineDistance(coordinateA, n.coordinate);
+    const dB = coordinateB ? haversineDistance(coordinateB, n.coordinate) : 0;
+    return { n, combined: dA + dB };
+  })
+    .sort((a, b) => a.combined - b.combined)
+    .slice(0, PREFILTER_TOP_N);
+
+  // 2) 동네별 ODsay 통근시간 (병렬). 동네 내부 경로는 순차(동시 호출 부하 완화).
+  const settled = await Promise.all(
+    prefiltered.map(async ({ n }): Promise<CandidateArea | null> => {
+      const commuteA = await fetchCommute(coordinateA, n.coordinate);
+      if (!commuteA) return null; // 직장 A 경로 없으면 후보 제외
+
+      let commuteB: CommuteInfo | null = null;
+      if (coordinateB) {
+        commuteB = await fetchCommute(coordinateB, n.coordinate);
+        if (!commuteB) return null; // couple 인데 배우자 경로 없으면 제외
+      }
+
+      // single 모드 여가거점 (선택)
+      let leisureA: CommuteInfo | null = null;
+      if (leisureCoordA) leisureA = await fetchCommute(leisureCoordA, n.coordinate);
+      let leisureB: CommuteInfo | null = null;
+      if (leisureCoordB) leisureB = await fetchCommute(leisureCoordB, n.coordinate);
+
+      // 필터 — 통근 상한
+      if (filters.maxCommuteTime) {
+        const maxCommute = Math.max(commuteA.time, commuteB?.time ?? 0);
+        if (maxCommute > filters.maxCommuteTime) return null;
+      }
+      // 필터 — 예산 범위
+      if (filters.budget) {
+        if (n.avgPrice < filters.budget.min || n.avgPrice > filters.budget.max) {
+          return null;
+        }
+      }
+
+      const score = scoreCandidate({
+        neighborhood: n,
+        commuteA: commuteA.time,
+        commuteB: commuteB?.time ?? null,
+        leisureA: leisureA?.time ?? null,
+        leisureB: leisureB?.time ?? null,
+      });
+
+      return {
+        id: n.id,
+        dong: n.dong,
+        gu: n.gu,
+        coordinate: n.coordinate,
+        commuteA,
+        commuteB: commuteB ?? undefined,
+        leisureA: leisureA ?? undefined,
+        leisureB: leisureB ?? undefined,
+        score,
+        safetyGrade: mode === "single" ? n.safetyGrade : undefined,
+        priceRange: {
+          min: Math.round(n.avgPrice * 0.85),
+          max: Math.round(n.avgPrice * 1.15),
+        },
+        facilities: n.facilities,
+        lines: n.lines,
+        listingsCount: n.listingsCount,
+        avgArea: n.avgArea,
+      };
+    }),
+  );
+
+  const candidates = settled
+    .filter((c): c is CandidateArea => c !== null)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, RESULT_TOP_N);
+
+  // 3) 저장 — production 분기는 클라가 계산한 candidates 를 받아 저장만 (B2).
+  const res = await fetch("/api/diagnosis", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...input, candidates }),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error ?? "진단 저장에 실패했습니다");
+  }
+  return res.json();
+}

--- a/onday-app/src/features/diagnosis/use-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/use-diagnosis.ts
@@ -2,8 +2,16 @@
 
 import { useMutation, useQuery } from "@tanstack/react-query";
 import type { DiagnosisInput, DiagnosisResult } from "@/lib/types";
+import { runRealDiagnosis } from "@/features/diagnosis/run-real-diagnosis";
+
+// ★ W2: production(USE_MOCK=false) = 클라 오케스트레이션(B2 — ODsay /api/commute Promise.all).
+//   mock(USE_MOCK=true) = 기존 단일 POST(서버 Haversine 계산) 무변경 = 회귀 격리.
+const IS_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 
 async function createDiagnosis(input: DiagnosisInput) {
+  if (!IS_MOCK) {
+    return runRealDiagnosis(input);
+  }
   const res = await fetch("/api/diagnosis", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/onday-app/src/lib/diagnosis/geocoding-types.ts
+++ b/onday-app/src/lib/diagnosis/geocoding-types.ts
@@ -8,15 +8,18 @@
 
 import type { Coordinate } from "@/lib/types";
 
-/** 카카오 Local API Geocoding 응답 원본 (★ Mismatch ② 자체 정의 — x/y 문자열). */
+/**
+ * 카카오 Local API 키워드(장소) 검색 응답 document 원본.
+ * ★ W2 정정: address.json(주소) → keyword.json(장소) 전환 — 사용자가 치는 역/장소
+ *   이름("강남역")을 매칭하기 위함. 실 응답은 snake_case + 평면 구조.
+ *   (기존 camelCase/nested 가정은 실 응답과 불일치 = production 미실행 잠복 버그였음.)
+ */
 export interface GeocodeResult {
-  addressName: string;
-  roadAddressName: string;
-  x: string;
-  y: string;
-  region1DepthName: string;
-  region2DepthName: string;
-  region3DepthName: string;
+  place_name: string; // 장소명 (예: "강남역 2호선")
+  address_name: string; // 지번 주소 (예: "서울 강남구 역삼동 858")
+  road_address_name: string; // 도로명 주소
+  x: string; // 경도 (lng)
+  y: string; // 위도 (lat)
 }
 
 /** 변환된 주소 DTO (★ coord: Coordinate 재사용 = ★ Mismatch ⑦, 결정론 가드 § 진화 후행 실전). */

--- a/onday-app/src/lib/diagnosis/geocoding.ts
+++ b/onday-app/src/lib/diagnosis/geocoding.ts
@@ -14,7 +14,9 @@ import * as Sentry from "@sentry/nextjs";
 import type { Coordinate } from "@/lib/types";
 import type { GeocodeResult, GeocodedAddress } from "./geocoding-types";
 
-const KAKAO_LOCAL_API_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+// ★ W2 정정: address.json(주소) → keyword.json(장소). 사용자가 치는 역/장소 이름
+//   ("강남역")은 주소 검색으론 0건 → 키워드(장소) 검색이어야 매칭됨.
+const KAKAO_LOCAL_API_URL = "https://dapi.kakao.com/v2/local/search/keyword.json";
 const METRO_AREA_PREFIXES = ["서울", "경기", "인천"];
 
 export async function geocodeAddress(query: string, apiKey: string): Promise<GeocodedAddress[]> {
@@ -45,13 +47,16 @@ export async function geocodeAddress(query: string, apiKey: string): Promise<Geo
 }
 
 function mapToGeocodedAddress(doc: GeocodeResult): GeocodedAddress {
-  const isMetroArea = METRO_AREA_PREFIXES.some((prefix) => doc.region1DepthName.startsWith(prefix));
+  const addressName = doc.address_name ?? "";
+  const isMetroArea = METRO_AREA_PREFIXES.some((prefix) =>
+    addressName.startsWith(prefix),
+  );
   const coord: Coordinate = { lat: parseFloat(doc.y), lng: parseFloat(doc.x) };
   return {
-    address: doc.addressName,
-    roadAddress: doc.roadAddressName,
+    address: doc.place_name, // 장소명 (사용자 친화 — 강남역)
+    roadAddress: doc.road_address_name,
     coord,
-    region: `${doc.region1DepthName} ${doc.region2DepthName} ${doc.region3DepthName}`.trim(),
+    region: addressName, // 지번 주소 (서울 강남구 역삼동)
     isMetroArea,
   } satisfies GeocodedAddress;
 }

--- a/onday-app/src/lib/diagnosis/scoring.ts
+++ b/onday-app/src/lib/diagnosis/scoring.ts
@@ -1,0 +1,54 @@
+import type { SafetyGrade } from "@/lib/types";
+
+// ScoringEngine (#27 CMD-DIAG-003) — mock-calculator 에서 추출한 순수 점수 로직.
+// client(실 ODsay 오케스트레이션) + server(mock-calculator) 양쪽이 동일 점수식을 재사용.
+// ★ 점수 기준 = 대중교통(transit) 통근시간 (R2 결정). 입력 commute* 는 "분".
+
+/** 점수 계산에 필요한 동네 속성만 (MOCK_NEIGHBORHOODS 항목이 구조적으로 할당 가능). */
+export interface ScoringNeighborhood {
+  safetyGrade: SafetyGrade;
+  facilities: { convenience: number; cafes: number; schools?: number };
+}
+
+export interface ScoreInput {
+  neighborhood: ScoringNeighborhood;
+  commuteA: number;
+  commuteB: number | null;
+  leisureA: number | null;
+  leisureB: number | null;
+}
+
+// 여가거점 가산 (Figma 비전 — single 모드, 0~5점/거점)
+function leisureBonus(minutes: number | null): number {
+  if (minutes == null) return 0;
+  // 0분 → +5, 30분 → 0, 그 이상 → 0
+  return Math.max(0, 5 - minutes / 6);
+}
+
+export function scoreCandidate({
+  neighborhood,
+  commuteA,
+  commuteB,
+  leisureA,
+  leisureB,
+}: ScoreInput): number {
+  let score = 100;
+
+  // 통근 패널티 (가장 큰 요인)
+  const avgCommute = commuteB != null ? (commuteA + commuteB) / 2 : commuteA;
+  score -= Math.min(40, avgCommute * 0.8);
+
+  // 안전등급 가산
+  const safetyBonus: Record<string, number> = { A: 10, B: 5, C: 0, D: -10 };
+  score += safetyBonus[neighborhood.safetyGrade] ?? 0;
+
+  // 편의시설 가산
+  const facilityScore =
+    (neighborhood.facilities.convenience + neighborhood.facilities.cafes) / 10;
+  score += Math.min(10, facilityScore);
+
+  // 여가거점 가산 (single 모드 — Figma 비전)
+  score += leisureBonus(leisureA) + leisureBonus(leisureB);
+
+  return Math.max(0, Math.min(100, Math.round(score)));
+}

--- a/onday-app/src/lib/external/odsay-transit/client.ts
+++ b/onday-app/src/lib/external/odsay-transit/client.ts
@@ -1,0 +1,81 @@
+import type { CommuteInfo } from "@/lib/types";
+import type {
+  IOdsayTransitClient,
+  OdsayCoord,
+  OdsayTransitClientConfig,
+  OdsayTransitResponse,
+} from "./types";
+import { DEFAULT_ODSAY_CONFIG, OdsayTransitError } from "./types";
+import { mapOdsayResponseToCommuteInfo } from "./mapper";
+
+/**
+ * ODsay 대중교통 길찾기 클라이언트 — 서버 전용 (#33 QRY-DIAG-002 / #30 timeout).
+ * ★ B2 아키텍처: /api/commute 프록시가 동네별로 1회씩 호출 (함수당 1 호출 → Vercel 10초 무관).
+ * ★ ODsay Server key 는 서버에서만 사용 (브라우저 직접 = CORS 차단).
+ */
+export class OdsayTransitClient implements IOdsayTransitClient {
+  private readonly apiKey: string;
+  private readonly config: OdsayTransitClientConfig;
+
+  constructor(
+    config: { apiKey: string } & Partial<
+      Omit<OdsayTransitClientConfig, "apiKey">
+    >,
+  ) {
+    this.apiKey = config.apiKey;
+    this.config = { ...DEFAULT_ODSAY_CONFIG, ...config };
+  }
+
+  async getTransitCommute(
+    origin: OdsayCoord,
+    destination: OdsayCoord,
+  ): Promise<CommuteInfo> {
+    const res = await this.fetchWithRetry(origin, destination);
+    return mapOdsayResponseToCommuteInfo(res);
+  }
+
+  private async fetchWithRetry(
+    origin: OdsayCoord,
+    destination: OdsayCoord,
+  ): Promise<OdsayTransitResponse> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      try {
+        return await this.fetchOnce(origin, destination);
+      } catch (err) {
+        lastError = err;
+        if (attempt < this.config.maxRetries) {
+          await new Promise((r) => setTimeout(r, this.config.retryDelayMs));
+        }
+      }
+    }
+    throw lastError instanceof Error
+      ? new OdsayTransitError(`ODsay 호출 실패: ${lastError.message}`)
+      : new OdsayTransitError("ODsay 호출 실패");
+  }
+
+  private async fetchOnce(
+    origin: OdsayCoord,
+    destination: OdsayCoord,
+  ): Promise<OdsayTransitResponse> {
+    const url = new URL(`${this.config.baseUrl}/searchPubTransPathT`);
+    url.searchParams.set("SX", String(origin.lng)); // 출발 경도
+    url.searchParams.set("SY", String(origin.lat)); // 출발 위도
+    url.searchParams.set("EX", String(destination.lng)); // 도착 경도
+    url.searchParams.set("EY", String(destination.lat)); // 도착 위도
+    url.searchParams.set("apiKey", this.apiKey);
+    url.searchParams.set("output", "json");
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.config.timeoutMs);
+    try {
+      const res = await fetch(url.toString(), { signal: controller.signal });
+      if (!res.ok) {
+        throw new OdsayTransitError(`ODsay HTTP ${res.status}`);
+      }
+      return (await res.json()) as OdsayTransitResponse;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/onday-app/src/lib/external/odsay-transit/index.ts
+++ b/onday-app/src/lib/external/odsay-transit/index.ts
@@ -1,0 +1,9 @@
+export { OdsayTransitClient } from "./client";
+export { mapOdsayResponseToCommuteInfo } from "./mapper";
+export {
+  OdsayTransitError,
+  DEFAULT_ODSAY_CONFIG,
+  type OdsayCoord,
+  type OdsayTransitResponse,
+  type IOdsayTransitClient,
+} from "./types";

--- a/onday-app/src/lib/external/odsay-transit/mapper.ts
+++ b/onday-app/src/lib/external/odsay-transit/mapper.ts
@@ -1,0 +1,35 @@
+import type { CommuteInfo } from "@/lib/types";
+import type { OdsayTransitResponse } from "./types";
+import { OdsayTransitError } from "./types";
+
+/**
+ * ODsay 대중교통 길찾기 응답 → CommuteInfo (앱 모델 무변경 — R2 transit-only).
+ * - 추천 경로 result.path[0] 사용 (ODsay 정렬 = 최단/추천 우선).
+ * - transfers = (지하철+버스 탑승 횟수) − 1 (첫 탑승은 환승 아님).
+ * @throws OdsayTransitError 경로 없음 / 에러 응답.
+ */
+export function mapOdsayResponseToCommuteInfo(
+  res: OdsayTransitResponse,
+): CommuteInfo {
+  if (res.error) {
+    throw new OdsayTransitError(
+      `ODsay error: ${res.error.message ?? res.error.msg ?? "unknown"}`,
+      res.error.code,
+    );
+  }
+
+  const path = res.result?.path?.[0];
+  if (!path) {
+    throw new OdsayTransitError("ODsay: 대중교통 경로 없음");
+  }
+
+  const { totalTime, subwayTransitCount, busTransitCount } = path.info;
+  const transfers = Math.max(0, subwayTransitCount + busTransitCount - 1);
+
+  return {
+    time: totalTime,
+    mode: "transit",
+    transfers,
+    // totalWalk / payment 는 현재 CommuteInfo 미보유 — 정보 손실 수용 (차후 모델 확장 시).
+  } satisfies CommuteInfo;
+}

--- a/onday-app/src/lib/external/odsay-transit/types.ts
+++ b/onday-app/src/lib/external/odsay-transit/types.ts
@@ -1,0 +1,65 @@
+// ──────────────────────────────────────────────
+// ODsay 대중교통 길찾기 도메인 — DTO + interface + config.
+// ★ transit=ODsay 신규 (car=kakao 는 kakao-transport/ 후속). W2 ODsay 슬라이스.
+//   SRS EXT-01 "카카오 모빌리티 = 대중교통" 은 사실오류(카카오=car) → 대중교통은 ODsay.
+// ──────────────────────────────────────────────
+
+import type { CommuteInfo } from "@/lib/types";
+
+/** ODsay 좌표 — SX/SY = 경도(lng)/위도(lat). */
+export interface OdsayCoord {
+  lng: number;
+  lat: number;
+}
+
+/** result.path[].info — 필요 필드만. */
+export interface OdsayPathInfo {
+  totalTime: number; // 총 소요시간 (분)
+  totalWalk: number; // 총 도보 거리 (미터)
+  payment: number; // 총 요금
+  busTransitCount: number; // 버스 환승 카운트
+  subwayTransitCount: number; // 지하철 환승 카운트
+}
+
+export interface OdsayPath {
+  info: OdsayPathInfo;
+  // subPath(구간 상세)는 현재 CommuteInfo 모델에 미사용.
+}
+
+/** searchPubTransPathT 응답. 경로 없음/에러 시 result 부재 또는 error 객체. */
+export interface OdsayTransitResponse {
+  result?: { path?: OdsayPath[] };
+  error?: { code?: string; message?: string; msg?: string };
+}
+
+export interface OdsayTransitClientConfig {
+  baseUrl: string;
+  timeoutMs: number;
+  maxRetries: number;
+  retryDelayMs: number;
+}
+
+export const DEFAULT_ODSAY_CONFIG: Omit<OdsayTransitClientConfig, "apiKey"> = {
+  baseUrl: "https://api.odsay.com/v1/api",
+  timeoutMs: 5000, // REQ-FUNC-007 정합 (단일 호출 — B2 라 함수당 1회)
+  maxRetries: 1,
+  retryDelayMs: 500,
+};
+
+export interface IOdsayTransitClient {
+  /** 출발→도착 대중교통 통근 정보 (mapOdsayResponseToCommuteInfo 활용). */
+  getTransitCommute(
+    origin: OdsayCoord,
+    destination: OdsayCoord,
+  ): Promise<CommuteInfo>;
+}
+
+/** ODsay 호출/매핑 실패 표준 에러. */
+export class OdsayTransitError extends Error {
+  readonly code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "OdsayTransitError";
+    this.code = code;
+  }
+}

--- a/tasks/ISSUE_REGISTER_LOG.md
+++ b/tasks/ISSUE_REGISTER_LOG.md
@@ -1820,3 +1820,85 @@ _본 § 신설: 2026-05-30 (REAL-API-W1-SUPABASE-AUTH (a) 실행 — #21+#23 카
 - **★ "auth 무관 선재 버그 분리 처리" 정수 = W1-2 검증이 부수적으로 잡아낸 데이터 버그 (스코프 분리 정직)** — auth PR 에 안 섞고 별도 브랜치.
 
 _본 § 신설: 2026-05-30 (fix/mock-dup-neighborhood — neighborhoods.ts 중복 동네 1개 삭제 + mock-calculator id dedup 가드. §32 W1-2 (b) 실 검증 중 발견된 auth 무관 선재 버그(Step 9.5 mock 확장 잔재) → 스코프 분리 별도 브랜치. tsc 0 / 후보 중복 id 0. 자동 머지 X._
+
+---
+
+## 34. REAL-API-W2-ODSAY-TRANSIT — 대중교통 실 통근시간 (2026-05-30 신설 NEW)
+
+**ISSUE:** #27(ScoringEngine) + #30(CMD-DIAG-006 timeout) + #33(QRY-DIAG-002 통근조회)
+**브랜치:** `feat/REAL-API-W2-ODSAY-TRANSIT`
+**선행 §:** §30 MASTER-PLAN W2 / §31 W1-DB / §32 W1-AUTH
+**grill-me:** R1(둘 다 단계적) / R2(transit-only 먼저) / R3(B2 아키텍처) / R4(odsay 신규 모듈) / Q5(범위) 합의
+
+### 본 § = 정직 § 10건 누적 (★ ㊧ Mismatch 16번째 = "카카오 모빌리티=대중교통" SRS 사실오류)
+
+**1. ★ ㊧ Mismatch 16번째 — SRS 전제 사실오류 (카카오 모빌리티 = 대중교통 X):**
+- SRS EXT-01 "카카오 모빌리티 API = 대중교통 경로·환승·소요시간 / 일 50만 건", CON-07 "교통 API 카카오 1종만", ASM-01.
+- 웹 검증: **카카오 모빌리티 공개 REST = 자동차 길찾기 전용** (대중교통 API 미제공). → SRS 전제 사실오류.
+- mapper(kakao-transport)가 가상 transit 응답 형태로 지어진 근본 원인.
+- **해소:** 대중교통=ODsay(신규 모듈) / 자차=카카오(후속). SSoT 역방향 갱신. (Auth "DB-007 산출물 허상" 답습 — SSoT 레벨)
+
+**2. car vs transit 결정 — 대중교통(ODsay) 우선 + 단계적 (R1/R2):**
+- 통근=대중교통이 OnDay 본질(3040 부부 수도권) → car time은 핵심가치 왜곡.
+- ODsay 무료 Basic tier(1,000/일) = 앱 모델(환승+소요시간) 정확 일치.
+- 자차(카카오 car, 이미 검증) = 후속 REAL-API-W2B-CAR-COMMUTE.
+
+**3. ★ B2 아키텍처 — ODsay CORS 차단 → 클라 오케스트레이션 + 서버 프록시 (R3):**
+- ODsay = 브라우저 직접 CORS 차단(Web key도) + Server key IP 화이트리스트 → 서버 호출 강제.
+- B2: 클라가 Haversine 사전필터(top12) → `/api/commute`(함수당 1 ODsay 호출) Promise.all → 점수 → 저장 POST.
+- **각 서버 함수 1 호출 = Vercel 10초 timeout 무관** (CLAUDE.md "클라 Promise.all" 정신 + ODsay CORS 우회). B1(서버 일괄)은 ODsay throttle 미공개라 비채택.
+
+**4. odsay-transit 신규 모듈 + ScoringEngine 추출 (R4/#27):**
+- `lib/external/odsay-transit/`(types/client/mapper/index) — kakao-transport는 자차 후속 보존.
+- `lib/diagnosis/scoring.ts` = scoreCandidate 추출(client+server 공유). mock-calculator 재사용 = 회귀 0.
+- mapper: totalTime→time, mode='transit', transfers=(지하철+버스)−1. 앱 모델 무변경.
+
+**5. ★ Tier 0 ODsay Server IP 화이트리스트 정직 (Vercel 유동 IP 비용 플래그):**
+- ODsay Server key = 공인 IP 화이트리스트 강제. 로컬=공인 IP 등록 OK / Vercel 서버리스=유동 IP → 고정 IP 유료(Pro Static IPs/프록시) 필연.
+- **로컬 (b) 검증은 무료 가능, 프로덕션 ODsay 운영 = 유료 비용 인지** (production flip 흡수).
+
+**6. ★ geocode 잠복 버그 발견·수정 (production 첫 실행에서 드러남):**
+- production 자동완성이 `address.json`(주소) → "강남역" 0건 + GeocodeResult camelCase가 실 응답 snake_case와 불일치 = 이중 버그(여태 mock만 써서 미실행).
+- **수정:** `keyword.json`(장소) + 실 필드 매핑. → "강남역 2호선" 매칭. **production 진단 흐름의 전제라 W2 포함** (르르 결정).
+
+**7. ★ 출처 배지 mode-aware 정합 (실 데이터 정직 표기):**
+- result-content(개인) + share-report-view(공유) = mock 하드코딩("카카오 모빌리티"/"통근 추정") → production은 **"ODsay 대중교통·실시간"**. mock 무변경(회귀 0). 개인↔공유 일관.
+
+**8. (b) 실 검증 통과:**
+- geocode keyword → autocomplete → coords → ODsay /api/commute(강남역→서울역 35분 transit 환승1) → 점수 → 저장.
+- 실 유저(33deaf63) 귀속 진단 2건, 후보 = 실 ODsay 통근(왕십리 22분/성수동 32분, transit, 환승1). mock 모드 무변경.
+
+**9. what-if 불일치 정직 발견 → 후속 (배지 무관):**
+- result 필터 what-if 재계산 = production에서도 `runMockDiagnosis`(Haversine) → 초기(ODsay)와 불일치.
+- 초기 진단=ODsay 정상(핵심) / what-if=부가 → **REAL-API-W2-WHATIF-ODSAY 후속 ISSUE 등록** (W2 한 바퀴 후).
+
+**10. 사전 박힘 ~50% 실측 (마스터플랜 70/60% 과대):**
+- types/config 100%지만 mapper가 실 응답 불일치 + car/transit 의미갭 + 아키텍처 이동 → 실측 ~50% (Auth 45% 답습).
+
+### Phase B 한계 § 21번째 누적 (13단계 답습)
+
+체인: #114 → … → MASTER-PLAN → W1-DB → W1-AUTH → **W2-ODSAY-TRANSIT**
+
+### ㊧ Mismatch 16번째 영역 진화 NEW
+
+- SRS EXT-01/CON-07/ASM-01 "카카오 모빌리티=대중교통" = **외부 API 제공범위 사실오류** (기존 15건 = 산출물 허상/버전/필드형태, 본 건 = SRS의 외부 API 기능 가정 오류). 해소 = ODsay 신규 + SSoT 역방향 갱신.
+
+### 차후 ISSUE 후보 영역 누적 표 갱신 (2026-05-30 기준)
+
+| 후보 ISSUE | 트리거 | 영역 | 상태 |
+|---|---|---|---|
+| **REAL-API-W2-ODSAY-TRANSIT** | (본 §) | 대중교통 실 통근 | **코드+(b) 완료 / 르르 머지·Close 대기** |
+| **REAL-API-W2B-CAR-COMMUTE** (NEW) | W2 완료 후 | 자차=카카오 car + commute 모델 양모드 + 카드 UI | 후속 (REQ-FUNC-004 나머지 절반) |
+| **REAL-API-W2-WHATIF-ODSAY** (NEW) | W2 완료 후 | result 필터 what-if = ODsay 재호출 (Haversine 불일치 해소) | 후속 |
+| ODsay 프로덕션 고정 IP | production flip | Vercel Static IPs(유료) or 프록시 | flip 단계 |
+| 후보 수 튜닝 (top N / 근거리 ODsay 404) | (관찰) | PREFILTER_TOP_N / 근거리 처리 | 후속 (관찰) |
+
+### 본 세션 누적 34건 § 박힘 표 (★ Phase B 한계 § 21번째)
+
+| § | 영역 | ISSUE | PR | 상태 | 답습 정수 |
+|---|---|---|---|---|---|
+| 32 | REAL-API-W1-SUPABASE-AUTH | #21+#23 | #140 머지 | 완료 | (기존) |
+| 33 | fix/mock-dup-neighborhood | (버그) | #141 머지 | 완료 | (기존) |
+| 34 | **REAL-API-W2-ODSAY-TRANSIT** | **#27+#30+#33** | **(커밋 대기)** | **코드+(b) 완료** | **★ ㊧ Mismatch 16번째 (SRS "카카오=대중교통" 사실오류) + B2 아키텍처(ODsay CORS→클라 오케스트레이션) + odsay 신규 모듈 + ScoringEngine 추출(#27) + geocode 잠복버그 수정(keyword.json) + 배지 mode-aware + (b) 실 ODsay 검증(왕십리 22분 transit) + Tier 0 IP 유료 정직 + what-if 후속 분리 + 사전박힘 ~50% 실측** |
+
+_본 § 신설: 2026-05-30 (REAL-API-W2-ODSAY-TRANSIT — 대중교통 실 통근시간). ★ ㊧ Mismatch 16번째 = SRS EXT-01 "카카오 모빌리티=대중교통" 사실오류(실제 car 전용) → 대중교통=ODsay 신규 모듈 + SSoT 역방향 갱신 + ★ B2 아키텍처(ODsay CORS 차단→클라 Haversine 사전필터 + /api/commute 프록시 Promise.all, 함수당 1호출=10초 무관) + ★ odsay-transit 신규(types/client/mapper/index) + ScoringEngine 추출(scoring.ts, #27) + ★ geocode 이중 잠복버그 수정(address.json→keyword.json + camelCase→snake_case, production 첫 실행에서 드러남) + ★ 출처 배지 mode-aware(개인/공유 ODsay 대중교통) + ★ (b) 실 검증 통과(geocode→ODsay 35분 transit→실유저 귀속 저장) + ★ Tier 0 ODsay Server IP 화이트리스트 = Vercel 유동IP 유료 정직 플래그 + ★ what-if 불일치 후속 분리(REAL-API-W2-WHATIF-ODSAY) + ★ 자차 후속(REAL-API-W2B-CAR-COMMUTE, REQ-FUNC-004 나머지) + ★ 사전박힘 ~50% 실측(마스터플랜 70/60% 과대). 자동 머지 X, ISSUE Close X, 프로덕션 flip X._

--- a/tasks/QRY-DIAG-002.md
+++ b/tasks/QRY-DIAG-002.md
@@ -5,6 +5,14 @@ labels: ['feature', 'priority:M', 'epic:Diagnosis', 'wave:3']
 assignees: []
 ---
 
+## 0. ⚠️ Rev 1.1 — 대중교통 데이터 소스 = ODsay (2026-05-30, 역방향 갱신 / W2)
+
+> 본 명세·SRS EXT-01 은 "카카오 모빌리티 API = 대중교통 경로·환승·소요시간"을 전제하나, **카카오 모빌리티 공개 REST 는 자동차 길찾기 전용**(대중교통 미제공) = 사실오류다. REAL-API-W2-ODSAY-TRANSIT 에서 **대중교통 = ODsay LAB API**(`searchPubTransPathT`)로 구현. 자차(카카오 car)는 후속 REAL-API-W2B-CAR-COMMUTE. 충돌 시 본 Rev 우선. (LOG §34 / ㊧ Mismatch 16번째)
+>
+> **실제 구현:** `lib/external/odsay-transit/`(client/mapper, totalTime→time·transfers=(지하철+버스)−1) + `/api/commute` 프록시(ODsay CORS·Server key IP 화이트리스트 → 서버 호출) + 클라 B2 오케스트레이션(Haversine 사전필터 + Promise.all, Vercel 10초 회피). **EXT-01/CON-07/ASM-01(카카오 50만건)은 ODsay(무료 1,000/일) 정합으로 정정.**
+
+---
+
 ## 1. 🎯 Summary
 
 - **기능명:** [QRY-DIAG-002] 출퇴근 시간 조회 — 후보 동네 탭 시 양쪽 직장까지 예상 소요시간 반환 (±10% 오차)


### PR DESCRIPTION
## Summary
Week 2 — mock(Haversine) 통근을 **실 ODsay 대중교통 시간**으로 전환 + `api/diagnosis` 501 채우기. 통근 동선 최적화(3040 부부 수도권)의 핵심 데이터를 실연동.

✅ **(a) 코드 + (b) 로컬 실 ODsay 검증 완료.** 프로덕션 flip 안 함(USE_MOCK 미설정 → mock fallback = 무변경).

## ㊧ Mismatch (SSoT 사실오류)
SRS EXT-01 "카카오 모빌리티 API = 대중교통 경로·환승·소요시간"은 **사실오류** — 카카오 모빌리티 공개 REST 는 **자동차 전용**(대중교통 미제공). → **대중교통 = ODsay** 신규 모듈, **자차 = 카카오** 후속.

## 결정 (grill-me)
- **R1/R2** 대중교통(ODsay) + 자차(카카오) **단계적** — 이번 W2 = **transit-only** (모델·UI 무변경). 점수=transit. 자차 후속.
- **R3 B2 아키텍처** — ODsay = 브라우저 CORS 차단 + Server key IP 화이트리스트 → 서버 호출 강제. 클라가 Haversine 사전필터(top12) → `/api/commute` 프록시 **Promise.all** → 점수 → 저장. **각 함수 1 호출 = Vercel 10초 timeout 무관**.
- **R4** `odsay-transit/` 신규 모듈 (kakao-transport=자차 후속 보존). mapper: totalTime→time, transfers=(지하철+버스)−1.

## 변경 (3 커밋)
**`82c12f1` feat W2 ODsay 코어**
- `lib/external/odsay-transit/{types,client,mapper,index}.ts` — fetch+AbortController timeout+retry (#30/#33)
- `app/api/commute/route.ts` — 얇은 프록시 (Server key 서버 보관)
- `lib/diagnosis/scoring.ts` — ScoringEngine 추출 (#27), mock-calculator 재사용
- `features/diagnosis/run-real-diagnosis.ts` — 클라 오케스트레이션
- `use-diagnosis` 분기 / `api/diagnosis` production(501) 저장 / 후보 풀=22 mock(행정동 v1.5+)

**`71c92f7` fix(geocode)** — production 첫 실행에서 드러난 이중 잠복버그: `address.json`(주소)→`keyword.json`(장소) + GeocodeResult camelCase→snake_case 실 응답 정합. "강남역"→강남역 2호선.

**`2a995c9` fix(result)** — 데이터 출처 배지 mode-aware: production="ODsay 대중교통·실시간" / mock 무변경. 개인+공유 일관.

**문서**: QRY-DIAG-002 Rev 1.1 + ISSUE_REGISTER_LOG §34.

## Test plan
- [x] tsc 0 / ESLint 0 / 인코딩 0
- [x] mock 무변경: POST 200, 8후보, 라우트 회귀 0
- [x] 실 ODsay: `/api/commute` 강남역→서울역 **35분 transit 환승1**
- [x] geocode: "강남역/서울역/판교" keyword 매칭 + coords
- [x] **(b) end-to-end**: geocode→ODsay→실유저(33deaf63) 귀속 저장 (왕십리 22분/성수동 32분 transit)

## DEFER / 후속
- **REAL-API-W2B-CAR-COMMUTE** (자차=카카오 car, REQ-FUNC-004 나머지)
- **REAL-API-W2-WHATIF-ODSAY** (result 필터 what-if = ODsay 재호출, 현재 Haversine 불일치)
- ODsay 프로덕션 고정 IP (Vercel 유동IP → 유료 Static IPs/프록시, flip 단계)
- 후보 수 튜닝 (관찰: 근거리 ODsay 404 제외) / 테스트(#135) / 프로덕션 flip(르르)

Closes #27
Closes #30
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)