### PR TITLE
[feat] 지도 시각화 완성 — 부부+싱글 지도 + 찜 목록 + 싱글 데드라인

### DIFF
--- a/onday-app/docs/local-real-demo-recording.md
+++ b/onday-app/docs/local-real-demo-recording.md
@@ -1,0 +1,109 @@
+# 로컬 real 데모 녹화 체크리스트 (경로 2)
+
+> **목적**: 로컬을 real 모드로 띄워 **실제 경로선(🚇 대중교통 정거장선 + 🚗 자동차 도로선)** 을
+> 화면 녹화 → 이력서/포트폴리오 첨부. **라이브 배포는 mock 유지(안정)**.
+
+## 왜 경로 2인가
+
+| | mock (현재 라이브) | 로컬 real (경로 2) | Vercel real 풀배포 (경로 1) |
+|---|---|---|---|
+| 경로선 | 직선 점선 | **실제 경로선** ✅ | 실제 경로선 |
+| 대중교통(ODsay) | — | **동작** (집 IP 등록) ✅ | ⚠️ Vercel 동적 IP → 화이트리스트 불가(유료 고정 IP 필요) |
+| 자동차(Kakao) | — | 동작 ✅ | 동작 (도메인 등록) |
+| 비용/리스크 | 0 | **0** | ODsay 고정 IP(유료) + 도메인 등록 |
+| 형태 | — | **영상** | 라이브 클릭 |
+
+→ 화면은 경로 1과 **동일**. 차이는 "라이브 클릭 vs 영상"뿐이고, 로컬 real은 ODsay 화이트리스트가
+집 IP로 간단히 풀려 **대중교통까지 완전**하다.
+
+핵심 원리: `commuteACar`·`routePath`는 **real 모드(`run-real-diagnosis`)에서만 생성**된다.
+mock(`runMockDiagnosis`)은 haversine 추정만 → 직선. (`NEXT_PUBLIC_USE_MOCK` 토글)
+
+---
+
+## STEP 1 — 집 공인 IP를 ODsay에 등록
+
+ODsay Server 키는 **공인 IP 화이트리스트 강제**라, 내 IP를 등록해야 `/api/commute`가 동작한다.
+
+```bash
+# 내 현재 공인 IP 확인
+curl ifconfig.me
+```
+
+1. [ODsay LAB 콘솔](https://lab.odsay.com) 로그인 → 내 API 키
+2. **허용 IP**에 위에서 확인한 공인 IP 추가 → 저장
+3. (IP가 바뀌면 — 공유기 재시작·망 변경 — 다시 확인 후 갱신)
+
+> 자동차(Kakao)는 브라우저 직접 호출이라 IP 등록 불필요. 단, 카카오 키가 도메인 제한이면
+> `localhost` 가 허용 도메인에 있어야 한다(보통 기본 포함). 401 나면 Kakao 콘솔 Web 도메인에
+> `http://localhost:3000` 확인.
+
+## STEP 2 — 키가 `.env.local`에 있는지 확인
+
+`.env.local`에 아래 4개가 채워져 있어야 한다 (이미 있으면 그대로):
+
+```
+NEXT_PUBLIC_KAKAO_MAP_KEY=...        # 지도 타일 (JavaScript 키)
+NEXT_PUBLIC_KAKAO_REST_API_KEY=...   # 자동차 길찾기 (REST 키, 브라우저 직접)
+ODSAY_API_KEY=...                    # 대중교통 (Server 키, /api/commute)
+# KAKAO_MOBILITY_API_KEY 는 코드 미사용 — 없어도 됨
+```
+
+> `.env.local`의 `NEXT_PUBLIC_USE_MOCK=true`는 **건드리지 않는다**. 아래 STEP 3에서
+> 셸 인라인으로만 override → 평소 `npm run dev`는 mock 그대로 유지.
+
+## STEP 3 — 로컬 real 모드로 띄우기
+
+`.env.local` 파일을 수정하지 않고 **셸 인라인 override**로 real 전환 (mock 기본값 보존):
+
+```bash
+# 기존 dev 서버 종료 + 캐시 삭제 (mock 값이 인라인 박혀있던 stale 방지)
+lsof -ti:3000 | xargs kill -9 2>/dev/null; rm -rf .next
+
+# real 모드 + 로그인은 mock 유지(데모 진입 마찰 0)로 띄우기
+NEXT_PUBLIC_USE_MOCK=false NEXT_PUBLIC_USE_MOCK_AUTH=true npm run dev
+```
+
+- `USE_MOCK=false` → 진단이 ODsay·Kakao 실 호출 (경로선 생성)
+- `USE_MOCK_AUTH=true` → 로그인은 mock(게스트) → 녹화 중 OAuth 안 거침
+- Next.js는 셸 env가 `.env.local`보다 우선 → 파일 안 건드림
+
+## STEP 4 — 진단 후 검증 포인트
+
+http://localhost:3000 → 진단(부부 또는 싱글) 입력 → 결과
+(real이라 실 API 호출로 mock보다 몇 초 더 걸림)
+
+- [ ] 메인 지도: 후보→직장 선이 **🚇 정거장 따라 / 🚗 도로 따라 꺾임** (직선 아님)
+- [ ] 🚇/🚗 **토글 전환** 시 선 모양 바뀜
+- [ ] 카드 탭 → 시트 **통근 정보**에 `대중교통` + `차량` **두 그룹 다** 표시
+- [ ] (싱글) 직장A 파랑 + 여가거점 녹색 마커 + 카드 탭 상세
+- [ ] 결과가 비면 → ODsay IP 미등록 신호 (STEP 1 재확인. commuteA 필수라 실패 시 후보 drop)
+
+## STEP 5 — 화면 녹화 (macOS)
+
+- **단축키**: `Cmd + Shift + 5` → 영역 선택 → 녹화 → 정지(메뉴바 ■)
+- 모바일 비율로 보이게: 브라우저 창 좁히거나 반응형(375px) 뷰
+- 녹화 시나리오 예: 진단 입력 → 결과 지도 → 🚇/🚗 토글 → 카드 탭 → 시트(통근 두 모드) → 찜 → 찜 목록
+
+## 되돌리기 (mock 복귀)
+
+```bash
+lsof -ti:3000 | xargs kill -9 2>/dev/null; rm -rf .next
+npm run dev   # .env.local 기본값(USE_MOCK=true) → mock
+```
+
+라이브(Vercel)는 처음부터 손 안 댔으니 그대로 mock·안정.
+
+---
+
+## 트러블슈팅
+
+| 증상 | 원인 | 해결 |
+|---|---|---|
+| 결과가 빔 / 후보 0개 | ODsay IP 미등록 → commuteA 실패 → 후보 전부 drop | STEP 1 (공인 IP 재확인·등록) |
+| 지도 타일 안 뜨고 격자만 | Kakao Map JS 키 401 (도메인) | Kakao 콘솔 Web 도메인에 `http://localhost:3000` |
+| 자동차 선만 직선 | Kakao REST 키 없음/실패 (자동차 best-effort) | `NEXT_PUBLIC_KAKAO_REST_API_KEY` 확인 |
+| 토글 차량 행 안 나옴 | `commuteACar` 미생성 = mock 모드 | STEP 3 인라인 override 확인 (`USE_MOCK=false`) |
+| 셸 종료해도 mock 안 돌아옴 | `.next` 캐시 stale | `rm -rf .next` 후 재시작 |
+
+> 참고: 경로 1(Vercel 풀배포)은 `docs/` 외 별도 — ODsay 고정 출站 IP(Vercel Pro 유료) 해결이 전제.

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -24,7 +24,11 @@ import {
   sortCandidates,
   toChipMode,
 } from "@/features/diagnosis/result-utils";
-import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
+import {
+  estimateCommuteMinutes,
+  haversineDistance,
+  rushHourFactor,
+} from "@/lib/haversine";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
 import { latLngToPixel } from "@/lib/coordinate-transform";
 import type { CandidateArea, CommuteInfo, DiagnosisFilters } from "@/lib/types";
@@ -49,6 +53,62 @@ interface ResultContentProps {
   onShare: () => void | Promise<void>;
 }
 
+// what-if(시간/통근/예산) 재계산 — ★ 후보 재선정 대신 고정 baseline 세트를 in-place 갱신.
+//   기존 runMockDiagnosis 는 풀에서 top-N 을 다시 뽑아(mock 점수) 세트가 바뀌고 → 새 후보엔
+//   routePath/자동차 없음(버그1) + 자동차 시간 미반영(버그2). 본 함수는 세트·순위·routePath 고정,
+//   통근 '분'만 재계산해 두 버그 동시 해소.
+//   · 대중교통: estimateCommuteMinutes(거리, 출발시각) — 러시아워 계수 반영
+//   · 자동차: 실 Kakao 기준시간 × rushHourFactor (거리추정은 도로보다 짧아 부정확 → 기준값 보존)
+//   · routePath(정거장/도로선)·순위(점수)·여가는 baseline 그대로 유지, 필터만 재적용.
+function recomputeWhatIf(
+  baseline: CandidateArea[],
+  filters: DiagnosisFilters,
+  coordA: { lat: number; lng: number },
+  coordB: { lat: number; lng: number } | null | undefined,
+): CandidateArea[] {
+  const depTime = filters.commuteSchedule?.departureTime;
+  const carFactor = rushHourFactor(depTime);
+  return baseline
+    .map((c) => {
+      const distA = haversineDistance(coordA, c.coordinate);
+      const next: CandidateArea = {
+        ...c,
+        commuteA: { ...c.commuteA, time: estimateCommuteMinutes(distA, depTime) },
+      };
+      if (coordB && c.commuteB) {
+        const distB = haversineDistance(coordB, c.coordinate);
+        next.commuteB = {
+          ...c.commuteB,
+          time: estimateCommuteMinutes(distB, depTime),
+        };
+      }
+      if (c.commuteACar) {
+        next.commuteACar = {
+          ...c.commuteACar,
+          time: Math.round(c.commuteACar.time * carFactor),
+        };
+      }
+      if (c.commuteBCar) {
+        next.commuteBCar = {
+          ...c.commuteBCar,
+          time: Math.round(c.commuteBCar.time * carFactor),
+        };
+      }
+      return next;
+    })
+    .filter((c) => {
+      if (filters.maxCommuteTime) {
+        const maxC = Math.max(c.commuteA.time, c.commuteB?.time ?? 0);
+        if (maxC > filters.maxCommuteTime) return false;
+      }
+      if (filters.budget && c.priceRange) {
+        const avg = (c.priceRange.min + c.priceRange.max) / 2;
+        if (avg < filters.budget.min || avg > filters.budget.max) return false;
+      }
+      return true;
+    });
+}
+
 export function ResultContent({
   candidates,
   filters,
@@ -67,12 +127,19 @@ export function ResultContent({
   const diagnosisId = useDiagnosisStore((s) => s.diagnosisId);
   const coordinateA = useDiagnosisStore((s) => s.coordinateA);
   const coordinateB = useDiagnosisStore((s) => s.coordinateB);
-  const mode = useDiagnosisStore((s) => s.mode);
-  const leisureCoordA = useDiagnosisStore((s) => s.leisureCoordA);
-  const leisureCoordB = useDiagnosisStore((s) => s.leisureCoordB);
 
   const favorites = useFavoritesStore((s) => s.favorites);
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
+
+  // ★ 첫 진단 결과를 baseline 으로 1회 캡처 — what-if 는 항상 이 고정 세트(routePath·자동차 보유)에서
+  //   재계산해 세트 churn/데이터 소실 방지. setResult 로 store 가 바뀌어도 ref 는 원본 유지.
+  //   (React 19 규칙 — 렌더 중 ref 접근 금지 → effect 에서 캡처. 핸들러는 이벤트라 ref 읽기 허용.)
+  const baselineRef = React.useRef<CandidateArea[] | null>(null);
+  React.useEffect(() => {
+    if (baselineRef.current === null && candidates.length > 0) {
+      baselineRef.current = candidates;
+    }
+  }, [candidates]);
 
   // Issue #111 β — 출근시간 chip 클릭 시 what-if 입력 inline 박힘 토글.
   // Issue #112 — maxCommuteTime + budget chip 클릭 시 what-if 입력 inline 박힘 토글 답습.
@@ -81,7 +148,7 @@ export function ResultContent({
   const [showBudgetOptions, setShowBudgetOptions] = React.useState(false);
   const currentDepartureTime = filters.commuteSchedule?.departureTime ?? "08:00";
 
-  const handleTimeWhatIf = async (time: string) => {
+  const handleTimeWhatIf = (time: string) => {
     if (!coordinateA) {
       pushToast({
         variant: "default",
@@ -97,23 +164,17 @@ export function ResultContent({
       },
     };
     setFilters(newFilters);
-    try {
-      const next = await runMockDiagnosis(
-        coordinateA,
-        coordinateB,
-        newFilters,
-        mode,
-        leisureCoordA,
-        leisureCoordB,
-      );
-      if (diagnosisId) setResult(diagnosisId, next);
-    } catch {
-      pushToast({ variant: "danger", message: "재계산에 실패했습니다" });
-    }
+    const next = recomputeWhatIf(
+      baselineRef.current ?? candidates,
+      newFilters,
+      coordinateA,
+      coordinateB,
+    );
+    if (diagnosisId) setResult(diagnosisId, next);
   };
 
   // Issue #112 — what-if maxCommuteTime/budget 재계산 (★ handleTimeWhatIf 답습).
-  const handleCommuteWhatIf = async (maxCommute: number) => {
+  const handleCommuteWhatIf = (maxCommute: number) => {
     if (!coordinateA) {
       pushToast({
         variant: "default",
@@ -123,22 +184,16 @@ export function ResultContent({
     }
     const newFilters = { ...filters, maxCommuteTime: maxCommute };
     setFilters(newFilters);
-    try {
-      const next = await runMockDiagnosis(
-        coordinateA,
-        coordinateB,
-        newFilters,
-        mode,
-        leisureCoordA,
-        leisureCoordB,
-      );
-      if (diagnosisId) setResult(diagnosisId, next);
-    } catch {
-      pushToast({ variant: "danger", message: "재계산에 실패했습니다" });
-    }
+    const next = recomputeWhatIf(
+      baselineRef.current ?? candidates,
+      newFilters,
+      coordinateA,
+      coordinateB,
+    );
+    if (diagnosisId) setResult(diagnosisId, next);
   };
 
-  const handleBudgetWhatIf = async (min: number, max: number) => {
+  const handleBudgetWhatIf = (min: number, max: number) => {
     if (!coordinateA) {
       pushToast({
         variant: "default",
@@ -148,19 +203,13 @@ export function ResultContent({
     }
     const newFilters = { ...filters, budget: { min, max } };
     setFilters(newFilters);
-    try {
-      const next = await runMockDiagnosis(
-        coordinateA,
-        coordinateB,
-        newFilters,
-        mode,
-        leisureCoordA,
-        leisureCoordB,
-      );
-      if (diagnosisId) setResult(diagnosisId, next);
-    } catch {
-      pushToast({ variant: "danger", message: "재계산에 실패했습니다" });
-    }
+    const next = recomputeWhatIf(
+      baselineRef.current ?? candidates,
+      newFilters,
+      coordinateA,
+      coordinateB,
+    );
+    if (diagnosisId) setResult(diagnosisId, next);
   };
 
   const sorted = React.useMemo(
@@ -227,10 +276,15 @@ export function ResultContent({
     [selectedId, sorted],
   );
 
-  // A-2 — 후보→직장 경로선. 자동차 실 도로(commute*Car.routePath) 있으면 실선,
-  //   없으면(mock·transit·실패) 직선 추정 점선. ★ 메인 맵(focus)·시트(selected) 공용.
+  // 지도 경로 표시 모드 — 🚇 대중교통(주 지표·정거장 선) / 🚗 자동차(실 도로). 기본=대중교통.
+  const [mapMode, setMapMode] = React.useState<"transit" | "car">("transit");
+
+  // 후보→직장 경로선. mode별 실 경로(routePath) 있으면 실선, 없으면(mock·실패) 직선 추정 점선.
+  //   · transit = commuteA/B.routePath(정거장 좌표) — 출발(후보)·도착(직장) 보강
+  //   · car     = commuteACar/BCar.routePath(도로 vertexes) — 이미 양끝 포함
+  //   ★ 메인 맵(focus)·시트(selected) 공용.
   const buildLinesFor = React.useCallback(
-    (cand: CandidateArea | null): MapLine[] => {
+    (cand: CandidateArea | null, mode: "transit" | "car"): MapLine[] => {
       if (!cand) return [];
       const candPoint = {
         position: latLngToPixel(cand.coordinate),
@@ -240,23 +294,25 @@ export function ResultContent({
         id: string,
         variant: "a" | "b",
         wp: typeof coordinateA,
-        car: CommuteInfo | undefined,
+        commute: CommuteInfo | undefined,
       ): MapLine | null => {
         if (!wp) return null;
-        const road = car?.routePath;
-        if (road && road.length >= 2) {
-          // 실 도로 경로 (solid) — Kakao vertexes (후보 → 직장 방향).
+        const route = commute?.routePath;
+        if (route && route.length >= 2) {
+          // transit=정거장만 → 출발·도착 보강 / car=도로 vertexes는 이미 양끝 포함.
+          const coords =
+            mode === "transit" ? [cand.coordinate, ...route, wp] : route;
           return {
             id,
             variant,
             dashed: false,
-            points: road.map((c) => ({
+            points: coords.map((c) => ({
               coordinate: c,
               position: latLngToPixel(c),
             })),
           };
         }
-        // 직선 추정 (dashed) — A-1 fallback.
+        // 직선 추정 (dashed) — 실 경로 없을 때(mock·실패) fallback.
         return {
           id,
           variant,
@@ -264,17 +320,19 @@ export function ResultContent({
           points: [candPoint, { position: latLngToPixel(wp), coordinate: wp }],
         };
       };
+      const aCommute = mode === "transit" ? cand.commuteA : cand.commuteACar;
+      const bCommute = mode === "transit" ? cand.commuteB : cand.commuteBCar;
       return [
-        build("line-a", "a", coordinateA, cand.commuteACar),
-        build("line-b", "b", coordinateB, cand.commuteBCar),
+        build("line-a", "a", coordinateA, aCommute),
+        build("line-b", "b", coordinateB, bCommute),
       ].filter((l): l is MapLine => l !== null);
     },
     [coordinateA, coordinateB],
   );
 
   const lines = React.useMemo(
-    () => buildLinesFor(focusCandidate),
-    [buildLinesFor, focusCandidate],
+    () => buildLinesFor(focusCandidate, mapMode),
+    [buildLinesFor, focusCandidate, mapMode],
   );
 
   // B — DetailSheet 지도: 선택 후보 1곳 + 두 직장 + 연결선 (전체 fit).
@@ -295,8 +353,39 @@ export function ResultContent({
     [selectedCandidate, selectedRank],
   );
   const detailLines = React.useMemo(
-    () => buildLinesFor(selectedCandidate),
-    [buildLinesFor, selectedCandidate],
+    () => buildLinesFor(selectedCandidate, mapMode),
+    [buildLinesFor, selectedCandidate, mapMode],
+  );
+
+  // 🚇/🚗 경로 표시 모드 토글 (지도 위 우상단). 통근 정보 [대중교통]/[차량] 그룹과 일관.
+  const mapModeToggle = (
+    <div
+      role="group"
+      aria-label="경로 표시 모드"
+      className="flex rounded-full bg-surface/90 p-0.5 shadow-card backdrop-blur"
+    >
+      {(
+        [
+          ["transit", "🚇 대중교통"],
+          ["car", "🚗 자동차"],
+        ] as const
+      ).map(([m, label]) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => setMapMode(m)}
+          aria-pressed={mapMode === m}
+          className={cn(
+            "rounded-full px-s-2 py-s-1 text-caption-xs font-bold transition-colors",
+            mapMode === m
+              ? "bg-primary text-primary-foreground"
+              : "text-ink-3",
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
   );
 
   const open = (cid: string) => {
@@ -424,6 +513,7 @@ export function ResultContent({
         markers={markers}
         workplaces={workplaces}
         lines={lines}
+        topRightSlot={mapModeToggle}
         onMarkerClick={open}
         height={320}
       />
@@ -487,6 +577,7 @@ export function ResultContent({
               markers={detailMarkers}
               workplaces={workplaces}
               lines={detailLines}
+              topRightSlot={mapModeToggle}
               fitAll
               height={180}
             />

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -409,10 +409,12 @@ export function ResultContent({
           </>
         ) : (
           /* production = 실 ODsay 대중교통 (자차=카카오는 후속) */
+          /* ★ "실시간" → "추정": ODsay 는 시간표 기반 평균(실시간 교통 아님) +
+             시간대 혼잡은 계수 추정 → 실시간이라 표기하면 과장. */
           <DataSourceBadge
             kind="aggregated"
             source="ODsay 대중교통"
-            updatedAt="실시간"
+            updatedAt="추정"
             tone="on-light"
           />
         )}

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -27,7 +27,7 @@ import {
 import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
 import { latLngToPixel } from "@/lib/coordinate-transform";
-import type { CandidateArea, DiagnosisFilters } from "@/lib/types";
+import type { CandidateArea, CommuteInfo, DiagnosisFilters } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useFavoritesStore } from "@/stores/favorites";
@@ -227,28 +227,48 @@ export function ResultContent({
     [selectedId, sorted],
   );
 
+  // A-2 — 자동차 실 도로 경로(commute*Car.routePath) 있으면 실선, 없으면(mock·transit·실패) 직선 추정 점선.
   const lines = React.useMemo<MapLine[]>(() => {
     if (!focusCandidate) return [];
-    const from = {
+    const candPoint = {
       position: latLngToPixel(focusCandidate.coordinate),
       coordinate: focusCandidate.coordinate,
     };
-    const out: MapLine[] = [];
-    if (coordinateA)
-      out.push({
-        id: "line-a",
-        from,
-        to: { position: latLngToPixel(coordinateA), coordinate: coordinateA },
-        variant: "a",
-      });
-    if (coordinateB)
-      out.push({
-        id: "line-b",
-        from,
-        to: { position: latLngToPixel(coordinateB), coordinate: coordinateB },
-        variant: "b",
-      });
-    return out;
+    const build = (
+      id: string,
+      variant: "a" | "b",
+      wp: typeof coordinateA,
+      car: CommuteInfo | undefined,
+    ): MapLine | null => {
+      if (!wp) return null;
+      const road = car?.routePath;
+      if (road && road.length >= 2) {
+        // 실 도로 경로 (solid) — Kakao vertexes (후보 → 직장 방향).
+        return {
+          id,
+          variant,
+          dashed: false,
+          points: road.map((c) => ({
+            coordinate: c,
+            position: latLngToPixel(c),
+          })),
+        };
+      }
+      // 직선 추정 (dashed) — A-1 fallback.
+      return {
+        id,
+        variant,
+        dashed: true,
+        points: [
+          candPoint,
+          { position: latLngToPixel(wp), coordinate: wp },
+        ],
+      };
+    };
+    return [
+      build("line-a", "a", coordinateA, focusCandidate.commuteACar),
+      build("line-b", "b", coordinateB, focusCandidate.commuteBCar),
+    ].filter((l): l is MapLine => l !== null);
   }, [focusCandidate, coordinateA, coordinateB]);
 
   const open = (cid: string) => {

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -227,49 +227,77 @@ export function ResultContent({
     [selectedId, sorted],
   );
 
-  // A-2 — 자동차 실 도로 경로(commute*Car.routePath) 있으면 실선, 없으면(mock·transit·실패) 직선 추정 점선.
-  const lines = React.useMemo<MapLine[]>(() => {
-    if (!focusCandidate) return [];
-    const candPoint = {
-      position: latLngToPixel(focusCandidate.coordinate),
-      coordinate: focusCandidate.coordinate,
-    };
-    const build = (
-      id: string,
-      variant: "a" | "b",
-      wp: typeof coordinateA,
-      car: CommuteInfo | undefined,
-    ): MapLine | null => {
-      if (!wp) return null;
-      const road = car?.routePath;
-      if (road && road.length >= 2) {
-        // 실 도로 경로 (solid) — Kakao vertexes (후보 → 직장 방향).
+  // A-2 — 후보→직장 경로선. 자동차 실 도로(commute*Car.routePath) 있으면 실선,
+  //   없으면(mock·transit·실패) 직선 추정 점선. ★ 메인 맵(focus)·시트(selected) 공용.
+  const buildLinesFor = React.useCallback(
+    (cand: CandidateArea | null): MapLine[] => {
+      if (!cand) return [];
+      const candPoint = {
+        position: latLngToPixel(cand.coordinate),
+        coordinate: cand.coordinate,
+      };
+      const build = (
+        id: string,
+        variant: "a" | "b",
+        wp: typeof coordinateA,
+        car: CommuteInfo | undefined,
+      ): MapLine | null => {
+        if (!wp) return null;
+        const road = car?.routePath;
+        if (road && road.length >= 2) {
+          // 실 도로 경로 (solid) — Kakao vertexes (후보 → 직장 방향).
+          return {
+            id,
+            variant,
+            dashed: false,
+            points: road.map((c) => ({
+              coordinate: c,
+              position: latLngToPixel(c),
+            })),
+          };
+        }
+        // 직선 추정 (dashed) — A-1 fallback.
         return {
           id,
           variant,
-          dashed: false,
-          points: road.map((c) => ({
-            coordinate: c,
-            position: latLngToPixel(c),
-          })),
+          dashed: true,
+          points: [candPoint, { position: latLngToPixel(wp), coordinate: wp }],
         };
-      }
-      // 직선 추정 (dashed) — A-1 fallback.
-      return {
-        id,
-        variant,
-        dashed: true,
-        points: [
-          candPoint,
-          { position: latLngToPixel(wp), coordinate: wp },
-        ],
       };
-    };
-    return [
-      build("line-a", "a", coordinateA, focusCandidate.commuteACar),
-      build("line-b", "b", coordinateB, focusCandidate.commuteBCar),
-    ].filter((l): l is MapLine => l !== null);
-  }, [focusCandidate, coordinateA, coordinateB]);
+      return [
+        build("line-a", "a", coordinateA, cand.commuteACar),
+        build("line-b", "b", coordinateB, cand.commuteBCar),
+      ].filter((l): l is MapLine => l !== null);
+    },
+    [coordinateA, coordinateB],
+  );
+
+  const lines = React.useMemo(
+    () => buildLinesFor(focusCandidate),
+    [buildLinesFor, focusCandidate],
+  );
+
+  // B — DetailSheet 지도: 선택 후보 1곳 + 두 직장 + 연결선 (전체 fit).
+  const detailMarkers = React.useMemo(
+    () =>
+      selectedCandidate
+        ? [
+            {
+              id: selectedCandidate.id,
+              label: markerLabel(selectedCandidate.dong),
+              position: latLngToPixel(selectedCandidate.coordinate),
+              coordinate: selectedCandidate.coordinate,
+              selected: true,
+              rank: selectedRank,
+            },
+          ]
+        : [],
+    [selectedCandidate, selectedRank],
+  );
+  const detailLines = React.useMemo(
+    () => buildLinesFor(selectedCandidate),
+    [buildLinesFor, selectedCandidate],
+  );
 
   const open = (cid: string) => {
     setSelectedId(cid);
@@ -452,6 +480,15 @@ export function ResultContent({
           liked={Boolean(favorites[selectedCandidate.id])}
           onLike={handleLike}
           onShare={onShare}
+          map={
+            <MapCanvas
+              markers={detailMarkers}
+              workplaces={workplaces}
+              lines={detailLines}
+              fitAll
+              height={180}
+            />
+          }
           commuteExtra={
             <TimeSlotSelector
               value={currentDepartureTime}

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -34,7 +34,7 @@ import { latLngToPixel } from "@/lib/coordinate-transform";
 import type { CandidateArea, CommuteInfo, DiagnosisFilters } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
-import { useFavoritesStore } from "@/stores/favorites";
+import { useFavoritesStore, toFavoriteSnapshot } from "@/stores/favorites";
 import { useUIStore } from "@/stores/ui";
 
 import { BudgetChipOptions } from "./budget-chip-options";
@@ -402,7 +402,7 @@ export function ResultContent({
   const handleLike = () => {
     if (!selectedCandidate) return;
     const wasLiked = Boolean(favorites[selectedCandidate.id]);
-    toggleFavorite(selectedCandidate.id);
+    toggleFavorite(toFavoriteSnapshot(selectedCandidate, "couple"));
     pushToast({
       variant: wasLiked ? "default" : "ok",
       message: wasLiked

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -7,6 +7,7 @@ import { CandidateCard } from "@/components/card/candidate-card";
 import { DataSourceBadge } from "@/components/data/data-source-badge";
 import { FilterPanel } from "@/components/form/filter-panel";
 import { MapCanvas } from "@/components/map/map-canvas";
+import type { MapWorkplace, MapLine } from "@/components/map/map-canvas";
 import { DetailSheet } from "@/components/sheet/detail-sheet";
 import {
   buildCommuteRows,
@@ -191,6 +192,65 @@ export function ResultContent({
     [sorted, selectedId],
   );
 
+  // A-1 (#졸업) — 직장 A·B 마커 + (선택/1위 후보 → 직장) 직선 연결선.
+  //   ★ couple=A·B 둘, single=A 만 (B 좌표 부재 시 자동 생략). 선은 focus 후보 1곳만 = 클러터 방지.
+  //   선 = 직선 추정(점선) — A-2에서 자동차 실 도로선(Kakao vertexes)으로 교체 예정.
+  const workplaces = React.useMemo<MapWorkplace[]>(() => {
+    const out: MapWorkplace[] = [];
+    if (coordinateA)
+      out.push({
+        id: "wp-a",
+        label: "내 직장",
+        short: "A",
+        coordinate: coordinateA,
+        position: latLngToPixel(coordinateA),
+        variant: "a",
+      });
+    if (coordinateB)
+      out.push({
+        id: "wp-b",
+        label: "배우자 직장",
+        short: "B",
+        coordinate: coordinateB,
+        position: latLngToPixel(coordinateB),
+        variant: "b",
+      });
+    return out;
+  }, [coordinateA, coordinateB]);
+
+  // focus = 선택 마커 → 없으면 1위 후보 (로드 직후에도 선이 보이게).
+  const focusCandidate = React.useMemo(
+    () =>
+      (selectedId ? sorted.find((c) => c.id === selectedId) : null) ??
+      sorted[0] ??
+      null,
+    [selectedId, sorted],
+  );
+
+  const lines = React.useMemo<MapLine[]>(() => {
+    if (!focusCandidate) return [];
+    const from = {
+      position: latLngToPixel(focusCandidate.coordinate),
+      coordinate: focusCandidate.coordinate,
+    };
+    const out: MapLine[] = [];
+    if (coordinateA)
+      out.push({
+        id: "line-a",
+        from,
+        to: { position: latLngToPixel(coordinateA), coordinate: coordinateA },
+        variant: "a",
+      });
+    if (coordinateB)
+      out.push({
+        id: "line-b",
+        from,
+        to: { position: latLngToPixel(coordinateB), coordinate: coordinateB },
+        variant: "b",
+      });
+    return out;
+  }, [focusCandidate, coordinateA, coordinateB]);
+
   const open = (cid: string) => {
     setSelectedId(cid);
     setOpenId(cid);
@@ -310,7 +370,13 @@ export function ResultContent({
         )}
       </section>
 
-      <MapCanvas markers={markers} onMarkerClick={open} height={320} />
+      <MapCanvas
+        markers={markers}
+        workplaces={workplaces}
+        lines={lines}
+        onMarkerClick={open}
+        height={320}
+      />
 
       <SortControl total={sorted.length} />
 

--- a/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
@@ -12,6 +12,7 @@ import {
 import { DeadlineBanner } from "@/components/deadline/deadline-banner";
 import { DeadlineBell } from "@/components/deadline/deadline-bell";
 import { DeadlineEntryCard } from "@/components/deadline/deadline-entry-card";
+import { FavoritesMenu } from "@/components/favorites/favorites-menu";
 import { EmptyState } from "@/components/diagnosis/empty-state";
 import { AppHeader } from "@/components/layout/app-header";
 import { Button } from "@/components/ui/button";
@@ -147,6 +148,7 @@ export function ResultView({ id }: ResultViewProps) {
         title={headerTitle}
         trailing={
           <>
+            <FavoritesMenu />
             <DeadlineBell />
             <Button
               variant="outline"

--- a/onday-app/src/app/diagnosis/result/[id]/time-slot-selector.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/time-slot-selector.tsx
@@ -22,7 +22,7 @@ export function TimeSlotSelector({
 }: TimeSlotSelectorProps) {
   return (
     <div className={cn("space-y-s-2", className)}>
-      <p className="text-caption text-ink-3">출근 시간대 시뮬레이션</p>
+      <p className="text-caption text-ink-3">출근 시간대 예상 시뮬레이션</p>
       <Tabs
         value={value}
         onValueChange={(next) => onChange(next as TimeSlot)}

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -6,6 +6,9 @@ import { AlertCircle, ChevronLeft, Filter, FileDown } from "lucide-react";
 
 import { SafetyCard } from "@/components/card/safety-card";
 import { LegendBar } from "@/components/data/legend-bar";
+import { MapCanvas } from "@/components/map/map-canvas";
+import type { MapWorkplace, MapLine } from "@/components/map/map-canvas";
+import { DetailSheet } from "@/components/sheet/detail-sheet";
 import { DeadlineBanner } from "@/components/deadline/deadline-banner";
 import { DeadlineBell } from "@/components/deadline/deadline-bell";
 import { AppHeader } from "@/components/layout/app-header";
@@ -20,8 +23,16 @@ import {
   getRadiusSub,
 } from "@/features/single/safety-stats";
 import { getSafetyByGu } from "@/features/single/safety-index";
+import { buildSinglePills, buildSingleMetrics } from "@/features/single/detail-mapper";
+import { markerLabel } from "@/features/diagnosis/result-utils";
+import { buildCommuteRows, buildLines } from "@/features/diagnosis/detail-mapper";
+import { latLngToPixel } from "@/lib/coordinate-transform";
+import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
+import { copyToClipboard } from "@/lib/utils/clipboard";
+import { cn } from "@/lib/utils";
 import type { CandidateArea, SafetyGrade } from "@/lib/types";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
+import { useFavoritesStore } from "@/stores/favorites";
 import { useUIStore } from "@/stores/ui";
 
 import { LayerToggle, type SingleLayer } from "./layer-toggle";
@@ -107,6 +118,12 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   const storeCandidates = useDiagnosisStore((s) => s.candidates);
   const storeAddressA = useDiagnosisStore((s) => s.addressA);
   const setResult = useDiagnosisStore((s) => s.setResult);
+  // 지도 마커용 좌표 — 부부 모드와 동일하게 store 직접 참조(같은 세션에서만 표시).
+  const coordinateA = useDiagnosisStore((s) => s.coordinateA);
+  const leisureCoordA = useDiagnosisStore((s) => s.leisureCoordA);
+  const leisureCoordB = useDiagnosisStore((s) => s.leisureCoordB);
+  const favorites = useFavoritesStore((s) => s.favorites);
+  const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
 
   const inSync = storeId === id && storeCandidates.length > 0;
   const query = useDiagnosis(inSync ? null : id);
@@ -134,6 +151,207 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   );
 
   const legend = LEGEND_META[layer];
+
+  // 지도 마커: 직장 A(파랑) + 여가거점 1~2(녹색). 좌표 없으면 자동 생략(공유링크/새로고침).
+  const workplaces = React.useMemo<MapWorkplace[]>(() => {
+    const out: MapWorkplace[] = [];
+    if (coordinateA)
+      out.push({
+        id: "wp-a",
+        label: "내 직장",
+        short: "A",
+        coordinate: coordinateA,
+        position: latLngToPixel(coordinateA),
+        variant: "a",
+      });
+    // 거점 2곳이면 "여가거점 1/2"로 번호 구분, 1곳이면 번호 생략.
+    const twoLeisure = Boolean(leisureCoordA && leisureCoordB);
+    if (leisureCoordA)
+      out.push({
+        id: "leisure-a",
+        label: twoLeisure ? "여가거점 1" : "여가거점",
+        short: "♥",
+        coordinate: leisureCoordA,
+        position: latLngToPixel(leisureCoordA),
+        variant: "leisure",
+      });
+    if (leisureCoordB)
+      out.push({
+        id: "leisure-b",
+        label: twoLeisure ? "여가거점 2" : "여가거점",
+        short: "♥",
+        coordinate: leisureCoordB,
+        position: latLngToPixel(leisureCoordB),
+        variant: "leisure",
+      });
+    return out;
+  }, [coordinateA, leisureCoordA, leisureCoordB]);
+
+  // 후보 마커 — 안전순 1위부터 회색 원+순위 (부부 모드 메인 맵과 동일).
+  const markers = React.useMemo(
+    () =>
+      sorted.map((c, i) => ({
+        id: c.id,
+        label: markerLabel(c.dong),
+        position: latLngToPixel(c.coordinate),
+        coordinate: c.coordinate,
+        rank: i + 1,
+      })),
+    [sorted],
+  );
+
+  // 지도 경로 표시 모드 — 🚇 대중교통(ODsay 정거장) / 🚗 자동차(Kakao 도로 vertexes). 부부와 일관.
+  const [mapMode, setMapMode] = React.useState<"transit" | "car">("transit");
+
+  // 후보 → 직장 A 연결선 1줄 (여가거점은 마커로 위치만). 메인 맵(focus)·시트(selected) 공용.
+  //   · transit = commuteA.routePath(정거장) — 출발(후보)·도착(직장) 보강
+  //   · car     = commuteACar.routePath(도로 vertexes) — 이미 양끝 포함
+  //   실 경로 없으면(mock·실패) 직선 점선 fallback.
+  const buildLineForMode = React.useCallback(
+    (cand: CandidateArea | null, mode: "transit" | "car"): MapLine[] => {
+      if (!cand || !coordinateA) return [];
+      const commute = mode === "transit" ? cand.commuteA : cand.commuteACar;
+      const route = commute?.routePath;
+      if (route && route.length >= 2) {
+        const coords =
+          mode === "transit" ? [cand.coordinate, ...route, coordinateA] : route;
+        return [
+          {
+            id: "line-a",
+            variant: "a",
+            dashed: false,
+            points: coords.map((c) => ({
+              coordinate: c,
+              position: latLngToPixel(c),
+            })),
+          },
+        ];
+      }
+      return [
+        {
+          id: "line-a",
+          variant: "a",
+          dashed: true,
+          points: [
+            {
+              coordinate: cand.coordinate,
+              position: latLngToPixel(cand.coordinate),
+            },
+            { coordinate: coordinateA, position: latLngToPixel(coordinateA) },
+          ],
+        },
+      ];
+    },
+    [coordinateA],
+  );
+
+  const focusCandidate = sorted[0] ?? null;
+  const lines = React.useMemo(
+    () => buildLineForMode(focusCandidate, mapMode),
+    [buildLineForMode, focusCandidate, mapMode],
+  );
+
+  // 카드 탭 → 상세 시트. 싱글은 배우자(B) 없음 → 직장A·여가거점·야간안전 중심.
+  const [openId, setOpenId] = React.useState<string | null>(null);
+  const selectedCandidate = React.useMemo(
+    () => (openId ? sorted.find((c) => c.id === openId) ?? null : null),
+    [openId, sorted],
+  );
+  const selectedRank = selectedCandidate
+    ? sorted.findIndex((c) => c.id === selectedCandidate.id) + 1
+    : 0;
+
+  // 시트 지도 — 선택 후보 1곳 focus + 직장A·여가거점 + 연결선 (전체 fit).
+  const detailMarkers = React.useMemo(
+    () =>
+      selectedCandidate
+        ? [
+            {
+              id: selectedCandidate.id,
+              label: markerLabel(selectedCandidate.dong),
+              position: latLngToPixel(selectedCandidate.coordinate),
+              coordinate: selectedCandidate.coordinate,
+              selected: true,
+              rank: selectedRank,
+            },
+          ]
+        : [],
+    [selectedCandidate, selectedRank],
+  );
+  const detailLines = React.useMemo(
+    () => buildLineForMode(selectedCandidate, mapMode),
+    [buildLineForMode, selectedCandidate, mapMode],
+  );
+
+  // 🚇/🚗 경로 표시 모드 토글 (지도 위 우상단). 시트 통근정보 [대중교통]/[차량] 그룹과 일관.
+  const mapModeToggle = (
+    <div
+      role="group"
+      aria-label="경로 표시 모드"
+      className="flex rounded-full bg-surface/90 p-0.5 shadow-card backdrop-blur"
+    >
+      {(
+        [
+          ["transit", "🚇 대중교통"],
+          ["car", "🚗 자동차"],
+        ] as const
+      ).map(([m, label]) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => setMapMode(m)}
+          aria-pressed={mapMode === m}
+          className={cn(
+            "rounded-full px-s-2 py-s-1 text-caption-xs font-bold transition-colors",
+            mapMode === m ? "bg-primary text-primary-foreground" : "text-ink-3",
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+
+  const open = (cid: string) => setOpenId(cid);
+
+  const handleLike = () => {
+    if (!selectedCandidate) return;
+    const wasLiked = Boolean(favorites[selectedCandidate.id]);
+    toggleFavorite(selectedCandidate.id);
+    pushToast({
+      variant: wasLiked ? "default" : "ok",
+      message: wasLiked
+        ? "찜 목록에서 뺐어요"
+        : `${selectedCandidate.gu} ${selectedCandidate.dong} 찜!`,
+    });
+  };
+
+  // 공유 — couple과 동일 흐름(/api/share POST → 링크 복사). 커플 브릿지(파트너 공유)의 기반.
+  const [isSharing, setIsSharing] = React.useState(false);
+  const handleShare = async () => {
+    if (isSharing) return;
+    setIsSharing(true);
+    try {
+      const res = await fetch("/api/share", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ diagnosisId: id }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "공유 링크 생성에 실패했습니다");
+      }
+      const data: { shareUrl: string } = await res.json();
+      await copyToClipboard(`${window.location.origin}${data.shareUrl}`);
+      pushToast({ variant: "ok", message: "공유 링크가 복사되었습니다" });
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "공유 링크 생성에 실패했습니다";
+      pushToast({ variant: "danger", message: msg });
+    } finally {
+      setIsSharing(false);
+    }
+  };
 
   return (
     <main className="flex min-h-screen flex-col bg-bg">
@@ -187,6 +405,17 @@ export function SingleResultView({ id }: SingleResultViewProps) {
               />
             </header>
 
+            {/* 지도 — 직장 A(파랑) + 여가거점(녹색) + 후보(회색·순위) + 1위→직장 연결선.
+                SDK 캔버스는 인쇄 시 빈칸이라 print 숨김 (PDF 리포트는 카드 중심). */}
+            <div className="print:hidden">
+              <MapCanvas
+                markers={markers}
+                workplaces={workplaces}
+                lines={lines}
+                topRightSlot={mapModeToggle}
+              />
+            </div>
+
             <div className="print:hidden">
               <LayerToggle value={layer} onChange={setLayer} />
             </div>
@@ -197,24 +426,32 @@ export function SingleResultView({ id }: SingleResultViewProps) {
               {sorted.map((c) => {
                 const grade = resolveGrade(c);
                 return (
-                  <SafetyCard
+                  <div
                     key={c.id}
-                    name={`${c.gu} ${c.dong}`}
-                    sub={getRadiusSub(c.facilities)}
-                    grade={grade}
-                    gradeLabel={getNightGradeLabel(grade)}
-                    metric={{
-                      label: "야간 범죄율 (10만명당)",
-                      value: getNightCrimeRate(grade),
-                      unit: "건",
-                    }}
-                    barPercent={getCrimePercent(grade)}
-                    stats={[
-                      { label: "통근", value: `${c.commuteA.time}분` },
-                      { label: "시세", value: priceText(c) },
-                      buildLayerStat(c, layer),
-                    ]}
-                  />
+                    className={cn(
+                      "scroll-mt-s-4 rounded-lg transition-shadow",
+                      openId === c.id && "ring-2 ring-primary ring-offset-2",
+                    )}
+                  >
+                    <SafetyCard
+                      name={`${c.gu} ${c.dong}`}
+                      sub={getRadiusSub(c.facilities)}
+                      grade={grade}
+                      gradeLabel={getNightGradeLabel(grade)}
+                      metric={{
+                        label: "야간 범죄율 (10만명당)",
+                        value: getNightCrimeRate(grade),
+                        unit: "건",
+                      }}
+                      barPercent={getCrimePercent(grade)}
+                      stats={[
+                        { label: "통근", value: `${c.commuteA.time}분` },
+                        { label: "시세", value: priceText(c) },
+                        buildLayerStat(c, layer),
+                      ]}
+                      onClick={() => open(c.id)}
+                    />
+                  </div>
                 );
               })}
             </section>
@@ -235,6 +472,55 @@ export function SingleResultView({ id }: SingleResultViewProps) {
             >
               리포트 저장 (PDF)
             </Button>
+
+            {selectedCandidate && (
+              <DetailSheet
+                open={openId !== null}
+                onClose={() => setOpenId(null)}
+                candidate={{
+                  name: `${selectedCandidate.gu} ${selectedCandidate.dong}`,
+                  score: selectedCandidate.score,
+                  pills: buildSinglePills(
+                    selectedCandidate,
+                    selectedRank,
+                    resolveGrade(selectedCandidate),
+                  ),
+                  lines: buildLines(selectedCandidate),
+                  commutes: buildCommuteRows(selectedCandidate, addressA),
+                  metrics: buildSingleMetrics(
+                    selectedCandidate,
+                    resolveGrade(selectedCandidate),
+                  ),
+                }}
+                liked={Boolean(favorites[selectedCandidate.id])}
+                onLike={handleLike}
+                onShare={handleShare}
+                map={
+                  <MapCanvas
+                    markers={detailMarkers}
+                    workplaces={workplaces}
+                    lines={detailLines}
+                    topRightSlot={mapModeToggle}
+                    fitAll
+                    height={180}
+                  />
+                }
+                primaryCta={{
+                  label: selectedCandidate.listingsCount
+                    ? `매물 ${selectedCandidate.listingsCount}건 보기`
+                    : "매물 보기",
+                  onClick: () => {
+                    const url = buildNaverRealEstateUrl(
+                      `${selectedCandidate.gu} ${selectedCandidate.dong}`,
+                      selectedCandidate.priceRange
+                        ? { priceMax: selectedCandidate.priceRange.max }
+                        : {},
+                    );
+                    window.open(url, "_blank", "noopener,noreferrer");
+                  },
+                }}
+              />
+            )}
           </>
         )}
       </div>

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -11,6 +11,7 @@ import type { MapWorkplace, MapLine } from "@/components/map/map-canvas";
 import { DetailSheet } from "@/components/sheet/detail-sheet";
 import { DeadlineBanner } from "@/components/deadline/deadline-banner";
 import { DeadlineBell } from "@/components/deadline/deadline-bell";
+import { DeadlineEntryCard } from "@/components/deadline/deadline-entry-card";
 import { AppHeader } from "@/components/layout/app-header";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
@@ -31,8 +32,9 @@ import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import { cn } from "@/lib/utils";
 import type { CandidateArea, SafetyGrade } from "@/lib/types";
+import { FavoritesMenu } from "@/components/favorites/favorites-menu";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
-import { useFavoritesStore } from "@/stores/favorites";
+import { useFavoritesStore, toFavoriteSnapshot } from "@/stores/favorites";
 import { useUIStore } from "@/stores/ui";
 
 import { LayerToggle, type SingleLayer } from "./layer-toggle";
@@ -317,7 +319,9 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   const handleLike = () => {
     if (!selectedCandidate) return;
     const wasLiked = Boolean(favorites[selectedCandidate.id]);
-    toggleFavorite(selectedCandidate.id);
+    toggleFavorite(
+      toFavoriteSnapshot(selectedCandidate, "single", resolveGrade(selectedCandidate)),
+    );
     pushToast({
       variant: wasLiked ? "default" : "ok",
       message: wasLiked
@@ -358,7 +362,12 @@ export function SingleResultView({ id }: SingleResultViewProps) {
       <AppHeader
         backHref="/diagnosis"
         title="싱글 모드 결과"
-        trailing={<DeadlineBell />}
+        trailing={
+          <>
+            <FavoritesMenu />
+            <DeadlineBell />
+          </>
+        }
       />
 
       <div className="flex-1 px-s-5 pt-s-3 pb-s-8 space-y-s-4">
@@ -379,8 +388,11 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                 발행 {new Date().toLocaleDateString("ko-KR")} · {addressA} 기준
               </p>
             </div>
-            <div className="print:hidden">
+            <div className="print:hidden space-y-s-3">
               <DeadlineBanner />
+              {/* 데드라인 미설정 시 진입 카드 (부부와 패리티) — 계약 역산 + 교집합 급매 보기 → /deadline.
+                  급매 리스트·지도·네이버는 /deadline 공용 라우트가 store candidates로 이미 처리. */}
+              <DeadlineEntryCard />
             </div>
             <header className="flex items-start justify-between gap-s-3 print:hidden">
               <div>

--- a/onday-app/src/components/favorites/favorites-menu.tsx
+++ b/onday-app/src/components/favorites/favorites-menu.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import * as React from "react";
+import { Heart, X, ExternalLink } from "lucide-react";
+
+import { SafetyGradeBadge } from "@/components/data/safety-grade-badge";
+import { BottomSheet } from "@/components/sheet/bottom-sheet";
+import { IconButton } from "@/components/ui/icon-button";
+import { formatPrice } from "@/features/diagnosis/result-utils";
+import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
+import { cn } from "@/lib/utils";
+import { useFavoritesStore } from "@/stores/favorites";
+import type { DiagnosisMode } from "@/lib/types";
+
+const MODE_LABEL: Record<DiagnosisMode, string> = {
+  couple: "부부",
+  single: "싱글",
+};
+
+type ModeFilter = "all" | DiagnosisMode;
+
+// 헤더 우측 하트 — 찜 개수 배지 + 탭 시 찜 목록 바텀시트. 부부·싱글 공통.
+//   찜은 favorites store(localStorage 스냅샷)에서 직접 읽어 모드 무관 재사용.
+export function FavoritesMenu() {
+  const favorites = useFavoritesStore((s) => s.favorites);
+  const remove = useFavoritesStore((s) => s.remove);
+  const [open, setOpen] = React.useState(false);
+  const [modeFilter, setModeFilter] = React.useState<ModeFilter>("all");
+
+  // 최근 찜 먼저.
+  const items = React.useMemo(
+    () => Object.values(favorites).sort((a, b) => b.savedAt - a.savedAt),
+    [favorites],
+  );
+  const count = items.length;
+  const coupleCount = items.filter((i) => i.mode === "couple").length;
+  const singleCount = items.filter((i) => i.mode === "single").length;
+  const visibleItems =
+    modeFilter === "all"
+      ? items
+      : items.filter((i) => i.mode === modeFilter);
+
+  return (
+    <>
+      <span className="relative inline-flex">
+        <IconButton
+          icon={<Heart className={cn(count > 0 && "fill-danger text-danger")} />}
+          ariaLabel={`찜한 동네 ${count}곳 보기`}
+          onClick={() => setOpen(true)}
+        />
+        {count > 0 && (
+          <span
+            aria-hidden
+            className="absolute -right-0.5 -top-0.5 inline-flex min-w-4 items-center justify-center rounded-full bg-danger px-1 text-[10px] font-extrabold leading-4 text-white ring-2 ring-surface"
+          >
+            {count}
+          </span>
+        )}
+      </span>
+
+      <BottomSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        ariaLabel="찜한 동네 목록"
+      >
+        <div className="px-s-5 pb-s-6 pt-s-2">
+          <h2 className="text-title font-extrabold text-ink">
+            찜한 동네 {count > 0 && <span className="text-primary">{count}</span>}
+          </h2>
+
+          {count > 0 && (
+            <div
+              role="tablist"
+              aria-label="찜 모드 분류"
+              className="mt-s-3 flex rounded-full bg-bg p-0.5"
+            >
+              {(
+                [
+                  ["all", "전체", count],
+                  ["couple", "부부", coupleCount],
+                  ["single", "싱글", singleCount],
+                ] as const
+              ).map(([m, label, n]) => (
+                <button
+                  key={m}
+                  type="button"
+                  role="tab"
+                  aria-selected={modeFilter === m}
+                  onClick={() => setModeFilter(m)}
+                  className={cn(
+                    "flex flex-1 items-center justify-center gap-1 rounded-full px-s-2 py-s-2 text-caption font-bold transition-colors",
+                    modeFilter === m
+                      ? "bg-surface text-ink shadow-card"
+                      : "text-ink-3",
+                  )}
+                >
+                  {label}
+                  <span
+                    className={cn(
+                      "inline-flex min-w-[18px] items-center justify-center rounded-full px-1 text-[10px] font-extrabold leading-[18px]",
+                      m === "all"
+                        ? "bg-ink/10 text-ink-2"
+                        : m === "couple"
+                          ? "bg-primary/15 text-primary"
+                          : "bg-success-soft text-success",
+                    )}
+                  >
+                    {n}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {count === 0 ? (
+            <div className="mt-s-5 rounded-lg border border-card-border bg-bg p-s-6 text-center">
+              <Heart aria-hidden className="mx-auto size-7 text-ink-3" />
+              <p className="mt-s-3 text-body font-bold text-ink">
+                아직 찜한 동네가 없어요
+              </p>
+              <p className="mt-s-1 text-body-sm text-ink-3">
+                마음에 드는 동네의 하트를 눌러 저장하세요
+              </p>
+            </div>
+          ) : visibleItems.length === 0 ? (
+            <p className="mt-s-5 text-center text-body-sm text-ink-3">
+              이 모드에 찜한 동네가 없어요
+            </p>
+          ) : (
+            <ul className="mt-s-4 space-y-s-3">
+              {visibleItems.map((it) => (
+                <li
+                  key={it.id}
+                  className="flex items-center gap-s-3 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 shadow-card"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-s-2">
+                      <span
+                        className={cn(
+                          "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-extrabold",
+                          it.mode === "couple"
+                            ? "bg-primary/10 text-primary"
+                            : "bg-success-soft text-success",
+                        )}
+                      >
+                        {MODE_LABEL[it.mode]}
+                      </span>
+                      <p className="truncate text-body font-bold text-ink">
+                        {it.gu} {it.dong}
+                      </p>
+                      {it.safetyGrade ? (
+                        <SafetyGradeBadge grade={it.safetyGrade} />
+                      ) : (
+                        <span className="shrink-0 text-caption-xs font-bold text-primary">
+                          {it.score}점
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-1 truncate text-caption text-ink-3">
+                      통근 {it.commuteA}분
+                      {it.commuteB != null && ` · 배우자 ${it.commuteB}분`} ·{" "}
+                      {formatPrice(it.priceRange)}
+                    </p>
+                  </div>
+
+                  <a
+                    href={buildNaverRealEstateUrl(
+                      `${it.gu} ${it.dong}`,
+                      it.priceRange ? { priceMax: it.priceRange.max } : {},
+                    )}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`${it.gu} ${it.dong} 매물 보기`}
+                    className="inline-flex size-9 shrink-0 items-center justify-center rounded-sm text-ink-3 hover:text-ink"
+                  >
+                    <ExternalLink aria-hidden className="size-4" />
+                  </a>
+                  <button
+                    type="button"
+                    onClick={() => remove(it.id)}
+                    aria-label={`${it.gu} ${it.dong} 찜 해제`}
+                    className="inline-flex size-9 shrink-0 items-center justify-center rounded-sm text-ink-3 hover:text-danger"
+                  >
+                    <X aria-hidden className="size-4" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </BottomSheet>
+    </>
+  );
+}

--- a/onday-app/src/components/map/map-canvas-kakao.tsx
+++ b/onday-app/src/components/map/map-canvas-kakao.tsx
@@ -25,11 +25,12 @@ interface KakaoMarker {
 }
 
 // A-1 (#졸업) — 직장 마커 + 직선 연결선. A=primary(파랑) / B=warning(주황).
+//   ★ single 모드 — variant "leisure"(녹색) = 여가거점 마커 (연결선은 직장만이라 a/b만).
 interface KakaoWorkplace {
   id: string;
   coordinate: Coordinate;
   label: string;
-  variant: "a" | "b";
+  variant: "a" | "b" | "leisure";
 }
 interface KakaoLine {
   id: string;
@@ -38,9 +39,11 @@ interface KakaoLine {
   dashed?: boolean; // true=직선 추정(A-1) / false=실 도로(A-2)
 }
 
-const LINE_COLOR: Record<"a" | "b", string> = {
+// 직장/거점 마커 + 연결선 색. leisure(녹색)=여가거점, 연결선은 a/b만 사용.
+const VARIANT_COLOR: Record<"a" | "b" | "leisure", string> = {
   a: "#2563EB", // primary
   b: "#F59E0B", // warning
+  leisure: "#10B981", // success (emerald)
 };
 
 interface MapCanvasKakaoProps {
@@ -173,7 +176,7 @@ export default function MapCanvasKakao({
           key={l.id}
           path={l.path}
           strokeWeight={l.dashed ? 3 : 5}
-          strokeColor={LINE_COLOR[l.variant]}
+          strokeColor={VARIANT_COLOR[l.variant]}
           strokeOpacity={0.85}
           strokeStyle={l.dashed ? "shortdash" : "solid"}
         />
@@ -219,7 +222,7 @@ export default function MapCanvasKakao({
         >
           <div
             style={{
-              background: LINE_COLOR[w.variant],
+              background: VARIANT_COLOR[w.variant],
               color: "#fff",
               padding: "3px 9px",
               borderRadius: 999,

--- a/onday-app/src/components/map/map-canvas-kakao.tsx
+++ b/onday-app/src/components/map/map-canvas-kakao.tsx
@@ -35,6 +35,7 @@ interface KakaoLine {
   id: string;
   path: Coordinate[];
   variant: "a" | "b";
+  dashed?: boolean; // true=직선 추정(A-1) / false=실 도로(A-2)
 }
 
 const LINE_COLOR: Record<"a" | "b", string> = {
@@ -99,23 +100,40 @@ export default function MapCanvasKakao({
     return () => clearTimeout(timer);
   }, [loading, onFail]);
 
-  // A-1 — 처음 로드 시 모든 마커(직장 A·B + 추천 6개)가 한눈에 들어오도록 자동 줌 맞춤.
-  //   ★ onCreate 1회만 = 카드 선택(line follow) 시엔 재줌 안 함 (사용자 줌/팬 보존).
-  //   (Hook은 early-return 위에 위치해야 함 — rules-of-hooks.)
-  const handleCreate = React.useCallback(
-    (map: kakao.maps.Map) => {
-      const pts = [
-        ...markers.map((m) => m.coordinate),
-        ...workplaces.map((w) => w.coordinate),
-      ];
-      if (pts.length < 2) return;
-      const bounds = new kakao.maps.LatLngBounds();
-      pts.forEach((c) => bounds.extend(new kakao.maps.LatLng(c.lat, c.lng)));
-      // 여백 70px — 마커가 가장자리에 붙지 않고 선 전체가 여유롭게 보이도록.
-      map.setBounds(bounds, 70, 70, 70, 70);
-    },
-    [markers, workplaces],
+  // map 인스턴스 — onCreate 로 받아 useEffect 에서 제어 (sdk 권장 패턴).
+  const [mapInstance, setMapInstance] = React.useState<kakao.maps.Map | null>(
+    null,
   );
+
+  // fit 기준 좌표 — couple=직장 A·B / single fallback=전체. 좌표값 key 로 카드 선택 시 재줌 방지.
+  const fitCoords =
+    workplaces.length >= 2
+      ? workplaces.map((w) => w.coordinate)
+      : [
+          ...markers.map((m) => m.coordinate),
+          ...workplaces.map((w) => w.coordinate),
+        ];
+  const fitKey = fitCoords.map((c) => `${c.lat},${c.lng}`).join("|");
+
+  // A-2 — 처음 로드 시 두 직장이 한눈에 들어오도록 자동 줌 맞춤.
+  //   ★ onCreate 직후 setBounds 는 컨테이너 크기 미확정 → 과도 줌인. map 준비 후
+  //     requestAnimationFrame 으로 1프레임 미뤄 레이아웃 확정 후 relayout+setBounds.
+  //   ★ deps=[mapInstance, fitKey] = 좌표값 변할 때만 (카드 선택=배열 identity만 변경 → 재줌 X).
+  React.useEffect(() => {
+    if (!mapInstance || !fitKey) return;
+    const coords = fitKey.split("|").map((s) => {
+      const [lat, lng] = s.split(",").map(Number);
+      return { lat, lng };
+    });
+    if (coords.length < 2) return;
+    const raf = requestAnimationFrame(() => {
+      const bounds = new kakao.maps.LatLngBounds();
+      coords.forEach((c) => bounds.extend(new kakao.maps.LatLng(c.lat, c.lng)));
+      mapInstance.relayout();
+      mapInstance.setBounds(bounds, 70, 70, 70, 70);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [mapInstance, fitKey]);
 
   if (loading) {
     return (
@@ -140,17 +158,17 @@ export default function MapCanvasKakao({
       level={5}
       aria-label="후보 동네 지도"
       className={cn("rounded-lg", className)}
-      onCreate={handleCreate}
+      onCreate={(map) => setMapInstance(map)}
     >
       {/* A-1 — 후보→직장 직선 연결선 (직선 추정 = 점선). 마커보다 먼저 그려 아래 깔림. */}
       {lines.map((l) => (
         <Polyline
           key={l.id}
           path={l.path}
-          strokeWeight={3}
+          strokeWeight={l.dashed ? 3 : 5}
           strokeColor={LINE_COLOR[l.variant]}
-          strokeOpacity={0.8}
-          strokeStyle="shortdash"
+          strokeOpacity={0.85}
+          strokeStyle={l.dashed ? "shortdash" : "solid"}
         />
       ))}
       {/* 추천지역 마커 — 통일 회색 원 + 순위 숫자 (직장 파랑/주황과 구분). 1위=금색 테두리. */}

--- a/onday-app/src/components/map/map-canvas-kakao.tsx
+++ b/onday-app/src/components/map/map-canvas-kakao.tsx
@@ -53,6 +53,8 @@ interface MapCanvasKakaoProps {
   workplaces?: KakaoWorkplace[];
   /** A-1 — 후보→직장 직선 연결선 (직선 추정 = 점선). */
   lines?: KakaoLine[];
+  /** B — true면 전체 마커(추천+직장) 기준 fit (DetailSheet). 기본=직장 A·B 기준 (메인 맵). */
+  fitAll?: boolean;
   /** SDK 로드 실패/타임아웃 시 호출 — 부모(MapCanvas)가 SVG fallback으로 전환 */
   onFail?: () => void;
 }
@@ -70,6 +72,7 @@ export default function MapCanvasKakao({
   className,
   workplaces = [],
   lines = [],
+  fitAll = false,
   onFail,
 }: MapCanvasKakaoProps) {
   const [loading, error] = useKakaoLoader({ appkey: appKey });
@@ -105,14 +108,16 @@ export default function MapCanvasKakao({
     null,
   );
 
-  // fit 기준 좌표 — couple=직장 A·B / single fallback=전체. 좌표값 key 로 카드 선택 시 재줌 방지.
+  // fit 기준 좌표 — fitAll(시트)=전체 / 기본(메인)=직장 A·B (single은 전체 fallback).
+  //   좌표값 key 로 카드 선택 시 재줌 방지.
+  const allCoords = [
+    ...markers.map((m) => m.coordinate),
+    ...workplaces.map((w) => w.coordinate),
+  ];
   const fitCoords =
-    workplaces.length >= 2
+    !fitAll && workplaces.length >= 2
       ? workplaces.map((w) => w.coordinate)
-      : [
-          ...markers.map((m) => m.coordinate),
-          ...workplaces.map((w) => w.coordinate),
-        ];
+      : allCoords;
   const fitKey = fitCoords.map((c) => `${c.lat},${c.lng}`).join("|");
 
   // A-2 — 처음 로드 시 두 직장이 한눈에 들어오도록 자동 줌 맞춤.
@@ -126,14 +131,16 @@ export default function MapCanvasKakao({
       return { lat, lng };
     });
     if (coords.length < 2) return;
+    // 시트(fitAll)=후보 더 잘 보이게 좁은 여백(35px) / 메인 맵=넉넉히(70px).
+    const pad = fitAll ? 35 : 70;
     const raf = requestAnimationFrame(() => {
       const bounds = new kakao.maps.LatLngBounds();
       coords.forEach((c) => bounds.extend(new kakao.maps.LatLng(c.lat, c.lng)));
       mapInstance.relayout();
-      mapInstance.setBounds(bounds, 70, 70, 70, 70);
+      mapInstance.setBounds(bounds, pad, pad, pad, pad);
     });
     return () => cancelAnimationFrame(raf);
-  }, [mapInstance, fitKey]);
+  }, [mapInstance, fitKey, fitAll]);
 
   if (loading) {
     return (

--- a/onday-app/src/components/map/map-canvas-kakao.tsx
+++ b/onday-app/src/components/map/map-canvas-kakao.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import * as React from "react";
-import { Map, MapMarker, useKakaoLoader } from "react-kakao-maps-sdk";
+import {
+  CustomOverlayMap,
+  Map,
+  Polyline,
+  useKakaoLoader,
+} from "react-kakao-maps-sdk";
 
 import type { Coordinate } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -19,12 +24,34 @@ interface KakaoMarker {
   rank?: number;
 }
 
+// A-1 (#졸업) — 직장 마커 + 직선 연결선. A=primary(파랑) / B=warning(주황).
+interface KakaoWorkplace {
+  id: string;
+  coordinate: Coordinate;
+  label: string;
+  variant: "a" | "b";
+}
+interface KakaoLine {
+  id: string;
+  path: Coordinate[];
+  variant: "a" | "b";
+}
+
+const LINE_COLOR: Record<"a" | "b", string> = {
+  a: "#2563EB", // primary
+  b: "#F59E0B", // warning
+};
+
 interface MapCanvasKakaoProps {
   appKey: string;
   markers: KakaoMarker[];
   height: number;
   onMarkerClick?: (id: string) => void;
   className?: string;
+  /** A-1 — 직장 A·B 마커 (추천지역 마커와 별개). */
+  workplaces?: KakaoWorkplace[];
+  /** A-1 — 후보→직장 직선 연결선 (직선 추정 = 점선). */
+  lines?: KakaoLine[];
   /** SDK 로드 실패/타임아웃 시 호출 — 부모(MapCanvas)가 SVG fallback으로 전환 */
   onFail?: () => void;
 }
@@ -40,21 +67,25 @@ export default function MapCanvasKakao({
   height,
   onMarkerClick,
   className,
+  workplaces = [],
+  lines = [],
   onFail,
 }: MapCanvasKakaoProps) {
   const [loading, error] = useKakaoLoader({ appkey: appKey });
 
+  // 후보 + 직장 마커를 모두 감싸도록 center 계산 (직장이 화면 밖으로 잘리지 않게).
   const center = React.useMemo<Coordinate>(() => {
-    if (markers.length === 0) return SEOUL_CENTER;
-    const sum = markers.reduce(
-      (acc, m) => ({
-        lat: acc.lat + m.coordinate.lat,
-        lng: acc.lng + m.coordinate.lng,
-      }),
+    const coords = [
+      ...markers.map((m) => m.coordinate),
+      ...workplaces.map((w) => w.coordinate),
+    ];
+    if (coords.length === 0) return SEOUL_CENTER;
+    const sum = coords.reduce(
+      (acc, c) => ({ lat: acc.lat + c.lat, lng: acc.lng + c.lng }),
       { lat: 0, lng: 0 },
     );
-    return { lat: sum.lat / markers.length, lng: sum.lng / markers.length };
-  }, [markers]);
+    return { lat: sum.lat / coords.length, lng: sum.lng / coords.length };
+  }, [markers, workplaces]);
 
   // 로드 에러 시 부모가 SVG fallback으로 전환.
   React.useEffect(() => {
@@ -67,6 +98,24 @@ export default function MapCanvasKakao({
     const timer = setTimeout(() => onFail?.(), SDK_LOAD_TIMEOUT_MS);
     return () => clearTimeout(timer);
   }, [loading, onFail]);
+
+  // A-1 — 처음 로드 시 모든 마커(직장 A·B + 추천 6개)가 한눈에 들어오도록 자동 줌 맞춤.
+  //   ★ onCreate 1회만 = 카드 선택(line follow) 시엔 재줌 안 함 (사용자 줌/팬 보존).
+  //   (Hook은 early-return 위에 위치해야 함 — rules-of-hooks.)
+  const handleCreate = React.useCallback(
+    (map: kakao.maps.Map) => {
+      const pts = [
+        ...markers.map((m) => m.coordinate),
+        ...workplaces.map((w) => w.coordinate),
+      ];
+      if (pts.length < 2) return;
+      const bounds = new kakao.maps.LatLngBounds();
+      pts.forEach((c) => bounds.extend(new kakao.maps.LatLng(c.lat, c.lng)));
+      // 여백 70px — 마커가 가장자리에 붙지 않고 선 전체가 여유롭게 보이도록.
+      map.setBounds(bounds, 70, 70, 70, 70);
+    },
+    [markers, workplaces],
+  );
 
   if (loading) {
     return (
@@ -91,15 +140,74 @@ export default function MapCanvasKakao({
       level={5}
       aria-label="후보 동네 지도"
       className={cn("rounded-lg", className)}
+      onCreate={handleCreate}
     >
+      {/* A-1 — 후보→직장 직선 연결선 (직선 추정 = 점선). 마커보다 먼저 그려 아래 깔림. */}
+      {lines.map((l) => (
+        <Polyline
+          key={l.id}
+          path={l.path}
+          strokeWeight={3}
+          strokeColor={LINE_COLOR[l.variant]}
+          strokeOpacity={0.8}
+          strokeStyle="shortdash"
+        />
+      ))}
+      {/* 추천지역 마커 — 통일 회색 원 + 순위 숫자 (직장 파랑/주황과 구분). 1위=금색 테두리. */}
       {markers.map((m) => (
-        <MapMarker
+        <CustomOverlayMap
           key={m.id}
           position={m.coordinate}
-          title={`${m.rank ? `${m.rank}. ` : ""}${m.label}`}
-          clickable
-          onClick={() => onMarkerClick?.(m.id)}
-        />
+          yAnchor={0.5}
+          xAnchor={0.5}
+        >
+          <button
+            type="button"
+            onClick={() => onMarkerClick?.(m.id)}
+            title={`추천 ${m.rank ?? "-"}위 ${m.label}`}
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: "50%",
+              background: m.selected ? "#1F2937" : "#6B7280",
+              color: "#fff",
+              fontSize: 12,
+              fontWeight: 800,
+              border: m.rank === 1 ? "2px solid #F59E0B" : "2px solid #fff",
+              boxShadow: "0 1px 4px rgba(0,0,0,0.3)",
+              cursor: "pointer",
+              padding: 0,
+              lineHeight: "24px",
+            }}
+          >
+            {m.rank ?? ""}
+          </button>
+        </CustomOverlayMap>
+      ))}
+      {/* A-1 — 직장 A·B 마커: 선 색과 맞춘 색상 라벨 pill (한눈에 내 직장/배우자 구분). */}
+      {workplaces.map((w) => (
+        <CustomOverlayMap
+          key={w.id}
+          position={w.coordinate}
+          yAnchor={0.5}
+          xAnchor={0.5}
+        >
+          <div
+            style={{
+              background: LINE_COLOR[w.variant],
+              color: "#fff",
+              padding: "3px 9px",
+              borderRadius: 999,
+              fontSize: 11,
+              fontWeight: 800,
+              whiteSpace: "nowrap",
+              border: "2px solid #fff",
+              boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
+            }}
+          >
+            {w.label}
+          </div>
+        </CustomOverlayMap>
       ))}
     </Map>
   );

--- a/onday-app/src/components/map/map-canvas.tsx
+++ b/onday-app/src/components/map/map-canvas.tsx
@@ -58,6 +58,8 @@ interface MapCanvasProps {
   markers: MarkerInput[];
   workplaces?: MapWorkplace[];
   lines?: MapLine[];
+  /** B — true면 전체 마커 기준 줌(DetailSheet). 기본=직장 A·B 기준(메인 맵). */
+  fitAll?: boolean;
   placeholder?: boolean;
   height?: number;
   topRightSlot?: React.ReactNode;
@@ -71,6 +73,7 @@ export function MapCanvas({
   markers,
   workplaces = [],
   lines = [],
+  fitAll = false,
   placeholder = true,
   height = 320,
   topRightSlot,
@@ -141,6 +144,7 @@ export function MapCanvas({
           markers={kakaoMarkers}
           workplaces={kakaoWorkplaces}
           lines={kakaoLines}
+          fitAll={fitAll}
           height={height}
           onMarkerClick={onMarkerClick}
           onFail={handleSdkFail}

--- a/onday-app/src/components/map/map-canvas.tsx
+++ b/onday-app/src/components/map/map-canvas.tsx
@@ -37,11 +37,12 @@ export interface MapWorkplace {
   coordinate?: Coordinate;
   variant: "a" | "b";
 }
+// points ≥2. dashed=true → 직선 추정(A-1) / false → 실 도로 경로(A-2 Kakao vertexes).
 export interface MapLine {
   id: string;
-  from: { position: { x: number; y: number }; coordinate?: Coordinate };
-  to: { position: { x: number; y: number }; coordinate?: Coordinate };
+  points: { position: { x: number; y: number }; coordinate?: Coordinate }[];
   variant: "a" | "b";
+  dashed?: boolean;
 }
 
 const LINE_STROKE: Record<"a" | "b", string> = {
@@ -117,11 +118,12 @@ export function MapCanvas({
   const kakaoLines = React.useMemo(
     () =>
       lines
-        .filter((l) => l.from.coordinate && l.to.coordinate)
+        .filter((l) => l.points.length >= 2 && l.points.every((p) => p.coordinate))
         .map((l) => ({
           id: l.id,
-          path: [l.from.coordinate as Coordinate, l.to.coordinate as Coordinate],
+          path: l.points.map((p) => p.coordinate as Coordinate),
           variant: l.variant,
+          dashed: l.dashed ?? false,
         })),
     [lines],
   );
@@ -195,18 +197,17 @@ export function MapCanvas({
             fill="#B6D6F2"
             opacity="0.85"
           />
-          {/* A-1 — 후보→직장 직선 연결선 (직선 추정 = 점선). 마커보다 먼저 = 아래 깔림. */}
+          {/* A-1/A-2 — 후보→직장 경로선 (점선=직선 추정 / 실선=실 도로). 마커보다 먼저 = 아래 깔림. */}
           {lines.map((l) => (
-            <line
+            <polyline
               key={l.id}
               aria-hidden
-              x1={l.from.position.x}
-              y1={l.from.position.y}
-              x2={l.to.position.x}
-              y2={l.to.position.y}
+              points={l.points.map((p) => `${p.position.x},${p.position.y}`).join(" ")}
+              fill="none"
               strokeWidth="2"
-              strokeDasharray="5 4"
+              strokeDasharray={l.dashed ? "5 4" : undefined}
               strokeLinecap="round"
+              strokeLinejoin="round"
               className={cn(LINE_STROKE[l.variant], "opacity-70")}
             />
           ))}

--- a/onday-app/src/components/map/map-canvas.tsx
+++ b/onday-app/src/components/map/map-canvas.tsx
@@ -28,8 +28,35 @@ interface MarkerInput {
   rank?: number;
 }
 
+// A-1 (#졸업) — 직장 마커 + 후보→직장 직선 연결선. position(SVG)+coordinate(SDK) 둘 다 보유.
+export interface MapWorkplace {
+  id: string;
+  label: string; // "내 직장" / "배우자 직장"
+  short: string; // SVG 뱃지용 "A" / "B"
+  position: { x: number; y: number };
+  coordinate?: Coordinate;
+  variant: "a" | "b";
+}
+export interface MapLine {
+  id: string;
+  from: { position: { x: number; y: number }; coordinate?: Coordinate };
+  to: { position: { x: number; y: number }; coordinate?: Coordinate };
+  variant: "a" | "b";
+}
+
+const LINE_STROKE: Record<"a" | "b", string> = {
+  a: "stroke-primary",
+  b: "stroke-warning",
+};
+const WORKPLACE_FILL: Record<"a" | "b", string> = {
+  a: "fill-primary",
+  b: "fill-warning",
+};
+
 interface MapCanvasProps {
   markers: MarkerInput[];
+  workplaces?: MapWorkplace[];
+  lines?: MapLine[];
   placeholder?: boolean;
   height?: number;
   topRightSlot?: React.ReactNode;
@@ -41,6 +68,8 @@ interface MapCanvasProps {
 
 export function MapCanvas({
   markers,
+  workplaces = [],
+  lines = [],
   placeholder = true,
   height = 320,
   topRightSlot,
@@ -70,6 +99,33 @@ export function MapCanvas({
     [markers],
   );
 
+  // SDK 모드 — 좌표 있는 직장 마커 + 양끝 좌표 있는 연결선만 전달.
+  const kakaoWorkplaces = React.useMemo(
+    () =>
+      workplaces
+        .filter((w): w is MapWorkplace & { coordinate: Coordinate } =>
+          Boolean(w.coordinate),
+        )
+        .map((w) => ({
+          id: w.id,
+          coordinate: w.coordinate,
+          label: w.label,
+          variant: w.variant,
+        })),
+    [workplaces],
+  );
+  const kakaoLines = React.useMemo(
+    () =>
+      lines
+        .filter((l) => l.from.coordinate && l.to.coordinate)
+        .map((l) => ({
+          id: l.id,
+          path: [l.from.coordinate as Coordinate, l.to.coordinate as Coordinate],
+          variant: l.variant,
+        })),
+    [lines],
+  );
+
   if (useSdk && kakaoMarkers.length === markers.length) {
     return (
       <div
@@ -81,6 +137,8 @@ export function MapCanvas({
         <MapCanvasKakao
           appKey={appKey as string}
           markers={kakaoMarkers}
+          workplaces={kakaoWorkplaces}
+          lines={kakaoLines}
           height={height}
           onMarkerClick={onMarkerClick}
           onFail={handleSdkFail}
@@ -137,6 +195,21 @@ export function MapCanvas({
             fill="#B6D6F2"
             opacity="0.85"
           />
+          {/* A-1 — 후보→직장 직선 연결선 (직선 추정 = 점선). 마커보다 먼저 = 아래 깔림. */}
+          {lines.map((l) => (
+            <line
+              key={l.id}
+              aria-hidden
+              x1={l.from.position.x}
+              y1={l.from.position.y}
+              x2={l.to.position.x}
+              y2={l.to.position.y}
+              strokeWidth="2"
+              strokeDasharray="5 4"
+              strokeLinecap="round"
+              className={cn(LINE_STROKE[l.variant], "opacity-70")}
+            />
+          ))}
           {/* 마커 = 시맨틱 (각 마커 g에 role=button + aria-label) */}
           {markers.map((m) => (
             <MapMarker
@@ -147,6 +220,47 @@ export function MapCanvas({
               rank={m.rank}
               onClick={() => onMarkerClick?.(m.id)}
             />
+          ))}
+          {/* A-1 — 직장 A·B 마커 (둥근 사각 + A/B 뱃지 + 선 색 맞춘 라벨, 후보 원형과 구분). */}
+          {workplaces.map((w) => (
+            <g
+              key={w.id}
+              aria-label={w.label}
+              transform={`translate(${w.position.x},${w.position.y})`}
+            >
+              <rect
+                x="-13"
+                y="-13"
+                width="26"
+                height="26"
+                rx="7"
+                className={cn(WORKPLACE_FILL[w.variant], "stroke-white stroke-[2]")}
+              />
+              <text
+                aria-hidden
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="pointer-events-none fill-white text-[11px] font-extrabold"
+              >
+                {w.short}
+              </text>
+              {/* 선 색과 맞춘 라벨 — 흰 외곽선(paint-order:stroke)으로 지도 위 가독성 확보. */}
+              <text
+                aria-hidden
+                y="26"
+                textAnchor="middle"
+                dominantBaseline="central"
+                stroke="white"
+                strokeWidth="3"
+                style={{ paintOrder: "stroke" }}
+                className={cn(
+                  WORKPLACE_FILL[w.variant],
+                  "pointer-events-none text-[10px] font-extrabold",
+                )}
+              >
+                {w.label}
+              </text>
+            </g>
           ))}
         </svg>
       )}

--- a/onday-app/src/components/map/map-canvas.tsx
+++ b/onday-app/src/components/map/map-canvas.tsx
@@ -29,13 +29,14 @@ interface MarkerInput {
 }
 
 // A-1 (#졸업) — 직장 마커 + 후보→직장 직선 연결선. position(SVG)+coordinate(SDK) 둘 다 보유.
+//   ★ single 모드 — variant "leisure"(녹색) = 여가거점. 직장(파랑/주황)과 색으로 구분.
 export interface MapWorkplace {
   id: string;
-  label: string; // "내 직장" / "배우자 직장"
-  short: string; // SVG 뱃지용 "A" / "B"
+  label: string; // "내 직장" / "배우자 직장" / "여가거점"
+  short: string; // SVG 뱃지용 "A" / "B" / "♥"
   position: { x: number; y: number };
   coordinate?: Coordinate;
-  variant: "a" | "b";
+  variant: "a" | "b" | "leisure";
 }
 // points ≥2. dashed=true → 직선 추정(A-1) / false → 실 도로 경로(A-2 Kakao vertexes).
 export interface MapLine {
@@ -49,9 +50,10 @@ const LINE_STROKE: Record<"a" | "b", string> = {
   a: "stroke-primary",
   b: "stroke-warning",
 };
-const WORKPLACE_FILL: Record<"a" | "b", string> = {
+const WORKPLACE_FILL: Record<"a" | "b" | "leisure", string> = {
   a: "fill-primary",
   b: "fill-warning",
+  leisure: "fill-success",
 };
 
 interface MapCanvasProps {

--- a/onday-app/src/components/map/map-marker.tsx
+++ b/onday-app/src/components/map/map-marker.tsx
@@ -29,8 +29,7 @@ export function MapMarker({
 }: MapMarkerProps) {
   const aria =
     ariaLabel ??
-    `${label}${rank ? `, ${rank}위` : ""}${selected ? " (선택됨)" : ""}`;
-  const isBest = rank === 1 || selected;
+    `${label}${rank ? `, 추천 ${rank}위` : ""}${selected ? " (선택됨)" : ""}`;
   return (
     <g
       role="button"
@@ -47,26 +46,22 @@ export function MapMarker({
       }}
       className="cursor-pointer outline-none focus-visible:[&>circle]:stroke-[3]"
     >
+      {/* 추천지역 = 통일 회색 (직장 파랑/주황과 구분). 선택 시만 진한 회색으로 강조. */}
       <circle
         r="14"
         className={cn(
-          "transition-all",
-          isBest
-            ? "fill-primary stroke-white"
-            : "fill-surface stroke-primary",
-          "stroke-[2] hover:[r:16]",
+          "transition-all stroke-white stroke-[2] hover:[r:16]",
+          selected ? "fill-ink" : "fill-ink-3",
         )}
       />
+      {/* 원 안 = 순위 숫자 (점수 순 1~N). */}
       <text
         aria-hidden
         textAnchor="middle"
         dominantBaseline="central"
-        className={cn(
-          "pointer-events-none text-[10px] font-extrabold tracking-tight",
-          isBest ? "fill-white" : "fill-primary",
-        )}
+        className="pointer-events-none fill-white text-[11px] font-extrabold tracking-tight"
       >
-        {label}
+        {rank ?? label}
       </text>
       {rank === 1 && (
         <g aria-hidden transform="translate(10,-10)">

--- a/onday-app/src/components/sheet/detail-sheet.tsx
+++ b/onday-app/src/components/sheet/detail-sheet.tsx
@@ -41,6 +41,8 @@ interface DetailSheetProps {
   onLike?: () => void;
   liked?: boolean;
   onShare?: () => void;
+  /** B (#졸업 지도) — header 아래 inject. 해당 추천지역 1곳 + 두 직장 + 연결선. */
+  map?: React.ReactNode;
   /** commute rows와 metrics 사이 inject (예: TimeSlotSelector) */
   commuteExtra?: React.ReactNode;
   primaryCta: {
@@ -58,6 +60,7 @@ export function DetailSheet({
   onLike,
   liked,
   onShare,
+  map,
   commuteExtra,
   primaryCta,
 }: DetailSheetProps) {
@@ -114,6 +117,11 @@ export function DetailSheet({
           )}
           <p className="text-caption text-ink-3">{candidate.lines}</p>
         </header>
+
+        {/* B (#졸업 지도) — 해당 추천지역 + 두 직장 + 연결선 (선택 후보 1곳 기준). */}
+        {map && (
+          <div className="overflow-hidden rounded-lg">{map}</div>
+        )}
 
         {/* ★ W2B: 수단별 그룹 ([대중교통] A/B / [차량] A/B) + 방향 '동네→직장'.
             행 카드 디자인은 보존, 수단은 그룹 헤더 아이콘+라벨로 이동. */}

--- a/onday-app/src/features/diagnosis/mock-calculator.ts
+++ b/onday-app/src/features/diagnosis/mock-calculator.ts
@@ -43,15 +43,18 @@ async function computeOneCandidate(
   // 비동기 API 지연 시뮬레이션 (50-200ms)
   await new Promise((r) => setTimeout(r, 50 + Math.random() * 150));
 
+  // 출퇴근 시간대 혼잡 계수 — 출발 시각(commuteSchedule.departureTime) 반영 (#졸업 시간대 시뮬).
+  const depTime = filters.commuteSchedule?.departureTime;
+
   const distA = haversineDistance(coordA, neighborhood.coordinate);
-  const commuteA = estimateCommuteMinutes(distA);
+  const commuteA = estimateCommuteMinutes(distA, depTime);
   const transfersA = estimateTransfers(distA);
 
   let commuteB: number | null = null;
   let transfersB: number | undefined;
   if (coordB) {
     const distB = haversineDistance(coordB, neighborhood.coordinate);
-    commuteB = estimateCommuteMinutes(distB);
+    commuteB = estimateCommuteMinutes(distB, depTime);
     transfersB = estimateTransfers(distB);
   }
 

--- a/onday-app/src/features/single/detail-mapper.ts
+++ b/onday-app/src/features/single/detail-mapper.ts
@@ -1,0 +1,65 @@
+import type { BadgeProps } from "@/components/ui/badge";
+import type { CandidateArea, SafetyGrade } from "@/lib/types";
+
+import { getNightCrimeRate } from "./safety-stats";
+
+interface PillItem {
+  variant: BadgeProps["variant"];
+  label: string;
+}
+
+interface MetricItem {
+  label: string;
+  value: string;
+  sub?: string;
+}
+
+// 싱글 시트 pills — 왜 1위(순위) + 야간안전 등급 + 매물 수. 배우자(B) 없는 싱글 전용.
+export function buildSinglePills(
+  c: CandidateArea,
+  rank: number,
+  grade: SafetyGrade,
+): PillItem[] {
+  const pills: PillItem[] = [];
+  if (rank === 1) pills.push({ variant: "solid", label: "BEST 매칭" });
+  pills.push({ variant: "neutral", label: `야간안전 ${grade}등급` });
+  if (c.listingsCount != null)
+    pills.push({ variant: "neutral", label: `매물 ${c.listingsCount}건` });
+  return pills;
+}
+
+// 싱글 metrics 3-col — 야간 범죄율(안전) / 평균 시세 / 여가거점(가장 가까운 곳).
+//   여가거점 미입력 시 통근(직장A)로 대체 → 3칸 항상 채움.
+export function buildSingleMetrics(
+  c: CandidateArea,
+  grade: SafetyGrade,
+): MetricItem[] {
+  const metrics: MetricItem[] = [
+    {
+      label: "야간 범죄율",
+      value: `${getNightCrimeRate(grade)}건`,
+      sub: "10만명당",
+    },
+  ];
+  if (c.priceRange) {
+    const avg = (c.priceRange.min + c.priceRange.max) / 2;
+    metrics.push({
+      label: "평균 시세",
+      value: `${(avg / 10000).toFixed(1)}억`,
+      sub: c.avgArea != null ? `${c.avgArea}평` : undefined,
+    });
+  }
+  const leisureTimes = [c.leisureA?.time, c.leisureB?.time].filter(
+    (t): t is number => t != null,
+  );
+  if (leisureTimes.length > 0) {
+    metrics.push({
+      label: "여가거점",
+      value: `${Math.min(...leisureTimes)}분`,
+      sub: leisureTimes.length > 1 ? "가장 가까운 곳" : "이동 시간",
+    });
+  } else {
+    metrics.push({ label: "통근", value: `${c.commuteA.time}분`, sub: "직장A" });
+  }
+  return metrics;
+}

--- a/onday-app/src/lib/external/kakao-car/mapper.ts
+++ b/onday-app/src/lib/external/kakao-car/mapper.ts
@@ -1,11 +1,29 @@
-import type { CommuteInfo } from "@/lib/types";
-import type { KakaoCarResponse } from "./types";
+import type { Coordinate, CommuteInfo } from "@/lib/types";
+import type { KakaoCarResponse, KakaoCarRoute } from "./types";
 import { KakaoCarError } from "./types";
+
+/**
+ * A-2 (#졸업 지도) — routes[].sections[].roads[].vertexes(평면 [lng,lat,…]) → Coordinate[].
+ * 실 도로 경로 폴리라인. 빈 배열이면 화면에서 직선 추정으로 fallback.
+ */
+function extractRoutePath(route: KakaoCarRoute): Coordinate[] {
+  const path: Coordinate[] = [];
+  for (const section of route.sections ?? []) {
+    for (const road of section.roads ?? []) {
+      const v = road.vertexes ?? [];
+      for (let i = 0; i + 1 < v.length; i += 2) {
+        path.push({ lng: v[i], lat: v[i + 1] });
+      }
+    }
+  }
+  return path;
+}
 
 /**
  * 카카오 자동차 길찾기 응답 → CommuteInfo (mode='driving', 환승 없음).
  * - routes[0] (추천 경로) 사용.
  * - duration(초) → time(분).
+ * - A-2: sections.roads.vertexes → routePath (실 도로 경로).
  * @throws KakaoCarError result_code !== 0 또는 빈 routes.
  */
 export function mapKakaoCarResponseToCommuteInfo(
@@ -22,9 +40,11 @@ export function mapKakaoCarResponseToCommuteInfo(
     );
   }
 
+  const routePath = extractRoutePath(route);
   return {
     time: Math.round(route.summary.duration / 60),
     mode: "driving",
     // 자동차 = 환승 없음 (transfers 미설정). fare/distance 는 현재 CommuteInfo 미보유.
+    ...(routePath.length >= 2 ? { routePath } : {}),
   } satisfies CommuteInfo;
 }

--- a/onday-app/src/lib/external/kakao-car/types.ts
+++ b/onday-app/src/lib/external/kakao-car/types.ts
@@ -26,11 +26,20 @@ export interface KakaoCarSummary {
   fare: KakaoCarFare;
 }
 
+/** routes[].sections[].roads[].vertexes — 평면 [x,y,x,y,…] = [lng,lat,lng,lat,…] 도로 폴리라인. */
+export interface KakaoCarRoad {
+  vertexes: number[];
+}
+export interface KakaoCarSection {
+  roads?: KakaoCarRoad[];
+}
+
 export interface KakaoCarRoute {
   result_code: number; // 0 = 성공
   result_msg: string;
   summary: KakaoCarSummary;
-  // sections(roads/guides)는 현재 CommuteInfo 미사용.
+  // A-2 (#졸업 지도) — 실 도로 경로. /v1/directions 는 summary=true 미지정 시 sections 포함.
+  sections?: KakaoCarSection[];
 }
 
 export interface KakaoCarResponse {

--- a/onday-app/src/lib/external/odsay-transit/mapper.ts
+++ b/onday-app/src/lib/external/odsay-transit/mapper.ts
@@ -1,6 +1,20 @@
-import type { CommuteInfo } from "@/lib/types";
-import type { OdsayTransitResponse } from "./types";
+import type { Coordinate, CommuteInfo } from "@/lib/types";
+import type { OdsayPath, OdsayTransitResponse } from "./types";
 import { OdsayTransitError } from "./types";
+
+/**
+ * A-3 (#졸업 지도) — subPath 의 지하철·버스 정거장 좌표를 순서대로 → Coordinate[].
+ * "거쳐가는 역" 선용. 도보 구간은 좌표 없어 제외(출발·도착 연결은 화면단에서 보강).
+ */
+function extractStationPath(path: OdsayPath): Coordinate[] {
+  const out: Coordinate[] = [];
+  for (const sp of path.subPath ?? []) {
+    for (const st of sp.passStopList?.stations ?? []) {
+      out.push({ lat: Number(st.y), lng: Number(st.x) });
+    }
+  }
+  return out;
+}
 
 /**
  * ODsay 대중교통 길찾기 응답 → CommuteInfo (앱 모델 무변경 — R2 transit-only).
@@ -25,11 +39,14 @@ export function mapOdsayResponseToCommuteInfo(
 
   const { totalTime, subwayTransitCount, busTransitCount } = path.info;
   const transfers = Math.max(0, subwayTransitCount + busTransitCount - 1);
+  const stationPath = extractStationPath(path);
 
   return {
     time: totalTime,
     mode: "transit",
     transfers,
+    // A-3 — 거쳐가는 정거장 좌표 (2개 이상일 때만). 출발·도착 연결은 화면단에서 보강.
+    ...(stationPath.length >= 2 ? { routePath: stationPath } : {}),
     // totalWalk / payment 는 현재 CommuteInfo 미보유 — 정보 손실 수용 (차후 모델 확장 시).
   } satisfies CommuteInfo;
 }

--- a/onday-app/src/lib/external/odsay-transit/types.ts
+++ b/onday-app/src/lib/external/odsay-transit/types.ts
@@ -21,9 +21,21 @@ export interface OdsayPathInfo {
   subwayTransitCount: number; // 지하철 환승 카운트
 }
 
+/** subPath[].passStopList.stations[] — 거쳐가는 정거장 좌표 (x=lng, y=lat). */
+export interface OdsayStation {
+  x: number | string; // 경도(lng)
+  y: number | string; // 위도(lat)
+  stationName?: string;
+}
+export interface OdsaySubPath {
+  trafficType: number; // 1=지하철, 2=버스, 3=도보
+  passStopList?: { stations?: OdsayStation[] };
+}
+
 export interface OdsayPath {
   info: OdsayPathInfo;
-  // subPath(구간 상세)는 현재 CommuteInfo 모델에 미사용.
+  // A-3 (#졸업 지도) — 대중교통 정거장 선. 도보(3)는 좌표 없음, 지하철(1)/버스(2)만 정거장 보유.
+  subPath?: OdsaySubPath[];
 }
 
 /** searchPubTransPathT 응답. 경로 없음/에러 시 result 부재 또는 error 객체. */

--- a/onday-app/src/lib/haversine.ts
+++ b/onday-app/src/lib/haversine.ts
@@ -15,17 +15,38 @@ export function haversineDistance(a: Coordinate, b: Coordinate): number {
 }
 
 /**
+ * 출발 시각(HH:MM) → 혼잡 계수. mock 시간대 시뮬레이션 (실 시간대 통계 부재 → 근사).
+ * - 출퇴근 피크(07~09, 17~19시) → ×1.3 (+30%, 지연·혼잡)
+ * - 심야(22~06시) → ×0.9 (-10%, 한산)
+ * - 그 외 → ×1.0
+ */
+export function rushHourFactor(departureTime?: string): number {
+  if (!departureTime) return 1;
+  const hour = Number.parseInt(departureTime.slice(0, 2), 10);
+  if (Number.isNaN(hour)) return 1;
+  if ((hour >= 7 && hour < 9) || (hour >= 17 && hour < 19)) return 1.3;
+  if (hour >= 22 || hour < 6) return 0.9;
+  return 1;
+}
+
+/**
  * Estimate transit commute time from straight-line distance.
  * - Base speed: ~25 km/h (Seoul metro average including transfers)
- * - Walking overhead: +5 min
+ * - Walking overhead: +5 min (시간대 무관 — 고정)
  * - Transfer penalty: +3 min per transfer (estimated 1 per 5km)
+ * - departureTime: 출퇴근 피크/심야 혼잡 계수 (이동 구간에만, 도보 제외).
  */
-export function estimateCommuteMinutes(distanceKm: number): number {
+export function estimateCommuteMinutes(
+  distanceKm: number,
+  departureTime?: string,
+): number {
   const baseMinutes = (distanceKm / 25) * 60;
   const walkingOverhead = 5;
   const transfers = Math.max(0, Math.floor(distanceKm / 5));
   const transferPenalty = transfers * 3;
-  return Math.round(baseMinutes + walkingOverhead + transferPenalty);
+  const travel =
+    (baseMinutes + transferPenalty) * rushHourFactor(departureTime);
+  return Math.round(travel + walkingOverhead);
 }
 
 export function estimateTransfers(distanceKm: number): number {

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -13,6 +13,9 @@ export interface CommuteInfo {
   time: number; // minutes
   mode: CommuteMode;
   transfers?: number;
+  // A-2 (#졸업 지도) — 실 이동 경로 좌표열. 자동차=Kakao 도로 vertexes.
+  //   없으면(mock·실패·transit) 화면에서 직선 추정으로 fallback.
+  routePath?: Coordinate[];
 }
 
 export interface CandidateArea {

--- a/onday-app/src/stores/favorites.ts
+++ b/onday-app/src/stores/favorites.ts
@@ -1,23 +1,59 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
-// 저장한 동네 (즐겨찾기) — localStorage persist
-// Record<areaId, true> 구조 — O(1) 조회 + JSON 직렬화 친화적
-// 서버 동기화는 CMD-SAVE-001 (TanStack mutation)이 담당, 본 store는 optimistic UI 상태
+import type { CandidateArea, DiagnosisMode, SafetyGrade } from "@/lib/types";
+
+// 저장한 동네 (즐겨찾기) — localStorage persist.
+// ★ id만 저장하면 새로고침 후 후보 상세(이름·등급·통근·시세)를 못 그림(diagnosis-store는 메모리).
+//   → 찜 시점에 표시용 스냅샷을 함께 저장해 세션 밖에서도 "찜 목록"을 그릴 수 있게 한다.
+//   서버 동기화는 CMD-SAVE-001 (TanStack mutation) 담당, 본 store는 optimistic + 로컬 캐시.
+
+export interface FavoriteItem {
+  id: string;
+  gu: string;
+  dong: string;
+  score: number;
+  /** 싱글=야간안전 등급(resolveGrade). 부부는 없을 수 있음 → 목록은 점수로 fallback. */
+  safetyGrade?: SafetyGrade;
+  commuteA: number;
+  commuteB?: number;
+  priceRange?: { min: number; max: number };
+  mode: DiagnosisMode;
+  savedAt: number;
+}
+
+// 후보 → 찜 스냅샷. grade는 호출처가 모드별 소스로 넘김(싱글=resolveGrade).
+export function toFavoriteSnapshot(
+  c: CandidateArea,
+  mode: DiagnosisMode,
+  grade?: SafetyGrade,
+  savedAt: number = Date.now(),
+): FavoriteItem {
+  return {
+    id: c.id,
+    gu: c.gu,
+    dong: c.dong,
+    score: c.score,
+    safetyGrade: grade ?? c.safetyGrade,
+    commuteA: c.commuteA.time,
+    commuteB: c.commuteB?.time,
+    priceRange: c.priceRange,
+    mode,
+    savedAt,
+  };
+}
 
 interface FavoritesState {
-  favorites: Record<string, true>;
-  /** 즉시 토글 (optimistic) — 서버 mutation은 호출자가 별도 트리거 */
-  toggleFavorite: (areaId: string) => void;
-  /** 명시적 추가/제거 — 서버 응답으로 상태 동기화 시 사용 */
-  add: (areaId: string) => void;
+  favorites: Record<string, FavoriteItem>;
+  /** 즉시 토글 (optimistic) — 추가 시 스냅샷 필요. 서버 mutation은 호출자가 별도 트리거. */
+  toggleFavorite: (item: FavoriteItem) => void;
   remove: (areaId: string) => void;
   isFavorite: (areaId: string) => boolean;
   clear: () => void;
 }
 
 const initialState = {
-  favorites: {} as Record<string, true>,
+  favorites: {} as Record<string, FavoriteItem>,
 };
 
 export const useFavoritesStore = create<FavoritesState>()(
@@ -25,16 +61,13 @@ export const useFavoritesStore = create<FavoritesState>()(
     (set, get) => ({
       ...initialState,
 
-      toggleFavorite: (areaId) =>
+      toggleFavorite: (item) =>
         set((state) => {
           const next = { ...state.favorites };
-          if (next[areaId]) delete next[areaId];
-          else next[areaId] = true;
+          if (next[item.id]) delete next[item.id];
+          else next[item.id] = item;
           return { favorites: next };
         }),
-
-      add: (areaId) =>
-        set((state) => ({ favorites: { ...state.favorites, [areaId]: true } })),
 
       remove: (areaId) =>
         set((state) => {
@@ -49,6 +82,9 @@ export const useFavoritesStore = create<FavoritesState>()(
     }),
     {
       name: "onday-favorites",
+      version: 1,
+      // v0(Record<id,true>)는 스냅샷이 없어 복원 불가 → 초기화. 이후 찜은 스냅샷 저장됨.
+      migrate: () => ({ favorites: {} }),
       storage: createJSONStorage(() => localStorage),
     },
   ),


### PR DESCRIPTION
## Summary
졸업 핵심 — 두 동선 교차 진단의 **지도 동선 시각화** 완성 묶음. 부부·싱글 양 모드 지도 + 찜 목록 + 싱글 데드라인 패리티. **추가 외부 API 호출 0** (Kakao directions 응답의 도로 geometry + ODsay 정거장 좌표 활용).

## 1. 부부 모드 지도 (A-1/A-2/B)
- **A-1**: 직장 A·B 마커(파랑 "내 직장"/주황 "배우자 직장") + 후보→직장 연결선. 후보=회색+순위(1위 금색). fitBounds 자동 줌
- **A-2**: 자동차 실 도로선 — `CommuteInfo.routePath` + Kakao `sections[].roads[].vertexes` 파싱. 실선=실도로 / 점선=직선추정 fallback. 초기 과도 줌인 수정(`map state + rAF + relayout`)
- **B**: DetailSheet 미니 지도(후보 1곳 + 두 직장 + 연결선), `fitAll` 3점 줌
- 대중교통 정거장 선 + 🚇/🚗 모드 토글 + 시간대 계수 + what-if 재계산 버그 2건 수정

## 2. 싱글 모드 지도 (신규)
- 직장 A(파랑) + 여가거점 `leisureCoordA/B`(녹색 ♥ "여가거점 1/2") + 후보(회색·순위) 마커. `MapWorkplace/KakaoWorkplace.variant`에 `"leisure"`(success) 추가
- 🚇/🚗 토글 + `buildLineForMode`(transit=정거장 / car=도로 vertexes). 연결선=직장A만
- 카드 탭 → DetailSheet(후보 focus 지도 + 통근[대중교통+차량] + 야간안전·시세·여가 + 매물/좋아요/공유). 싱글 전용 빌더 `features/single/detail-mapper.ts`

## 3. 찜 목록 (부부·싱글 공통)
- favorites store: id-only → **스냅샷 저장**(`Record<id, FavoriteItem>` + persist v1 migrate). 새로고침 후에도 목록 유지
- `FavoritesMenu` 공통 컴포넌트: 헤더 하트 + 개수 배지 + 바텀시트 + **모드 탭(전체/부부/싱글)** + 항목 모드 배지 + 매물/해제

## 4. 싱글 데드라인 패리티
- `/deadline`은 모드 공용(급매 리스트+지도+네이버, store candidates 기반) → 싱글에 빠졌던 `DeadlineEntryCard`만 추가

## 동작 / 운영
- **mock(라이브)** = 직선 점선 / **real 모드** = 실 도로·정거장 경로선 (`commuteACar`·routePath는 real에서만 생성)
- 라이브 real 전환 시 ODsay 공인 IP 화이트리스트 제약 → 데모는 로컬 real 녹화 권장(`docs/local-real-demo-recording.md`)

## Test plan
- [x] `tsc --noEmit` 0 / `eslint`(변경 파일) 0
- [x] (수동) 실 모드 진단 → 부부/싱글 도로·정거장 선 + 토글 + 카드 탭 시트
- [x] (수동) 찜 → 헤더 하트 → 모드 탭 목록 / 싱글 데드라인 진입 카드 → 급매

## 이슈
Closes #36
> #104(UI-003 MapCanvas SDK 통합)는 이미 CLOSED — 본 PR은 열린 #36만 닫음 (중복이나 재close 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
