### PR TITLE
[fix] /api/diagnosis 임시 디버그 노출 제거

### DIFF
--- a/onday-app/src/app/api/diagnosis/route.ts
+++ b/onday-app/src/app/api/diagnosis/route.ts
@@ -92,14 +92,6 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("[API] POST /api/diagnosis error:", error);
-    // ★ 디버그 임시 — 실제 에러를 응답에 실어 브라우저 Network 탭에서 바로 확인 (DB 진단용).
-    //   원인 잡으면 제거 예정.
-    return NextResponse.json(
-      {
-        error: "서버 오류가 발생했습니다",
-        debug: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });
   }
 }


### PR DESCRIPTION
라이브 DB 원인(DATABASE_URL UI 붙여넣기 깨짐) 확인 끝나서 PR #152 임시 디버그 제거. 원래 일반 500 메시지로 복원.