### PR TITLE
feat(diagnosis): W2B 자차(카카오) 통근 + 통근 DetailSheet UI 마무리

### DIFF
--- a/onday-app/src/components/sheet/detail-sheet.tsx
+++ b/onday-app/src/components/sheet/detail-sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Heart, Share2 } from "lucide-react";
+import { Heart, Share2, TrainFront, Car } from "lucide-react";
 
 import { type CommuteMode } from "@/components/data/commute-chip";
 import { Stat } from "@/components/data/stat";
@@ -115,42 +115,72 @@ export function DetailSheet({
           <p className="text-caption text-ink-3">{candidate.lines}</p>
         </header>
 
-        <section aria-label="통근 정보" className="space-y-s-2">
-          {candidate.commutes.map((c) => (
-            <div
-              key={c.tag}
-              role="group"
-              aria-label={`${c.tag} 직장까지 ${c.modeLabel} ${c.minutes}분${
-                c.detail ? `, ${c.detail}` : ""
-              }`}
-              className="flex items-center gap-s-3 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 shadow-card"
-            >
-              <span
-                aria-hidden
-                className={cn(
-                  "inline-flex size-6 items-center justify-center rounded-sm text-caption-xs font-extrabold text-white",
-                  c.tag === "A" ? "bg-primary" : "bg-secondary",
-                )}
-              >
-                {c.tag}
-              </span>
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-body-sm font-bold text-ink">
-                  {c.dest}
+        {/* ★ W2B: 수단별 그룹 ([대중교통] A/B / [차량] A/B) + 방향 '동네→직장'.
+            행 카드 디자인은 보존, 수단은 그룹 헤더 아이콘+라벨로 이동. */}
+        <section aria-label="통근 정보" className="space-y-s-3">
+          <div className="flex items-center justify-between">
+            <p className="text-caption font-bold text-ink-2">통근 정보</p>
+            <p className="text-caption-xs text-ink-3">동네 → 직장 기준</p>
+          </div>
+          {(
+            [
+              {
+                key: "transit",
+                icon: <TrainFront aria-hidden className="size-4 text-ink-3" />,
+                label: "대중교통",
+                rows: candidate.commutes.filter((c) => c.mode !== "car"),
+              },
+              {
+                key: "car",
+                icon: <Car aria-hidden className="size-4 text-ink-3" />,
+                label: "차량",
+                rows: candidate.commutes.filter((c) => c.mode === "car"),
+              },
+            ] as const
+          ).map((group) =>
+            group.rows.length === 0 ? null : (
+              <div key={group.key} className="space-y-s-2">
+                <p className="flex items-center gap-s-1 text-caption font-bold text-ink-2">
+                  {group.icon}
+                  {group.label}
                 </p>
-                <p className="text-caption text-ink-3">
-                  {c.modeLabel}
-                  {c.detail ? ` · ${c.detail}` : ""}
-                </p>
+                {group.rows.map((c) => (
+                  <div
+                    key={`${c.tag}-${c.mode}`}
+                    role="group"
+                    aria-label={`${c.tag} 직장까지 ${group.label} ${c.minutes}분${
+                      c.detail ? `, ${c.detail}` : ""
+                    }`}
+                    className="flex items-center gap-s-3 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 shadow-card"
+                  >
+                    <span
+                      aria-hidden
+                      className={cn(
+                        "inline-flex size-6 items-center justify-center rounded-sm text-caption-xs font-extrabold text-white",
+                        c.tag === "A" ? "bg-primary" : "bg-secondary",
+                      )}
+                    >
+                      {c.tag}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-body-sm font-bold text-ink">
+                        {c.dest}
+                      </p>
+                      {c.detail && (
+                        <p className="text-caption text-ink-3">{c.detail}</p>
+                      )}
+                    </div>
+                    <span className="tabular text-title font-extrabold text-ink">
+                      {c.minutes}
+                      <span className="ml-0.5 text-caption font-normal text-ink-3">
+                        분
+                      </span>
+                    </span>
+                  </div>
+                ))}
               </div>
-              <span className="tabular text-title font-extrabold text-ink">
-                {c.minutes}
-                <span className="ml-0.5 text-caption font-normal text-ink-3">
-                  분
-                </span>
-              </span>
-            </div>
-          ))}
+            ),
+          )}
         </section>
 
         {commuteExtra}

--- a/onday-app/src/features/diagnosis/detail-mapper.ts
+++ b/onday-app/src/features/diagnosis/detail-mapper.ts
@@ -1,7 +1,7 @@
 import { MODE_LABELS, type CommuteMode as ChipMode } from "@/components/data/commute-chip";
 import type { BadgeProps } from "@/components/ui/badge";
 import { toChipMode } from "@/features/diagnosis/result-utils";
-import type { CandidateArea } from "@/lib/types";
+import type { CandidateArea, CommuteInfo } from "@/lib/types";
 
 interface PillItem {
   variant: BadgeProps["variant"];
@@ -35,36 +35,36 @@ export function buildLines(c: CandidateArea): string {
   return c.lines ?? "노선 정보 곧 추가";
 }
 
+function toCommuteRow(
+  tag: "A" | "B",
+  dest: string,
+  info: CommuteInfo,
+): CommuteRowItem {
+  const mode = toChipMode(info.mode);
+  return {
+    tag,
+    dest,
+    mode,
+    modeLabel: MODE_LABELS[mode],
+    detail: info.transfers != null ? `환승 ${info.transfers}회` : undefined,
+    minutes: info.time,
+  };
+}
+
+// ★ W2B: 직장 경로마다 대중교통 + 자차(있으면) 행 — REQ-FUNC-004 "탭했을 때 대중교통·자차".
+//   순서: A 대중교통 / A 차량 / B 대중교통 / B 차량 (자차는 옵셔널 best-effort).
 export function buildCommuteRows(
   c: CandidateArea,
   destA: string,
   destB?: string,
 ): CommuteRowItem[] {
-  const rows: CommuteRowItem[] = [
-    {
-      tag: "A",
-      dest: destA || "직장 A",
-      mode: toChipMode(c.commuteA.mode),
-      modeLabel: MODE_LABELS[toChipMode(c.commuteA.mode)],
-      detail:
-        c.commuteA.transfers != null
-          ? `환승 ${c.commuteA.transfers}회`
-          : undefined,
-      minutes: c.commuteA.time,
-    },
-  ];
+  const da = destA || "직장 A";
+  const db = destB || "직장 B";
+  const rows: CommuteRowItem[] = [toCommuteRow("A", da, c.commuteA)];
+  if (c.commuteACar) rows.push(toCommuteRow("A", da, c.commuteACar));
   if (c.commuteB) {
-    rows.push({
-      tag: "B",
-      dest: destB || "직장 B",
-      mode: toChipMode(c.commuteB.mode),
-      modeLabel: MODE_LABELS[toChipMode(c.commuteB.mode)],
-      detail:
-        c.commuteB.transfers != null
-          ? `환승 ${c.commuteB.transfers}회`
-          : undefined,
-      minutes: c.commuteB.time,
-    });
+    rows.push(toCommuteRow("B", db, c.commuteB));
+    if (c.commuteBCar) rows.push(toCommuteRow("B", db, c.commuteBCar));
   }
   return rows;
 }

--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -9,6 +9,27 @@ import type {
 import { haversineDistance } from "@/lib/haversine";
 import { scoreCandidate } from "@/lib/diagnosis/scoring";
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
+import { KakaoCarClient } from "@/lib/external/kakao-car";
+
+// ★ W2B 자차 — 카카오 모빌리티 브라우저 직접 (NEXT_PUBLIC, 도메인 제한). ODsay 프록시와 병렬.
+const KAKAO_KEY = process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY ?? "";
+const kakaoCar = KAKAO_KEY ? new KakaoCarClient({ apiKey: KAKAO_KEY }) : null;
+
+/** 자차 통근 — best-effort. 실패/키없음 → null (차량 행만 생략, 후보·점수 무영향). */
+async function fetchCarCommute(
+  origin: Coordinate,
+  destination: Coordinate,
+): Promise<CommuteInfo | null> {
+  if (!kakaoCar) return null;
+  try {
+    return await kakaoCar.getCarCommute(
+      { x: origin.lng, y: origin.lat },
+      { x: destination.lng, y: destination.lat },
+    );
+  } catch {
+    return null;
+  }
+}
 
 // ★ B2 클라 오케스트레이션 (production 모드 = USE_MOCK=false).
 //   1) Haversine 사전필터 top N (가까운 동네만) → ODsay 호출 수 감축 (10~12)
@@ -18,6 +39,23 @@ import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
 
 const PREFILTER_TOP_N = 12;
 const RESULT_TOP_N = 8;
+
+// ★ ODsay 초당 호출 제한(미공개) 회피 — 동네를 배치로 처리(동시 ODsay 호출 cap).
+//   Promise.all 전량 동시(~20+)는 429(Too Many Requests) 유발 → 배치 N개씩.
+const ODSAY_CONCURRENCY = 4;
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    const batch = items.slice(i, i + limit);
+    results.push(...(await Promise.all(batch.map(fn))));
+  }
+  return results;
+}
 
 /** /api/commute 1회 — 경로 없음/에러면 null (해당 동네 제외). */
 async function fetchCommute(
@@ -55,23 +93,26 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
     .sort((a, b) => a.combined - b.combined)
     .slice(0, PREFILTER_TOP_N);
 
-  // 2) 동네별 ODsay 통근시간 (병렬). 동네 내부 경로는 순차(동시 호출 부하 완화).
-  const settled = await Promise.all(
-    prefiltered.map(async ({ n }): Promise<CandidateArea | null> => {
-      const commuteA = await fetchCommute(coordinateA, n.coordinate);
+  // 2) 동네별 통근시간 (병렬). ★ 방향 = 동네(집) → 직장 (출퇴근 의미론, #3 정정).
+  //    동네 내부 경로는 순차(동시 호출 부하 완화).
+  const settled = await mapWithConcurrency(
+    prefiltered,
+    ODSAY_CONCURRENCY,
+    async ({ n }): Promise<CandidateArea | null> => {
+      const commuteA = await fetchCommute(n.coordinate, coordinateA);
       if (!commuteA) return null; // 직장 A 경로 없으면 후보 제외
 
       let commuteB: CommuteInfo | null = null;
       if (coordinateB) {
-        commuteB = await fetchCommute(coordinateB, n.coordinate);
+        commuteB = await fetchCommute(n.coordinate, coordinateB);
         if (!commuteB) return null; // couple 인데 배우자 경로 없으면 제외
       }
 
-      // single 모드 여가거점 (선택)
+      // single 모드 여가거점 (선택) — 동네 → 여가거점
       let leisureA: CommuteInfo | null = null;
-      if (leisureCoordA) leisureA = await fetchCommute(leisureCoordA, n.coordinate);
+      if (leisureCoordA) leisureA = await fetchCommute(n.coordinate, leisureCoordA);
       let leisureB: CommuteInfo | null = null;
-      if (leisureCoordB) leisureB = await fetchCommute(leisureCoordB, n.coordinate);
+      if (leisureCoordB) leisureB = await fetchCommute(n.coordinate, leisureCoordB);
 
       // 필터 — 통근 상한
       if (filters.maxCommuteTime) {
@@ -84,6 +125,15 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
           return null;
         }
       }
+
+      // ★ W2B 자차(카카오) — 필터 통과한 후보의 직장 경로만. best-effort 병렬.
+      //   대중교통이 주(필수)이므로 여기서 실패해도 후보·점수 불변.
+      const [commuteACar, commuteBCar] = await Promise.all([
+        fetchCarCommute(n.coordinate, coordinateA),
+        coordinateB
+          ? fetchCarCommute(n.coordinate, coordinateB)
+          : Promise.resolve(null),
+      ]);
 
       const score = scoreCandidate({
         neighborhood: n,
@@ -100,6 +150,8 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
         coordinate: n.coordinate,
         commuteA,
         commuteB: commuteB ?? undefined,
+        commuteACar: commuteACar ?? undefined,
+        commuteBCar: commuteBCar ?? undefined,
         leisureA: leisureA ?? undefined,
         leisureB: leisureB ?? undefined,
         score,
@@ -113,7 +165,7 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
         listingsCount: n.listingsCount,
         avgArea: n.avgArea,
       };
-    }),
+    },
   );
 
   const candidates = settled

--- a/onday-app/src/lib/external/kakao-car/client.ts
+++ b/onday-app/src/lib/external/kakao-car/client.ts
@@ -1,0 +1,79 @@
+import type { CommuteInfo } from "@/lib/types";
+import type {
+  IKakaoCarClient,
+  KakaoCarCoord,
+  KakaoCarClientConfig,
+  KakaoCarResponse,
+} from "./types";
+import { DEFAULT_KAKAO_CAR_CONFIG, KakaoCarError } from "./types";
+import { mapKakaoCarResponseToCommuteInfo } from "./mapper";
+
+/**
+ * 카카오 모빌리티 자동차 길찾기 클라이언트 — 브라우저 직접 호출 (CORS 허용, 도메인 제한).
+ * ★ W2B: runRealDiagnosis(클라)에서 직장 경로마다 호출. ODsay(/api/commute 프록시)와 병렬.
+ *   카카오는 일 50만급 + 브라우저 직접이라 Vercel 함수/10초/IP 화이트리스트 무관.
+ */
+export class KakaoCarClient implements IKakaoCarClient {
+  private readonly apiKey: string;
+  private readonly config: KakaoCarClientConfig;
+
+  constructor(
+    config: { apiKey: string } & Partial<Omit<KakaoCarClientConfig, "apiKey">>,
+  ) {
+    this.apiKey = config.apiKey;
+    this.config = { ...DEFAULT_KAKAO_CAR_CONFIG, ...config };
+  }
+
+  async getCarCommute(
+    origin: KakaoCarCoord,
+    destination: KakaoCarCoord,
+  ): Promise<CommuteInfo> {
+    const res = await this.fetchWithRetry(origin, destination);
+    return mapKakaoCarResponseToCommuteInfo(res);
+  }
+
+  private async fetchWithRetry(
+    origin: KakaoCarCoord,
+    destination: KakaoCarCoord,
+  ): Promise<KakaoCarResponse> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      try {
+        return await this.fetchOnce(origin, destination);
+      } catch (err) {
+        lastError = err;
+        if (attempt < this.config.maxRetries) {
+          await new Promise((r) => setTimeout(r, this.config.retryDelayMs));
+        }
+      }
+    }
+    throw lastError instanceof Error
+      ? new KakaoCarError(`카카오 자동차 호출 실패: ${lastError.message}`)
+      : new KakaoCarError("카카오 자동차 호출 실패");
+  }
+
+  private async fetchOnce(
+    origin: KakaoCarCoord,
+    destination: KakaoCarCoord,
+  ): Promise<KakaoCarResponse> {
+    const url = new URL(`${this.config.baseUrl}/v1/directions`);
+    // 카카오 directions = "경도,위도" (x,y) 순서.
+    url.searchParams.set("origin", `${origin.x},${origin.y}`);
+    url.searchParams.set("destination", `${destination.x},${destination.y}`);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.config.timeoutMs);
+    try {
+      const res = await fetch(url.toString(), {
+        headers: { Authorization: `KakaoAK ${this.apiKey}` },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        throw new KakaoCarError(`카카오 HTTP ${res.status}`, res.status);
+      }
+      return (await res.json()) as KakaoCarResponse;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/onday-app/src/lib/external/kakao-car/index.ts
+++ b/onday-app/src/lib/external/kakao-car/index.ts
@@ -1,0 +1,9 @@
+export { KakaoCarClient } from "./client";
+export { mapKakaoCarResponseToCommuteInfo } from "./mapper";
+export {
+  KakaoCarError,
+  DEFAULT_KAKAO_CAR_CONFIG,
+  type KakaoCarCoord,
+  type KakaoCarResponse,
+  type IKakaoCarClient,
+} from "./types";

--- a/onday-app/src/lib/external/kakao-car/mapper.ts
+++ b/onday-app/src/lib/external/kakao-car/mapper.ts
@@ -1,0 +1,30 @@
+import type { CommuteInfo } from "@/lib/types";
+import type { KakaoCarResponse } from "./types";
+import { KakaoCarError } from "./types";
+
+/**
+ * 카카오 자동차 길찾기 응답 → CommuteInfo (mode='driving', 환승 없음).
+ * - routes[0] (추천 경로) 사용.
+ * - duration(초) → time(분).
+ * @throws KakaoCarError result_code !== 0 또는 빈 routes.
+ */
+export function mapKakaoCarResponseToCommuteInfo(
+  res: KakaoCarResponse,
+): CommuteInfo {
+  const route = res.routes?.[0];
+  if (!route) {
+    throw new KakaoCarError("카카오 자동차 경로 없음");
+  }
+  if (route.result_code !== 0) {
+    throw new KakaoCarError(
+      `카카오 길찾기 실패: ${route.result_msg}`,
+      route.result_code,
+    );
+  }
+
+  return {
+    time: Math.round(route.summary.duration / 60),
+    mode: "driving",
+    // 자동차 = 환승 없음 (transfers 미설정). fare/distance 는 현재 CommuteInfo 미보유.
+  } satisfies CommuteInfo;
+}

--- a/onday-app/src/lib/external/kakao-car/types.ts
+++ b/onday-app/src/lib/external/kakao-car/types.ts
@@ -1,0 +1,69 @@
+// ──────────────────────────────────────────────
+// 카카오 모빌리티 자동차 길찾기 도메인 — DTO + interface + config.
+// ★ W2B: car=카카오 (transit=ODsay 는 odsay-transit/). 실 /v1/directions 응답 정합.
+//   (기존 kakao-transport/ 는 가상 transit 형태 + dead 소비자(intersection/mocks)라
+//    재작성 대신 본 신규 모듈로 분리 — ODsay 답습. LOG §35.)
+// ★ 카카오 모빌리티 = 브라우저 직접 호출 OK (CORS 허용, 도메인 제한). 서버 프록시 불필요.
+// ──────────────────────────────────────────────
+
+import type { CommuteInfo } from "@/lib/types";
+
+/** 카카오 좌표계 — x=경도(lng), y=위도(lat). 앱 Coordinate {lat,lng} 와 독립. */
+export interface KakaoCarCoord {
+  x: number; // 경도 (lng)
+  y: number; // 위도 (lat)
+}
+
+export interface KakaoCarFare {
+  taxi: number;
+  toll: number;
+}
+
+/** routes[].summary — 실 응답 필드(snake_case). 자동차라 환승 개념 없음. */
+export interface KakaoCarSummary {
+  duration: number; // 초
+  distance: number; // 미터
+  fare: KakaoCarFare;
+}
+
+export interface KakaoCarRoute {
+  result_code: number; // 0 = 성공
+  result_msg: string;
+  summary: KakaoCarSummary;
+  // sections(roads/guides)는 현재 CommuteInfo 미사용.
+}
+
+export interface KakaoCarResponse {
+  routes: KakaoCarRoute[];
+}
+
+export interface KakaoCarClientConfig {
+  baseUrl: string;
+  timeoutMs: number;
+  maxRetries: number;
+  retryDelayMs: number;
+}
+
+export const DEFAULT_KAKAO_CAR_CONFIG: Omit<KakaoCarClientConfig, "apiKey"> = {
+  baseUrl: "https://apis-navi.kakaomobility.com",
+  timeoutMs: 5000, // REQ-FUNC-007 정합
+  maxRetries: 1,
+  retryDelayMs: 500,
+};
+
+export interface IKakaoCarClient {
+  /** 출발→도착 자동차 통근 정보 (mode='driving'). */
+  getCarCommute(
+    origin: KakaoCarCoord,
+    destination: KakaoCarCoord,
+  ): Promise<CommuteInfo>;
+}
+
+export class KakaoCarError extends Error {
+  readonly code?: number;
+  constructor(message: string, code?: number) {
+    super(message);
+    this.name = "KakaoCarError";
+    this.code = code;
+  }
+}

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -20,9 +20,13 @@ export interface CandidateArea {
   dong: string;
   gu: string;
   coordinate: Coordinate;
-  commuteA: CommuteInfo;
+  commuteA: CommuteInfo; // 대중교통(ODsay) — 주 지표·점수 기준 (mock=Haversine 추정)
   commuteB?: CommuteInfo; // nullable for single mode
-  // single 모드 여가거점까지의 통근 정보 (Figma 비전)
+  // ★ W2B 자차(카카오) — 직장 경로 보조(mode='driving', 옵셔널 best-effort).
+  //   대중교통이 주, 자차는 DetailSheet 표시 보조. 실패/mock 시 undefined → 차량 행 생략.
+  commuteACar?: CommuteInfo;
+  commuteBCar?: CommuteInfo;
+  // single 모드 여가거점까지의 통근 정보 (Figma 비전) — 자차 미적용(REQ-FUNC-004 밖)
   leisureA?: CommuteInfo;
   leisureB?: CommuteInfo;
   score: number; // 0-100

--- a/tasks/ISSUE_REGISTER_LOG.md
+++ b/tasks/ISSUE_REGISTER_LOG.md
@@ -1902,3 +1902,68 @@ _본 § 신설: 2026-05-30 (fix/mock-dup-neighborhood — neighborhoods.ts 중�
 | 34 | **REAL-API-W2-ODSAY-TRANSIT** | **#27+#30+#33** | **(커밋 대기)** | **코드+(b) 완료** | **★ ㊧ Mismatch 16번째 (SRS "카카오=대중교통" 사실오류) + B2 아키텍처(ODsay CORS→클라 오케스트레이션) + odsay 신규 모듈 + ScoringEngine 추출(#27) + geocode 잠복버그 수정(keyword.json) + 배지 mode-aware + (b) 실 ODsay 검증(왕십리 22분 transit) + Tier 0 IP 유료 정직 + what-if 후속 분리 + 사전박힘 ~50% 실측** |
 
 _본 § 신설: 2026-05-30 (REAL-API-W2-ODSAY-TRANSIT — 대중교통 실 통근시간). ★ ㊧ Mismatch 16번째 = SRS EXT-01 "카카오 모빌리티=대중교통" 사실오류(실제 car 전용) → 대중교통=ODsay 신규 모듈 + SSoT 역방향 갱신 + ★ B2 아키텍처(ODsay CORS 차단→클라 Haversine 사전필터 + /api/commute 프록시 Promise.all, 함수당 1호출=10초 무관) + ★ odsay-transit 신규(types/client/mapper/index) + ScoringEngine 추출(scoring.ts, #27) + ★ geocode 이중 잠복버그 수정(address.json→keyword.json + camelCase→snake_case, production 첫 실행에서 드러남) + ★ 출처 배지 mode-aware(개인/공유 ODsay 대중교통) + ★ (b) 실 검증 통과(geocode→ODsay 35분 transit→실유저 귀속 저장) + ★ Tier 0 ODsay Server IP 화이트리스트 = Vercel 유동IP 유료 정직 플래그 + ★ what-if 불일치 후속 분리(REAL-API-W2-WHATIF-ODSAY) + ★ 자차 후속(REAL-API-W2B-CAR-COMMUTE, REQ-FUNC-004 나머지) + ★ 사전박힘 ~50% 실측(마스터플랜 70/60% 과대). 자동 머지 X, ISSUE Close X, 프로덕션 flip X._
+
+---
+
+## 35. REAL-API-W2B-CAR-COMMUTE — 자차(카카오) 통근 추가 + 통근 UI 마무리 (2026-05-30 신설 NEW)
+
+**ISSUE:** CMD-DIAG-001(카카오 모빌리티 client API-007) + REQ-FUNC-004(대중교통·자차)
+**브랜치:** `feat/REAL-API-W2B-CAR-COMMUTE`
+**선행 §:** §34 W2 (대중교통 ODsay). REQ-FUNC-004 "양쪽 직장 대중교통·자차" 나머지 절반 완성.
+**grill-me:** R1(commuteACar 필드) / R2(DetailSheet 4행, 카드 컴팩트) / R3(직장만·best-effort·브라우저직접) 합의
+
+### 본 § = 정직 § 9건 누적
+
+**1. ★ 신규 모듈 kakao-car (계획 "kakao-transport 재작성" 조정):**
+- 계획은 kakao-transport 재작성이었으나, 그 types를 **dead 스캐폴딩(intersection.ts + mocks, 앱 미배선)이 OLD transit 형태로 사용** → 재작성 시 tsc 깨짐.
+- → **신규 `lib/external/kakao-car/`(types/client/mapper/index)** 분리(ODsay 답습). kakao-transport는 dead 보존. 계획 의도(실 car 클라) 동일 달성.
+- **★ "계획 means 조정(재작성→신규) 정직" = dead 소비자 회피 정수 NEW**
+
+**2. ㊧ Mismatch (3회째) — kakao-transport types 가상 transit vs 실 car 응답:**
+- 실 car = `routes[].result_code`/`summary.{duration,distance,fare}`(snake_case, 환승 없음). mapper: duration→time, mode='driving'.
+
+**3. ★ 아키텍처 비대칭 — 자차=브라우저 직접 (ODsay=서버 프록시 대비):**
+- 카카오 모빌리티 CORS 허용(localhost echo 확인) + 일 50만급 → runRealDiagnosis 브라우저 직접 호출. ODsay(/api/commute 프록시, CORS 차단)와 대조. 각 API 특성에 맞춤.
+
+**4. 모델 = commuteACar?/commuteBCar? 옵셔널 (R1):**
+- commuteA=transit 유지(점수 기준·기존 읽기 무변경) + car 옵셔널 신규. mock=car 안 만듦→undefined→회귀 0.
+
+**5. UI = DetailSheet 수단별 그룹 (R2 + PM 피드백):**
+- [🚆 대중교통] A/B / [🚗 차량] A/B (TrainFront/Car 아이콘) + "동네→직장" 방향 라벨. 행 카드 토큰 보존. 카드 리스트 컴팩트 유지(REQ-FUNC-004 "탭했을 때"). key tag→tag-mode 가드.
+
+**6. ★ 방향 swap (#3 PM 발견) — 직장→동네 → 동네→직장:**
+- 기존(W2부터) origin=직장이라 의미 거꾸로 → origin=동네(집)로 swap (출퇴근 의미론). 값은 대칭이라 비슷하나 라벨·의미 정정.
+
+**7. ★ 자차 best-effort — 회귀 격리:**
+- 대중교통 필수(없으면 후보 제외), 자차 보조(실패→commuteACar undefined→차량 그룹 생략, 후보·점수 무영향). 점수=transit 고정.
+
+**8. ★ ODsay 초당 throttle 발견 → 동시호출 cap (실 검증 중):**
+- Promise.all 버스트(~20+)가 ODsay 초당 제한 초과 → 429(Too Many Requests). 단일 호출은 성공(일 한도 아님) 판별.
+- → `mapWithConcurrency`(배치 4) 추가 = 동시 ODsay 최대 4 → 429 해소(48ca44a9 후보7 정상). **★ B2 timeout 회피와 별개의 throttle 정수 NEW**
+
+**9. (b) 실 검증 통과:**
+- geocode→ODsay+카카오 car→실유저(33deaf63) 귀속 저장. car보유 진단 확인(정자동 대중22/차량35, 서현동 27/43 = 강남 체증 현실 반영). DetailSheet 그룹/아이콘/방향 라벨 확인. mock 무변경.
+
+**what-if(시간대 변경) 차량 사라짐 = REAL-API-W2-WHATIF-ODSAY 후속** (result what-if = runMockDiagnosis Haversine, car 미호출). W2B 새 버그 아님 — 초기 진단(ODsay+car)은 완성. 후속에서 what-if를 ODsay+kakao 재호출로.
+
+### Phase B 한계 § 22번째 (14단계 답습)
+
+체인: … → MASTER-PLAN → W1-DB → W1-AUTH → W2-ODSAY → **W2B-CAR**
+
+### 차후 ISSUE 후보 영역 누적 표 갱신 (2026-05-30 기준)
+
+| 후보 ISSUE | 트리거 | 영역 | 상태 |
+|---|---|---|---|
+| **REAL-API-W2B-CAR-COMMUTE** | (본 §) | 자차 통근 + 통근 UI | **코드+(b) 완료 / 르르 머지·Close 대기** |
+| **REAL-API-W2-WHATIF-ODSAY** | what-if 재계산 | result 필터/시간대 변경 = ODsay+kakao 재호출 (현 Haversine + car 미호출) | 후속 |
+| **REAL-API-COMMUTE-DEPARTURE-TIME** (NEW) | 출퇴근 정확도 | 08:00 출발시간을 ODsay/카카오 호출에 연결 (현 현재시각) | 후속 (API 제약) |
+| ODsay 프로덕션 고정 IP / 후보 수 튜닝 | (기존) | (기존) | flip / 후속 |
+
+### 본 세션 누적 35건 § 박힘 표 (★ Phase B 한계 § 22번째)
+
+| § | 영역 | ISSUE | PR | 상태 | 답습 정수 |
+|---|---|---|---|---|---|
+| 34 | REAL-API-W2-ODSAY-TRANSIT | #27+#30+#33 | #142 머지 | 완료 | (기존) |
+| 35 | **REAL-API-W2B-CAR-COMMUTE** | **CMD-DIAG-001/REQ-FUNC-004** | **(커밋 대기)** | **코드+(b) 완료** | **★ kakao-car 신규(재작성 조정) + ㊧ Mismatch 3회째 + 자차 브라우저직접(ODsay 프록시 비대칭) + commuteACar 옵셔널 + DetailSheet 수단별 그룹+아이콘 + 방향 swap(동네→직장, #3) + best-effort 회귀격리 + ODsay 초당 throttle cap(배치4) + (b) car 저장 검증 + what-if/departureTime 후속 분리** |
+
+_본 § 신설: 2026-05-30 (REAL-API-W2B-CAR-COMMUTE — 자차 카카오 + 통근 UI 마무리). ★ Phase B 한계 § 22번째(14단계) + 신규 kakao-car 모듈(계획 재작성→신규 조정, dead 소비자 회피) + ㊧ Mismatch 3회째(가상 transit vs 실 car) + ★ 자차=브라우저 직접(ODsay 서버프록시 비대칭, 각 API 특성) + commuteACar?/BCar? 옵셔널(회귀0) + DetailSheet 수단별 그룹(🚆/🚗 + 동네→직장 라벨, 카드 컴팩트 유지) + ★ 방향 swap(#3 PM 발견, 직장→동네 의미 정정) + 자차 best-effort 격리(점수=transit) + ★ ODsay 초당 throttle → mapWithConcurrency 배치4 cap(429 해소) + (b) 실 car 저장 검증(정자동 대중22/차량35) + what-if(REAL-API-W2-WHATIF-ODSAY)·출발시간(REAL-API-COMMUTE-DEPARTURE-TIME) 후속 분리. 자동 머지 X, ISSUE Close X, 프로덕션 flip X._


### PR DESCRIPTION
## Summary
REQ-FUNC-004 "양쪽 직장 **대중교통·자차**" 나머지 절반 — 직장 경로에 **자차(카카오 모빌리티)** 추가. W2(ODsay 대중교통) 위에 "통근 둘 다" 완성. + 통근 DetailSheet UI 마무리(수단별 그룹/아이콘/방향).

✅ **(a) 코드 + (b) 로컬 실 검증 완료.** 프로덕션 flip 안 함(USE_MOCK 미설정 → mock fallback = 무변경).

## 결정 (grill-me)
- **R1** `commuteACar?`/`commuteBCar?` 옵셔널 필드 (commuteA=transit 유지, 회귀0).
- **R2** 자차 = DetailSheet(탭) 4행, 카드 컴팩트 유지 (REQ-FUNC-004 "탭했을 때").
- **R3** 직장만(여가 제외) + best-effort + **카카오 브라우저 직접**(ODsay 서버프록시와 비대칭, 각 API 특성).

## 변경 (2 커밋)
**`258f89d` 자차 백엔드 + cap**
- `lib/external/kakao-car/` (신규) — 실 car 응답(result_code/duration/fare) 정합, mode='driving', 브라우저 직접 + timeout/retry. (계획 "kakao-transport 재작성"은 dead 소비자(intersection/mocks) tsc 충돌로 **신규 모듈 조정** — ODsay 답습.)
- `CandidateArea` + commuteACar?/commuteBCar?.
- `run-real-diagnosis`: 직장 KakaoCar 브라우저 직접 + ODsay 병렬, **best-effort**. **방향 swap(#3): 직장→동네 → 동네→직장**(출퇴근 의미). **ODsay 429 → `mapWithConcurrency` 배치4 cap**.

**`d02924d` 통근 UI**
- `buildCommuteRows`: 대중교통 + 자차 행. `DetailSheet`: **[🚆 대중교통] A/B / [🚗 차량] A/B** + "동네→직장" 라벨. 행 카드 토큰 보존, key tag→tag-mode.

## Test plan
- [x] tsc 0 / ESLint 0 / 인코딩 0
- [x] mock 무변경 (car undefined, 회귀0) / commuteA 읽기 무변경
- [x] KakaoCar 강남→판교 = **33분 driving**
- [x] **(b) 실 검증**: geocode→ODsay+카카오→실유저(33deaf63) car 저장 (정자동 대중22/차량35, 서현동 27/43 = 강남 체증 현실) + DetailSheet 그룹/아이콘/방향 라벨 + cap 후 429 해소(후보7)

## DEFER / 후속
- **REAL-API-W2-WHATIF-ODSAY**: 시간대/필터 what-if = runMockDiagnosis(Haversine)라 차량 사라짐 → ODsay+kakao 재호출 (초기 진단은 정상)
- **REAL-API-COMMUTE-DEPARTURE-TIME**: 08:00 출발시간 연결 (현 현재시각, API 제약)
- 자차 카드 보조텍스트 / ODsay 프로덕션 고정IP / 후보수 튜닝 / 프로덕션 flip

(GitHub ISSUE 번호 없음 — CMD-DIAG-001/REQ-FUNC-004 관련. Close 키워드 생략, 르르 정합.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)