### PR TITLE
feat(diagnosis): 거래유형 토글 UX + 매매 추정 표시 — 월세 Stage 1-B

### DIFF
--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -8,7 +8,7 @@ import { AddressInput } from "@/components/form/address-input";
 import { ModeSelector } from "@/components/form/mode-selector";
 // ★ DTO-COMMUTE-TIME (#98) — TimeRangeToggle 제거 + CommuteSchedulePicker 교체 (★ Mismatch ㊱).
 import { CommuteSchedulePicker } from "@/components/form/commute-schedule-picker";
-import type { CommuteSchedule, DiagnosisFilters } from "@/lib/types";
+import type { CommuteSchedule, DealType, DiagnosisFilters } from "@/lib/types";
 import { AppHeader } from "@/components/layout/app-header";
 import { StickyCTABar } from "@/components/layout/sticky-cta-bar";
 import { Button } from "@/components/ui/button";
@@ -99,18 +99,28 @@ export default function DiagnosisPage() {
   const [budgetMaxInput, setBudgetMaxInput] = React.useState(
     filters.budget ? String(filters.budget.max / 10000) : "",
   );
+  // 거래유형(전세/매매) — 월세는 Stage 2(준비중). budget 에 함께 박힘.
+  const [dealType, setDealType] = React.useState<DealType>(
+    filters.budget?.dealType ?? "jeonse",
+  );
 
-  const syncBudget = (minStr: string, maxStr: string) => {
+  const syncBudget = (minStr: string, maxStr: string, dt: DealType = dealType) => {
     const minNum = Number(minStr);
     const maxNum = Number(maxStr);
     if (minStr !== "" && maxStr !== "" && minNum > 0 && maxNum > 0) {
       setFilters({
         ...filters,
-        budget: { min: minNum * 10000, max: maxNum * 10000 },
+        budget: { dealType: dt, min: minNum * 10000, max: maxNum * 10000 },
       });
     } else {
       setFilters({ ...filters, budget: undefined });
     }
+  };
+
+  // 거래유형 변경 — dealType 즉시 반영 + 입력값 있으면 budget 재동기화(새 dealType 로).
+  const handleDealType = (dt: DealType) => {
+    setDealType(dt);
+    syncBudget(budgetMinInput, budgetMaxInput, dt);
   };
 
   const { suggestions: suggestionsA } = useAddressSuggest(queryA);
@@ -210,10 +220,11 @@ export default function DiagnosisPage() {
       setShowL2(Boolean(config.leisureB));
       // Issue #112 — budget local state sync (★ filters.budget 자가 치유와 별개 영역).
       const nextBudget = (config.filters?.budget ?? undefined) as
-        | { min: number; max: number }
+        | { dealType?: DealType; min: number; max: number }
         | undefined;
       setBudgetMinInput(nextBudget ? String(nextBudget.min / 10000) : "");
       setBudgetMaxInput(nextBudget ? String(nextBudget.max / 10000) : "");
+      setDealType(nextBudget?.dealType ?? "jeonse");
       pushToast({ variant: "default", message: "이전 조건을 불러왔습니다 ✨" });
     } catch {
       pushToast({ variant: "default", message: "이전 조건 불러오기 실패" });
@@ -390,8 +401,49 @@ export default function DiagnosisPage() {
               />
               분
             </label>
+            {/* 거래유형(전세/매매) — 월세는 Stage 2(준비중·disabled). 선택 시 예산 라벨도 전환. */}
+            <div className="space-y-s-2">
+              <p className="text-body-sm text-ink-2">거래유형</p>
+              <div className="flex gap-s-2" role="group" aria-label="거래유형 선택">
+                {(
+                  [
+                    { key: "jeonse", label: "전세" },
+                    { key: "maemae", label: "매매" },
+                  ] as const
+                ).map((opt) => {
+                  const active = dealType === opt.key;
+                  return (
+                    <button
+                      key={opt.key}
+                      type="button"
+                      onClick={() => handleDealType(opt.key)}
+                      aria-pressed={active}
+                      className={cn(
+                        "rounded-sm border px-s-3 py-s-1 text-body-sm font-bold transition-all",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2",
+                        active
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-card-border bg-surface text-ink-2 hover:brightness-95",
+                      )}
+                    >
+                      {opt.label}
+                    </button>
+                  );
+                })}
+                <button
+                  type="button"
+                  disabled
+                  aria-disabled="true"
+                  title="월세는 준비 중입니다"
+                  className="cursor-not-allowed rounded-sm border border-card-border bg-surface px-s-3 py-s-1 text-body-sm font-bold text-ink-3 opacity-60"
+                >
+                  월세{" "}
+                  <span className="text-caption font-normal">준비중</span>
+                </button>
+              </div>
+            </div>
             <label className="flex flex-wrap items-center gap-s-2 text-body-sm text-ink-2">
-              예산
+              {dealType === "maemae" ? "매매가" : "전세 보증금"}
               <input
                 type="number"
                 min={1}

--- a/onday-app/src/app/diagnosis/result/[id]/budget-chip-options.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/budget-chip-options.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 
+import type { DealType } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 // Issue #112 — what-if 명시적 확인 UX (★ TimeChipOptions 답습 + 억 단위 2 number input + 내부 만원 변환).
@@ -13,6 +14,7 @@ interface BudgetChipOptionsProps {
   baseMax: number; // 만원 단위
   onConfirm: (min: number, max: number) => void; // 만원 단위
   disabled?: boolean;
+  dealType?: DealType; // 라벨용(읽기전용) — 거래유형은 진단 시점 고정, what-if 는 min/max 만 조정.
 }
 
 export function BudgetChipOptions({
@@ -20,7 +22,9 @@ export function BudgetChipOptions({
   baseMax,
   onConfirm,
   disabled,
+  dealType,
 }: BudgetChipOptionsProps) {
+  const budgetLabel = dealType === "maemae" ? "매매가" : "전세 보증금";
   // 내부 영역 = 억 단위 (★ UX 직관).
   const [pendingMin, setPendingMin] = React.useState(baseMin / 10000);
   const [pendingMax, setPendingMax] = React.useState(baseMax / 10000);
@@ -43,9 +47,9 @@ export function BudgetChipOptions({
   );
 
   return (
-    <div className="pt-s-2" role="group" aria-label="예산 범위 변경 입력">
+    <div className="pt-s-2" role="group" aria-label={`${budgetLabel} 범위 변경 입력`}>
       <label className="flex flex-wrap items-center gap-s-2 text-caption font-bold text-ink-2">
-        예산
+        {budgetLabel}
         <input
           type="number"
           min={1}

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -204,7 +204,11 @@ export function ResultContent({
       });
       return;
     }
-    const newFilters = { ...filters, budget: { min, max } };
+    // what-if 는 min/max 만 조정 — dealType(거래유형)은 진단 시점 값 보존.
+    const newFilters = {
+      ...filters,
+      budget: { dealType: filters.budget?.dealType, min, max },
+    };
     setFilters(newFilters);
     const next = recomputeWhatIf(
       baselineRef.current ?? candidates,
@@ -468,6 +472,7 @@ export function ResultContent({
           key={`${filters.budget.min}-${filters.budget.max}`}
           baseMin={filters.budget.min}
           baseMax={filters.budget.max}
+          dealType={filters.budget.dealType}
           onConfirm={handleBudgetWhatIf}
         />
       )}
@@ -556,7 +561,7 @@ export function ResultContent({
                     ]
                   : []),
               ]}
-              price={formatPrice(c.priceRange)}
+              price={formatPrice(c.priceRange, filters.budget?.dealType)}
               tagReason={buildPreferenceReason(priorityKey, c) ?? undefined}
               onClick={() => open(c.id)}
             />

--- a/onday-app/src/features/diagnosis/mock-calculator.ts
+++ b/onday-app/src/features/diagnosis/mock-calculator.ts
@@ -138,10 +138,14 @@ async function computeOneCandidate(
           : undefined,
       score,
       safetyGrade: mode === "single" ? neighborhood.safetyGrade : undefined,
-      priceRange: {
-        min: Math.round(neighborhood.avgPrice * 0.85),
-        max: Math.round(neighborhood.avgPrice * 1.15),
-      },
+      // priceRange 는 거래유형 scale — 매매는 전세가율 환산값 기준(추정). 전세=avgPrice 그대로(동일).
+      priceRange: (() => {
+        const base = comparablePrice(
+          neighborhood.avgPrice,
+          filters.budget?.dealType,
+        );
+        return { min: Math.round(base * 0.85), max: Math.round(base * 1.15) };
+      })(),
       facilities: neighborhood.facilities,
       lines: neighborhood.lines,
       listingsCount: neighborhood.listingsCount,

--- a/onday-app/src/features/diagnosis/result-utils.ts
+++ b/onday-app/src/features/diagnosis/result-utils.ts
@@ -1,7 +1,10 @@
 import type { CommuteMode as ChipMode } from "@/components/data/commute-chip";
-import type { CandidateArea, CommuteMode } from "@/lib/types";
+import type { CandidateArea, CommuteMode, DealType } from "@/lib/types";
 
 export type SortKey = "score" | "commute" | "price";
+
+// 거래유형 표시 라벨 — undefined(레거시 데이터)는 전세로 간주(avgPrice=전세 추정).
+const DEAL_LABEL: Record<DealType, string> = { jeonse: "전세", maemae: "매매" };
 
 const SORT_KEYS: ReadonlySet<SortKey> = new Set(["score", "commute", "price"]);
 
@@ -37,13 +40,16 @@ export function toChipMode(mode: CommuteMode): ChipMode {
   return mode === "driving" ? "car" : "subway";
 }
 
-// priceRange (단위 만원) → "평균 9.2억"
+// priceRange (단위 만원) → "평균 9.2억" / 매매는 "평균 9.2억 (추정)"
+//   priceRange 는 dealType scale 로 계산됨(comparablePrice). 매매는 전세가율 환산이라 "추정" 명시.
 export function formatPrice(
   range: { min: number; max: number } | undefined,
+  dealType?: DealType,
 ): string {
   if (!range) return "시세 미공개";
   const avg = (range.min + range.max) / 2;
-  return `평균 ${(avg / 10000).toFixed(1)}억`;
+  const suffix = dealType === "maemae" ? " (추정)" : "";
+  return `평균 ${(avg / 10000).toFixed(1)}억${suffix}`;
 }
 
 export function formatCommuteFilter(maxMinutes: number | undefined): string {
@@ -51,12 +57,13 @@ export function formatCommuteFilter(maxMinutes: number | undefined): string {
 }
 
 export function formatBudgetFilter(
-  budget: { min: number; max: number } | undefined,
+  budget: { dealType?: DealType; min: number; max: number } | undefined,
 ): string {
   if (!budget) return "전체";
   const min = (budget.min / 10000).toFixed(0);
   const max = (budget.max / 10000).toFixed(0);
-  return `${min}-${max}억`;
+  const label = DEAL_LABEL[budget.dealType ?? "jeonse"];
+  return `${label} ${min}-${max}억`;
 }
 
 export function markerLabel(dong: string): string {

--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -190,10 +190,11 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
         leisureB: leisureB ?? undefined,
         score,
         safetyGrade: mode === "single" ? n.safetyGrade : undefined,
-        priceRange: {
-          min: Math.round(n.avgPrice * 0.85),
-          max: Math.round(n.avgPrice * 1.15),
-        },
+        // priceRange 는 거래유형 scale — 매매는 전세가율 환산값 기준(추정). 전세=avgPrice 그대로(동일).
+        priceRange: (() => {
+          const base = comparablePrice(n.avgPrice, filters.budget?.dealType);
+          return { min: Math.round(base * 0.85), max: Math.round(base * 1.15) };
+        })(),
         facilities: n.facilities,
         lines: n.lines,
         listingsCount: n.listingsCount,


### PR DESCRIPTION
## 월세 토글 Stage 1-B — UX (1-A 구조 위에 전세/매매 화면)

PR #154(1-A 구조, 머지·라이브 회귀 0 검증 완료) 위에 거래유형 UX를 올립니다. 월세는 **disabled "준비중" 자리**만, 활성화는 Stage 2.

### 이 PR이 하는 일
- **입력 폼 거래유형 토글** — 전세/매매 active + **월세 disabled "준비중"**. 선택 시 예산 라벨이 **"전세 보증금" ↔ "매매가"** 로 전환
- **`priceRange` 를 dealType scale 로 계산** (`comparablePrice`) — 1-A에서 미뤄둔 what-if 필터 정합을 해소. 전세=avgPrice 그대로(**회귀 0**), 매매만 전세가율 환산 range
- **"추정" 표시** — `formatPrice(range, dealType)` → 매매는 `"평균 N억 (추정)"` (날조 금지)
- **거래유형 라벨** — `formatBudgetFilter` → `"전세 4-5억"` / `"매매 8-10억"`
- **what-if(BudgetChipOptions)** — dealType 라벨 표시(읽기전용) + min/max 변경 시 dealType 보존

### 회귀 0 (전세)
`comparablePrice('jeonse')=avgPrice` 이므로 priceRange·필터·점수·정렬 전부 **기존과 동일**. 유일한 의도적 변화 = 예산 뱃지 "전세" 접두(사용자 승인). 매매 경로만 신규.

### 정직성
매매가는 데이터 미보유 → 전세가율(0.55) 환산값이라 화면에 **"추정" 명시**. avgPrice="전세 추정 보증금" 전제와 일관.

### 알려진 후속 (이 PR 범위 밖)
- `favorites-menu` 는 찜 스냅샷에 dealType 미보유 → "추정" 미표기. 별도 후속.
- Stage 2: 월세 mock(전월세전환율 5%) 활성화.

### 검증
- ✅ `tsc --noEmit` 통과 · ✅ ESLint 0 · ✅ 인코딩 정상
- 머지 후 라이브 검증 예정: **전세 4-5억(기존과 동일)** + **매매 토글 → 8-10억 → "추정" 표시 + 그 범위 동네** + 월세 disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)