### PR TITLE
[feat] 시간↔비용 트레이드오프 인사이트 + 부부 카드 점수 색감

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -9,6 +9,7 @@ import { FilterPanel } from "@/components/form/filter-panel";
 import { MapCanvas } from "@/components/map/map-canvas";
 import type { MapWorkplace, MapLine } from "@/components/map/map-canvas";
 import { DetailSheet } from "@/components/sheet/detail-sheet";
+import { TradeOffSection } from "@/components/diagnosis/trade-off-section";
 import {
   buildCommuteRows,
   buildLines,
@@ -556,6 +557,8 @@ export function ResultContent({
           </li>
         ))}
       </ul>
+
+      <TradeOffSection candidates={sorted} onSelect={open} />
 
       {selectedCandidate && (
         <DetailSheet

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -9,6 +9,7 @@ import { LegendBar } from "@/components/data/legend-bar";
 import { MapCanvas } from "@/components/map/map-canvas";
 import type { MapWorkplace, MapLine } from "@/components/map/map-canvas";
 import { DetailSheet } from "@/components/sheet/detail-sheet";
+import { TradeOffSection } from "@/components/diagnosis/trade-off-section";
 import { DeadlineBanner } from "@/components/deadline/deadline-banner";
 import { DeadlineBell } from "@/components/deadline/deadline-bell";
 import { DeadlineEntryCard } from "@/components/deadline/deadline-entry-card";
@@ -467,6 +468,10 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                 );
               })}
             </section>
+
+            <div className="print:hidden">
+              <TradeOffSection candidates={sorted} onSelect={open} />
+            </div>
 
             <Button
               fullWidth

--- a/onday-app/src/components/card/candidate-card.tsx
+++ b/onday-app/src/components/card/candidate-card.tsx
@@ -14,6 +14,23 @@ import { cn } from "@/lib/utils";
 //   aria-label 종합 ("마포구 공덕동, 매칭 점수 92점, 1위, A 통근 18분, B 통근 32분, 평균 시세 9.2억")
 //   native <a> (href) 또는 <button> (onClick)
 
