### PR TITLE
feat(diagnosis): 거래유형(전세/매매) 분기 토대 — 월세 토글 Stage 1-A (구조)

### DIFF
--- a/onday-app/src/features/diagnosis/mock-calculator.ts
+++ b/onday-app/src/features/diagnosis/mock-calculator.ts
@@ -12,6 +12,7 @@ import {
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
 // ScoringEngine (#27) — 점수 로직은 공용 모듈로 추출. client(실 ODsay) + server(mock) 공유.
 import { scoreCandidate } from "@/lib/diagnosis/scoring";
+import { comparablePrice } from "@/lib/diagnosis/price";
 
 interface ComputeResult {
   status: "fulfilled";
@@ -88,7 +89,8 @@ async function computeOneCandidate(
   // Issue #123 — 예산 범위 외 제외 (★ maxCommuteTime 답습 정합).
   //   사용자 시각 검증 짚음: "예산 4~5억 박힘 + 결과 카드 4~5억 사이 X = 다양 박힘" → 범위 외 카드 제외 박힘.
   if (filters.budget) {
-    const price = neighborhood.avgPrice;
+    // 거래유형별 비교가 — 매매 시 전세가율로 환산(추정). 미지정=전세(기존과 동일).
+    const price = comparablePrice(neighborhood.avgPrice, filters.budget.dealType);
     if (price < filters.budget.min || price > filters.budget.max) {
       return {
         status: "rejected",

--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -12,6 +12,7 @@ import {
   estimateTransfers,
 } from "@/lib/haversine";
 import { scoreCandidate } from "@/lib/diagnosis/scoring";
+import { comparablePrice } from "@/lib/diagnosis/price";
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
 import { KakaoCarClient } from "@/lib/external/kakao-car";
 
@@ -151,7 +152,9 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
       }
       // 필터 — 예산 범위
       if (filters.budget) {
-        if (n.avgPrice < filters.budget.min || n.avgPrice > filters.budget.max) {
+        // 거래유형별 비교가 — 매매 시 전세가율로 환산(추정). 미지정=전세(기존과 동일).
+        const price = comparablePrice(n.avgPrice, filters.budget.dealType);
+        if (price < filters.budget.min || price > filters.budget.max) {
           return null;
         }
       }

--- a/onday-app/src/lib/diagnosis/generate-suggestions.ts
+++ b/onday-app/src/lib/diagnosis/generate-suggestions.ts
@@ -51,7 +51,7 @@ export function generateRelaxationSuggestions(
     const newMaxOk = newMax / 10_000; // 만원 → 억원 변환 (10,000만원 = 1억원)
     suggestions.push({
       label: `예산 최대를 ${newMaxOk.toFixed(1)}억원으로 늘려보세요`,
-      apply: { budget: { min: filters.budget.min, max: newMax } },
+      apply: { budget: { ...filters.budget, max: newMax } }, // dealType 보존
     });
   }
 

--- a/onday-app/src/lib/diagnosis/price.ts
+++ b/onday-app/src/lib/diagnosis/price.ts
@@ -1,0 +1,20 @@
+import type { DealType } from "@/lib/types";
+
+// 전세가율 추정치 — 매매가 ≈ 전세 ÷ 0.55 (서울 아파트 대략치).
+//   동네 데이터는 avgPrice(전세 추정 보증금) 단일값만 보유 → 매매 시세를 보유하지 않아
+//   이 상수로 파생(추정)한다. 표시 시 "추정" 명시 필수(날조 금지). 월세는 Stage 2.
+export const JEONSE_RATIO = 0.55;
+
+/**
+ * 동네 avgPrice(전세 추정 보증금, 만원) → 거래유형별 비교가(만원).
+ *   - jeonse: 그대로 (전세 보증금)
+ *   - maemae: 전세가율로 환산한 매매가(추정)
+ * dealType 미지정 시 전세로 간주 — 기존 budget({min,max}) 하위호환.
+ */
+export function comparablePrice(
+  avgPrice: number,
+  dealType: DealType = "jeonse",
+): number {
+  if (dealType === "maemae") return Math.round(avgPrice / JEONSE_RATIO);
+  return avgPrice;
+}

--- a/onday-app/src/lib/mocks/diagnosis/get-diagnosis.ts
+++ b/onday-app/src/lib/mocks/diagnosis/get-diagnosis.ts
@@ -21,7 +21,7 @@ export const MOCK_DIAGNOSIS_ENTITY = {
   addressB: '서울 중구 세종대로 110',
   filters: {
     maxCommuteTime: 60,
-    budget: { min: 8000, max: 15000 },
+    budget: { dealType: 'jeonse', min: 8000, max: 15000 },
     commuteSchedule: { days: ['mon', 'tue', 'wed', 'thu', 'fri'], departureTime: '08:00' },
     priorities: ['safety', 'commute'],
   },

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -3,6 +3,8 @@ export type DiagnosisMode = "couple" | "single";
 export type DiagnosisStatus = "processing" | "completed" | "expired";
 export type SafetyGrade = "A" | "B" | "C" | "D";
 export type CommuteMode = "transit" | "driving";
+// 거래유형 — budget 범위가 어떤 시세를 가리키는지. Stage 2에서 "wolse"(월세) 추가 예정.
+export type DealType = "jeonse" | "maemae";
 
 export interface Coordinate {
   lat: number;
@@ -51,7 +53,9 @@ export interface CommuteSchedule {
 
 export interface DiagnosisFilters {
   maxCommuteTime?: number; // minutes
-  budget?: { min: number; max: number }; // 만원
+  // dealType 미지정 = 전세 (기존 {min,max} 하위호환). min/max 단위 = 만원.
+  //   maemae 시 비교가는 comparablePrice()로 전세→매매 환산(추정).
+  budget?: { dealType?: DealType; min: number; max: number };
   commuteSchedule?: CommuteSchedule; // 요일 + 시간 자유 — Issue #98 commuteSchedule DTO 정수 정정 (★ REFACTOR-COMMUTE-LEGACY #102 timeRange 제거 완성).
   priorities?: string[];
 }
@@ -108,7 +112,7 @@ export interface Neighborhood {
   dong: string;
   gu: string;
   coordinate: Coordinate;
-  avgPrice: number; // 만원
+  avgPrice: number; // 만원 (전세 추정 보증금 — 매매가는 comparablePrice()로 파생)
   safetyGrade: SafetyGrade;
   facilities: { convenience: number; cafes: number; schools: number };
   lines?: string; // 지하철/버스 노선 요약 — step-10.5에서 보강

--- a/onday-app/src/lib/types/saved-search.ts
+++ b/onday-app/src/lib/types/saved-search.ts
@@ -28,7 +28,7 @@ export interface SearchParams {
   coordinateB?: { lat: number; lng: number };
   filters?: {
     maxCommuteTime?: number;
-    budget?: { min: number; max: number };
+    budget?: { dealType?: "jeonse" | "maemae"; min: number; max: number };
     commuteSchedule?: CommuteSchedule;
     priorities?: string[];
   };

--- a/onday-app/src/lib/validators/diagnosis.ts
+++ b/onday-app/src/lib/validators/diagnosis.ts
@@ -18,6 +18,7 @@ export const diagnosisInputSchema = z.object({
     maxCommuteTime: z.number().min(10).max(120).optional(),
     budget: z
       .object({
+        dealType: z.enum(["jeonse", "maemae"]).optional(), // 미지정 = 전세 (하위호환)
         min: z.number().min(0),
         max: z.number().min(0),
       })

--- a/onday-app/src/mocks/neighborhoods.ts
+++ b/onday-app/src/mocks/neighborhoods.ts
@@ -1,5 +1,6 @@
 import type { Neighborhood } from "@/lib/types";
 
+// avgPrice = 전세 추정 보증금(만원). 매매가는 미보유 → comparablePrice()로 전세가율 환산(추정).
 export const MOCK_NEIGHBORHOODS: Neighborhood[] = [
   {
     id: "jong-3",


### PR DESCRIPTION
## 월세 토글 Stage 1-A — 구조 (UX 변경 없음, 회귀 0 목표)

월세 토글은 예산 구조가 바뀌는 큰 작업이라 **Stage 1(전세/매매 토대) → Stage 2(월세 mock)** 로 분할, Stage 1을 다시 **1-A(구조) → 1-B(UX)** 로 쪼갠 그 첫 PR입니다.

### 이 PR이 하는 일
- `DealType`(`"jeonse"|"maemae"`) 타입 + `DiagnosisFilters.budget.dealType?` **옵셔널** 추가
- `comparablePrice()` 헬퍼 신규 — `avgPrice`(전세 추정 보증금)에서 매매가를 **전세가율 0.55로 환산(추정)**
- `mock-calculator`·`run-real-diagnosis` 예산 필터를 `comparablePrice` 기준으로 전환
- `validators`·`saved-search`·seed·완화제안에 `dealType` 옵셔널 반영 (보존)
- `avgPrice` 정체를 "전세 추정 보증금"으로 주석 명시

### 회귀 0 설계
`dealType`을 **옵셔널**로 두어 기존 `budget {min,max}`·저장 데이터·공유 링크가 전부 `dealType ?? "jeonse"` 로 동작합니다. 입력 폼은 **이 PR에서 건드리지 않으므로** 모든 진단이 전세로 흘러 **기존 결과와 동일**합니다.

### 정직성 (날조 금지)
동네 데이터는 `avgPrice` 단일값(전세 추정)만 보유 → 매매 시세는 **전세가율 환산(추정)** 입니다. 화면에 "추정" 뱃지를 붙이는 작업은 매매 UX가 실제로 켜지는 **1-B**에서 함께 합니다.

### 범위 밖 (다음 단계)
- **1-B (UX):** 입력 폼 거래유형 토글 + 동적 라벨 + 결과 "추정" 표시 (월세는 disabled "준비중" 자리)
- **Stage 2:** 월세 mock(전월세전환율 5%) 활성화

### 검증
- ✅ `tsc --noEmit` 통과
- ✅ ESLint 0 warnings/errors
- ✅ 한글 인코딩 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)