### PR TITLE
[debug] /api/diagnosis 500 실제 에러 응답 노출 (임시)

### DIFF
--- a/onday-app/src/app/api/diagnosis/route.ts
+++ b/onday-app/src/app/api/diagnosis/route.ts
@@ -92,6 +92,14 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("[API] POST /api/diagnosis error:", error);
-    return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });
+    // ★ 디버그 임시 — 실제 에러를 응답에 실어 브라우저 Network 탭에서 바로 확인 (DB 진단용).
+    //   원인 잡으면 제거 예정.
+    return NextResponse.json(
+      {
+        error: "서버 오류가 발생했습니다",
+        debug: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
   }
 }


### PR DESCRIPTION
라이브 진단 500 원인을 브라우저 Network 탭에서 바로 보려고 catch 에러 메시지를 응답 debug 필드에 실음. DB 원인 잡으면 제거.