+// 매칭 점수 → 색 티어 (싱글 SafetyCard의 등급색 패턴을 점수 기반으로 답습).
+//   color 단독 금지 원칙 — 라벨(최상/우수/…) + 색 칩 + 색 바 3중 표기.
+function scoreTier(score: number): {
+  label: string;
+  text: string;
+  chip: string;
+  fill: string;
+} {
+  if (score >= 90)
+    return { label: "최상", text: "text-success", chip: "bg-success-soft text-success", fill: "bg-success" };
+  if (score >= 80)
+    return { label: "우수", text: "text-primary", chip: "bg-primary-soft text-primary", fill: "bg-primary" };
+  if (score >= 70)
+    return { label: "양호", text: "text-warning", chip: "bg-warning-soft text-warning", fill: "bg-warning" };
+  return { label: "보통", text: "text-ink-2", chip: "bg-bg text-ink-2", fill: "bg-ink-3" };
+}
+
 interface CommuteSummary {
   tag: "A" | "B";
   mode: CommuteMode;
@@ -44,6 +61,7 @@ export function CandidateCard({
   className,
 }: CandidateCardProps) {
   const isBest = best ?? rank === 1;
+  const tier = scoreTier(score);
   const commuteAria = commutes
     .map(
       (c) =>
@@ -62,17 +80,22 @@ export function CandidateCard({
             <h3 className="text-title font-bold text-ink">{name}</h3>
             {isBest && <Badge variant="best">BEST</Badge>}
           </div>
-          <p className="mt-0.5 text-caption text-ink-3">
-            매칭 점수{" "}
+          <p className="mt-0.5 flex items-center gap-s-2 text-caption text-ink-3">
+            <span>
+              매칭 점수{" "}
+              <span className={cn("tabular text-title-sm font-extrabold", tier.text)}>
+                {score}
+              </span>
+              점
+            </span>
             <span
               className={cn(
-                "tabular text-title-sm font-extrabold",
-                isBest ? "text-primary" : "text-ink",
+                "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-extrabold",
+                tier.chip,
               )}
             >
-              {score}
+              {tier.label}
             </span>
-            점
           </p>
         </div>
         {rank !== undefined && (
@@ -81,6 +104,21 @@ export function CandidateCard({
           </Badge>
         )}
       </header>
+
+      {/* 매칭 점수 색 진행바 — 싱글 SafetyBar 패턴 답습(데이터값=점수). 색 단독 아닌 라벨+칩과 3중. */}
+      <div
+        role="progressbar"
+        aria-valuenow={score}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`매칭 점수 ${score}점, ${tier.label}`}
+        className="h-1.5 overflow-hidden rounded-xs bg-bg"
+      >
+        <div
+          className={cn("h-full rounded-xs", tier.fill)}
+          style={{ width: `${Math.max(0, Math.min(100, score))}%` }}
+        />
+      </div>
 
       <div className="flex flex-wrap gap-s-2">
         {commutes.map((c) => (

--- a/onday-app/src/components/diagnosis/trade-off-section.tsx
+++ b/onday-app/src/components/diagnosis/trade-off-section.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import * as React from "react";
+import { TrendingDown, Zap, Scale } from "lucide-react";
+
+import {
+  computeTradeOff,
+  type TradeOffAlt,
+} from "@/features/diagnosis/trade-off";
+import type { CandidateArea } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+interface TradeOffSectionProps {
+  candidates: CandidateArea[];
+  /** 대체안 탭 시 해당 후보 상세 열기 (결과/싱글 공용 open). */
+  onSelect?: (id: string) => void;
+}
+
+// 시세 차이(만원, 절대값) → "X.X억" / "X천만원" / "X만원".
+function formatPriceDelta(manwon: number): string {
+  const v = Math.abs(manwon);
+  if (v >= 10000) return `${(v / 10000).toFixed(1)}억`;
+  if (v >= 1000) return `${Math.round(v / 1000)}천만원`;
+  return `${v}만원`;
+}
+
+function AltCard({
+  alt,
+  kind,
+  onSelect,
+}: {
+  alt: TradeOffAlt;
+  kind: "cheaper" | "faster";
+  onSelect?: (id: string) => void;
+}) {
+  const { candidate: c, timeDelta, priceDelta, monthlyDelta } = alt;
+  const name = `${c.gu} ${c.dong}`;
+  const price = formatPriceDelta(priceDelta);
+  const monthly = formatPriceDelta(monthlyDelta);
+
+  const tone =
+    kind === "cheaper"
+      ? { Icon: TrendingDown, badge: "더 싸게", cls: "text-success bg-success-soft" }
+      : { Icon: Zap, badge: "더 빠르게", cls: "text-primary bg-primary/10" };
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(c.id)}
+      className="flex w-full items-start gap-s-3 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 text-left shadow-card transition-shadow hover:shadow-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+    >
+      <span
+        className={cn(
+          "mt-0.5 inline-flex size-8 shrink-0 items-center justify-center rounded-full",
+          tone.cls,
+        )}
+      >
+        <tone.Icon aria-hidden className="size-4" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-s-2">
+          <span className={cn("shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-extrabold", tone.cls)}>
+            {tone.badge}
+          </span>
+          <span className="truncate text-body font-bold text-ink">{name}</span>
+        </span>
+        <span className="mt-1 block text-caption text-ink-2">
+          {kind === "cheaper" ? (
+            <>
+              통근 <b className="text-ink">{timeDelta}분</b> 더 가면, 시세{" "}
+              <b className="text-success">{price} 절감</b>{" "}
+              <span className="text-ink-3">(월 ~{monthly})</span>
+            </>
+          ) : (
+            <>
+              시세 <b className="text-ink">{price} 더</b>{" "}
+              <span className="text-ink-3">(월 ~{monthly})</span> 쓰면, 통근{" "}
+              <b className="text-primary">{Math.abs(timeDelta)}분 단축</b>
+            </>
+          )}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+export function TradeOffSection({ candidates, onSelect }: TradeOffSectionProps) {
+  const result = React.useMemo(() => computeTradeOff(candidates), [candidates]);
+  if (!result) return null;
+  const { reference, cheaper, faster } = result;
+
+  return (
+    <section aria-label="타협 인사이트" className="space-y-s-3">
+      <div className="flex items-center gap-s-2">
+        <Scale aria-hidden className="size-4 text-ink-2" />
+        <h2 className="text-title font-bold text-ink">타협 인사이트</h2>
+        <span className="text-caption-xs text-ink-3">
+          1위 {reference.dong} 기준
+        </span>
+      </div>
+
+      {!cheaper && !faster ? (
+        <p className="rounded-lg border border-card-border bg-surface px-s-4 py-s-3 text-body-sm text-ink-3 shadow-card">
+          1위 {reference.dong}가 통근·시세 모두 가장 유리해요. 타협할 대안이 없네요.
+        </p>
+      ) : (
+        <div className="space-y-s-2">
+          {cheaper && <AltCard alt={cheaper} kind="cheaper" onSelect={onSelect} />}
+          {faster && <AltCard alt={faster} kind="faster" onSelect={onSelect} />}
+        </div>
+      )}
+
+      <p className="text-caption-xs text-ink-3">
+        · 월 환산은 시세 차이를 연 금리 3.5% 대출로 가정한 추정이에요.
+      </p>
+    </section>
+  );
+}

--- a/onday-app/src/features/diagnosis/trade-off.ts
+++ b/onday-app/src/features/diagnosis/trade-off.ts
@@ -1,0 +1,68 @@
+import type { CandidateArea } from "@/lib/types";
+
+import { avgCommute } from "./result-utils";
+
+// 시간 vs 비용 트레이드오프 — OnDay "타협 인사이트".
+//   두 축이 직교(점수=통근·안전·편의·여가만, 시세는 점수 밖)라 비교가 의미 있음.
+//   기준점=1위 후보, 대체안=나머지 중 한 방향으로 트레이드오프가 가장 효율적인 1곳.
+
+// ★ 월 환산 가정 — 시세 차이를 대출로 가정한 연이자율(정직 표기: "금리 3.5% 가정").
+//   priceDelta(만원) × 3.5% ÷ 12 = 월 부담 차이(만원). UI에 가정 라벨 필수 노출.
+export const TRADE_OFF_ANNUAL_RATE = 0.035;
+
+export function monthlyFromPriceDelta(priceDeltaManwon: number): number {
+  return Math.round((priceDeltaManwon * TRADE_OFF_ANNUAL_RATE) / 12);
+}
+
+function avgPrice(c: CandidateArea): number | null {
+  if (!c.priceRange) return null;
+  return (c.priceRange.min + c.priceRange.max) / 2;
+}
+
+export interface TradeOffAlt {
+  candidate: CandidateArea;
+  timeDelta: number; // 분 (+ = 더 걸림 / - = 단축)
+  priceDelta: number; // 만원 (+ = 더 비쌈 / - = 저렴)
+  monthlyDelta: number; // 만원/월 (priceDelta 환산, 부호 동일)
+}
+
+export interface TradeOffResult {
+  reference: CandidateArea;
+  cheaper?: TradeOffAlt; // 더 싸지만 통근 더 걸림
+  faster?: TradeOffAlt; // 통근 더 빠르지만 더 비쌈
+}
+
+function toAlt(c: CandidateArea, refTime: number, refPrice: number): TradeOffAlt {
+  const priceDelta = Math.round((avgPrice(c) as number) - refPrice);
+  return {
+    candidate: c,
+    timeDelta: Math.round(avgCommute(c) - refTime),
+    priceDelta,
+    monthlyDelta: monthlyFromPriceDelta(priceDelta),
+  };
+}
+
+// 후보 목록(점수순) → 1위 기준 트레이드오프. 시세 없는 후보·1위는 비교에서 제외.
+export function computeTradeOff(
+  candidates: CandidateArea[],
+): TradeOffResult | null {
+  const reference = candidates[0];
+  const refPrice = reference ? avgPrice(reference) : null;
+  if (!reference || refPrice == null) return null;
+  const refTime = avgCommute(reference);
+
+  const pool = candidates.slice(1).filter((c) => avgPrice(c) != null);
+  const alts = pool.map((c) => toAlt(c, refTime, refPrice));
+
+  // 더 싸지만 먼 곳 — 추가 1분당 절감액(만원/분)이 큰 순. priceDelta<0·timeDelta>0.
+  const cheaper = alts
+    .filter((a) => a.priceDelta < 0 && a.timeDelta > 0)
+    .sort((a, b) => -b.priceDelta / b.timeDelta - -a.priceDelta / a.timeDelta)[0];
+
+  // 더 빠르지만 비싼 곳 — 추가 1만원당 단축 분(분/만원)이 큰 순. timeDelta<0·priceDelta>0.
+  const faster = alts
+    .filter((a) => a.timeDelta < 0 && a.priceDelta > 0)
+    .sort((a, b) => -b.timeDelta / b.priceDelta - -a.timeDelta / a.priceDelta)[0];
+
+  return { reference, cheaper, faster };
+}


### PR DESCRIPTION
## Summary
OnDay 핵심 **"타협 인사이트"** — 1위 후보 대비 시간↔비용 트레이드오프 대체안 제시 + 부부 카드 점수 색감 통일. 부부·싱글 공통.

## 트레이드오프 (시간 vs 비용)
- `features/diagnosis/trade-off.ts` — 1위 기준, 두 방향 대체안 선정
  - **더 싸지만 먼 곳**: 추가 1분당 절감액(만원/분) 최대 = 효율적 타협
  - **더 빠르지만 비싼 곳**: 추가 1만원당 단축 분 최대 = 효율적 단축
  - 시간축=`avgCommute`(부부 A+B평균/싱글 A), 비용축=`priceRange` 평균. 시세는 점수 밖이라 직교
  - 월 환산 = 시세차 × **연 3.5%** ÷ 12 (가정 라벨 명시 = 정직 표기)
- `TradeOffSection` — 💸 더 싸게(녹색) / ⚡ 더 빠르게(파랑) 카드. 탭 시 해당 후보 상세 열림
  - "통근 +N분 더 가면 시세 X 절감 (월 ~Y)" 식. 대안 없으면 1위 최선 안내
- 결과 하단(부부=카드↓ / 싱글=카드섹션↓)에 연결, 공통 컴포넌트

## 부부 카드 점수 색감
- 싱글 SafetyCard 패턴(색 값 + 라벨 칩 + 색 바 3중) 답습
- 매칭 점수 티어(최상90+/우수80+/양호70+/보통) → 점수 색 + 티어 칩 + 색 진행바
- 비best 카드도 점수별 색 → 싱글과 통일감 (이전엔 흰배경+회색 밋밋)

## Test plan
- [x] `tsc --noEmit` 0 / `eslint`(변경 파일) 0
- [x] (수동) 부부·싱글 결과 하단 "타협 인사이트" 대체안 → 탭 시 상세
- [x] (수동) 부부 카드 점수 티어 색 + 진행바

🤖 Generated with [Claude Code](https://claude.com/claude-code)
