### PR TITLE
feat(diagnosis): 월세 구조+데이터 토대 — 월세 Stage 2-A

### DIFF
--- a/onday-app/src/features/diagnosis/mock-calculator.ts
+++ b/onday-app/src/features/diagnosis/mock-calculator.ts
@@ -12,7 +12,7 @@ import {
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
 // ScoringEngine (#27) — 점수 로직은 공용 모듈로 추출. client(실 ODsay) + server(mock) 공유.
 import { scoreCandidate } from "@/lib/diagnosis/scoring";
-import { comparablePrice } from "@/lib/diagnosis/price";
+import { comparablePrice, estimateWolse } from "@/lib/diagnosis/price";
 
 interface ComputeResult {
   status: "fulfilled";
@@ -89,14 +89,32 @@ async function computeOneCandidate(
   // Issue #123 — 예산 범위 외 제외 (★ maxCommuteTime 답습 정합).
   //   사용자 시각 검증 짚음: "예산 4~5억 박힘 + 결과 카드 4~5억 사이 X = 다양 박힘" → 범위 외 카드 제외 박힘.
   if (filters.budget) {
-    // 거래유형별 비교가 — 매매 시 전세가율로 환산(추정). 미지정=전세(기존과 동일).
-    const price = comparablePrice(neighborhood.avgPrice, filters.budget.dealType);
-    if (price < filters.budget.min || price > filters.budget.max) {
-      return {
-        status: "rejected",
-        neighborhoodId: neighborhood.id,
-        reason: `Price ${price} outside budget [${filters.budget.min}, ${filters.budget.max}]`,
-      };
+    if (filters.budget.dealType === "wolse") {
+      // 월세 — 보증금(상한) + 월세(범위) 2축. 추정값(estimateWolse) 기준.
+      const { deposit, monthly } = estimateWolse(neighborhood.avgPrice);
+      const depositOk = deposit <= (filters.budget.depositMax ?? Infinity);
+      const monthlyOk =
+        monthly >= filters.budget.min && monthly <= filters.budget.max;
+      if (!depositOk || !monthlyOk) {
+        return {
+          status: "rejected",
+          neighborhoodId: neighborhood.id,
+          reason: `Wolse deposit ${deposit}/monthly ${monthly} outside budget`,
+        };
+      }
+    } else {
+      // 전세/매매 — 단일 금액. 매매 시 전세가율로 환산(추정). 미지정=전세(기존과 동일).
+      const price = comparablePrice(
+        neighborhood.avgPrice,
+        filters.budget.dealType,
+      );
+      if (price < filters.budget.min || price > filters.budget.max) {
+        return {
+          status: "rejected",
+          neighborhoodId: neighborhood.id,
+          reason: `Price ${price} outside budget [${filters.budget.min}, ${filters.budget.max}]`,
+        };
+      }
     }
   }
 
@@ -146,6 +164,11 @@ async function computeOneCandidate(
         );
         return { min: Math.round(base * 0.85), max: Math.round(base * 1.15) };
       })(),
+      // 월세 추정 — dealType=wolse 시만 채움(표시는 보증금/월). 그 외 undefined.
+      wolseEstimate:
+        filters.budget?.dealType === "wolse"
+          ? estimateWolse(neighborhood.avgPrice)
+          : undefined,
       facilities: neighborhood.facilities,
       lines: neighborhood.lines,
       listingsCount: neighborhood.listingsCount,

--- a/onday-app/src/features/diagnosis/result-utils.ts
+++ b/onday-app/src/features/diagnosis/result-utils.ts
@@ -4,7 +4,11 @@ import type { CandidateArea, CommuteMode, DealType } from "@/lib/types";
 export type SortKey = "score" | "commute" | "price";
 
 // 거래유형 표시 라벨 — undefined(레거시 데이터)는 전세로 간주(avgPrice=전세 추정).
-const DEAL_LABEL: Record<DealType, string> = { jeonse: "전세", maemae: "매매" };
+const DEAL_LABEL: Record<DealType, string> = {
+  jeonse: "전세",
+  maemae: "매매",
+  wolse: "월세",
+};
 
 const SORT_KEYS: ReadonlySet<SortKey> = new Set(["score", "commute", "price"]);
 
@@ -52,14 +56,37 @@ export function formatPrice(
   return `평균 ${(avg / 10000).toFixed(1)}억${suffix}`;
 }
 
+// 월세 추정 { deposit, monthly }(만원) → "보증금 X억 / 월 Y만 (추정)"
+//   동네 데이터는 전세 추정뿐 → 전월세전환율 환산값이라 "추정" 명시(날조 X).
+export function formatWolse(
+  estimate: { deposit: number; monthly: number } | undefined,
+): string {
+  if (!estimate) return "시세 미공개";
+  const deposit = (estimate.deposit / 10000).toFixed(1);
+  return `보증금 ${deposit}억 / 월 ${estimate.monthly}만 (추정)`;
+}
+
 export function formatCommuteFilter(maxMinutes: number | undefined): string {
   return maxMinutes ? `≤ ${maxMinutes}분` : "제한 없음";
 }
 
 export function formatBudgetFilter(
-  budget: { dealType?: DealType; min: number; max: number } | undefined,
+  budget:
+    | {
+        dealType?: DealType;
+        min: number;
+        max: number;
+        depositMin?: number;
+        depositMax?: number;
+      }
+    | undefined,
 ): string {
   if (!budget) return "전체";
+  if (budget.dealType === "wolse") {
+    // 월세 — 보증금 상한(억) + 월세 상한(만원).
+    const dep = ((budget.depositMax ?? 0) / 10000).toFixed(1);
+    return `월세 보증금 ${dep}억↓ / 월 ${budget.max}만↓`;
+  }
   const min = (budget.min / 10000).toFixed(0);
   const max = (budget.max / 10000).toFixed(0);
   const label = DEAL_LABEL[budget.dealType ?? "jeonse"];

--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -12,7 +12,7 @@ import {
   estimateTransfers,
 } from "@/lib/haversine";
 import { scoreCandidate } from "@/lib/diagnosis/scoring";
-import { comparablePrice } from "@/lib/diagnosis/price";
+import { comparablePrice, estimateWolse } from "@/lib/diagnosis/price";
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
 import { KakaoCarClient } from "@/lib/external/kakao-car";
 
@@ -152,10 +152,19 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
       }
       // 필터 — 예산 범위
       if (filters.budget) {
-        // 거래유형별 비교가 — 매매 시 전세가율로 환산(추정). 미지정=전세(기존과 동일).
-        const price = comparablePrice(n.avgPrice, filters.budget.dealType);
-        if (price < filters.budget.min || price > filters.budget.max) {
-          return null;
+        if (filters.budget.dealType === "wolse") {
+          // 월세 — 보증금(상한) + 월세(범위) 2축. 추정값 기준.
+          const { deposit, monthly } = estimateWolse(n.avgPrice);
+          const depositOk = deposit <= (filters.budget.depositMax ?? Infinity);
+          const monthlyOk =
+            monthly >= filters.budget.min && monthly <= filters.budget.max;
+          if (!depositOk || !monthlyOk) return null;
+        } else {
+          // 전세/매매 — 단일 금액. 매매 시 전세가율로 환산(추정). 미지정=전세(기존과 동일).
+          const price = comparablePrice(n.avgPrice, filters.budget.dealType);
+          if (price < filters.budget.min || price > filters.budget.max) {
+            return null;
+          }
         }
       }
 
@@ -195,6 +204,11 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
           const base = comparablePrice(n.avgPrice, filters.budget?.dealType);
           return { min: Math.round(base * 0.85), max: Math.round(base * 1.15) };
         })(),
+        // 월세 추정 — dealType=wolse 시만 채움. 그 외 undefined.
+        wolseEstimate:
+          filters.budget?.dealType === "wolse"
+            ? estimateWolse(n.avgPrice)
+            : undefined,
         facilities: n.facilities,
         lines: n.lines,
         listingsCount: n.listingsCount,

--- a/onday-app/src/lib/diagnosis/price.ts
+++ b/onday-app/src/lib/diagnosis/price.ts
@@ -2,8 +2,14 @@ import type { DealType } from "@/lib/types";
 
 // 전세가율 추정치 — 매매가 ≈ 전세 ÷ 0.55 (서울 아파트 대략치).
 //   동네 데이터는 avgPrice(전세 추정 보증금) 단일값만 보유 → 매매 시세를 보유하지 않아
-//   이 상수로 파생(추정)한다. 표시 시 "추정" 명시 필수(날조 금지). 월세는 Stage 2.
+//   이 상수로 파생(추정)한다. 표시 시 "추정" 명시 필수(날조 금지).
 export const JEONSE_RATIO = 0.55;
+
+// 전월세전환율(연 5%) + 보증금 가정(전세 10% = 반전세) — 월세 추정용.
+//   동네 데이터는 avgPrice(전세 추정)뿐 → 월세를 파생(추정). 보증금 10%면 90%를 월세로
+//   전환해 월세가 다소 높게 나옴(현실 반전세는 보증금 비중↑). "추정" 명시 + 상수라 튜닝 용이.
+export const WOLSE_CONVERSION_RATE = 0.05;
+export const WOLSE_DEPOSIT_RATIO = 0.1;
 
 /**
  * 동네 avgPrice(전세 추정 보증금, 만원) → 거래유형별 비교가(만원).
@@ -17,4 +23,17 @@ export function comparablePrice(
 ): number {
   if (dealType === "maemae") return Math.round(avgPrice / JEONSE_RATIO);
   return avgPrice;
+}
+
+/**
+ * avgPrice(전세 추정 보증금, 만원) → 월세 추정 { deposit, monthly }(만원).
+ *   보증금 = 전세 × 10%, 월세 = (전세 − 보증금) × 5% ÷ 12 (전월세전환율 환산, 추정).
+ */
+export function estimateWolse(avgPrice: number): {
+  deposit: number;
+  monthly: number;
+} {
+  const deposit = Math.round(avgPrice * WOLSE_DEPOSIT_RATIO);
+  const monthly = Math.round(((avgPrice - deposit) * WOLSE_CONVERSION_RATE) / 12);
+  return { deposit, monthly };
 }

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -3,8 +3,9 @@ export type DiagnosisMode = "couple" | "single";
 export type DiagnosisStatus = "processing" | "completed" | "expired";
 export type SafetyGrade = "A" | "B" | "C" | "D";
 export type CommuteMode = "transit" | "driving";
-// 거래유형 — budget 범위가 어떤 시세를 가리키는지. Stage 2에서 "wolse"(월세) 추가 예정.
-export type DealType = "jeonse" | "maemae";
+// 거래유형 — budget 범위가 어떤 시세를 가리키는지.
+//   jeonse/maemae=단일 금액(min/max), wolse=월세(min/max) + 보증금(depositMin/Max) 2축.
+export type DealType = "jeonse" | "maemae" | "wolse";
 
 export interface Coordinate {
   lat: number;
@@ -36,7 +37,9 @@ export interface CandidateArea {
   leisureB?: CommuteInfo;
   score: number; // 0-100
   safetyGrade?: SafetyGrade;
-  priceRange?: { min: number; max: number }; // KRW in 만원
+  priceRange?: { min: number; max: number }; // KRW in 만원 (전세/매매 표시·정렬용)
+  // 월세 추정(만원) — dealType=wolse 시 채움. 표시는 보증금/월 (estimateWolse, 추정).
+  wolseEstimate?: { deposit: number; monthly: number };
   facilities?: { convenience: number; cafes: number; schools?: number };
   lines?: string; // 지하철/버스 노선 요약 — step-10.5에서 22개 보강
   listingsCount?: number; // 매물 건수 — step-10.5에서 보강
@@ -53,9 +56,16 @@ export interface CommuteSchedule {
 
 export interface DiagnosisFilters {
   maxCommuteTime?: number; // minutes
-  // dealType 미지정 = 전세 (기존 {min,max} 하위호환). min/max 단위 = 만원.
-  //   maemae 시 비교가는 comparablePrice()로 전세→매매 환산(추정).
-  budget?: { dealType?: DealType; min: number; max: number };
+  // dealType 미지정 = 전세 (기존 {min,max} 하위호환). 단위 = 만원.
+  //   jeonse/maemae: min/max = 금액 범위 (maemae 비교가는 comparablePrice 환산).
+  //   wolse: min/max = 월세 범위, depositMin/Max = 보증금 범위 (상한만 입력 시 min=0).
+  budget?: {
+    dealType?: DealType;
+    min: number;
+    max: number;
+    depositMin?: number;
+    depositMax?: number;
+  };
   commuteSchedule?: CommuteSchedule; // 요일 + 시간 자유 — Issue #98 commuteSchedule DTO 정수 정정 (★ REFACTOR-COMMUTE-LEGACY #102 timeRange 제거 완성).
   priorities?: string[];
 }

--- a/onday-app/src/lib/types/saved-search.ts
+++ b/onday-app/src/lib/types/saved-search.ts
@@ -28,7 +28,13 @@ export interface SearchParams {
   coordinateB?: { lat: number; lng: number };
   filters?: {
     maxCommuteTime?: number;
-    budget?: { dealType?: "jeonse" | "maemae"; min: number; max: number };
+    budget?: {
+      dealType?: "jeonse" | "maemae" | "wolse";
+      min: number;
+      max: number;
+      depositMin?: number;
+      depositMax?: number;
+    };
     commuteSchedule?: CommuteSchedule;
     priorities?: string[];
   };

--- a/onday-app/src/lib/validators/diagnosis.ts
+++ b/onday-app/src/lib/validators/diagnosis.ts
@@ -18,9 +18,11 @@ export const diagnosisInputSchema = z.object({
     maxCommuteTime: z.number().min(10).max(120).optional(),
     budget: z
       .object({
-        dealType: z.enum(["jeonse", "maemae"]).optional(), // 미지정 = 전세 (하위호환)
+        dealType: z.enum(["jeonse", "maemae", "wolse"]).optional(), // 미지정 = 전세 (하위호환)
         min: z.number().min(0),
         max: z.number().min(0),
+        depositMin: z.number().min(0).optional(), // 월세 전용 — 보증금 범위(만원)
+        depositMax: z.number().min(0).optional(),
       })
       .optional(),
     commuteSchedule: z


### PR DESCRIPTION
## 월세 Stage 2-A — 구조+데이터 (토글 disabled, 전세/매매 무회귀)

월세 mock의 **구조/데이터만**. 입력 토글은 아직 disabled, 활성화는 2-B.
월세는 **보증금+월세 2축**이라 전세/매매의 단일 금액 모델을 확장합니다(처음 말한 "예산 구조 바뀜" 지점).

### 이 PR이 하는 일
- `DealType += "wolse"` · `budget.depositMin/Max` 추가(플랫 확장) · `CandidateArea.wolseEstimate`
- **`estimateWolse()`** — 전월세전환율 5% + 보증금 10%(반전세) → `{deposit, monthly}` 추정
- 필터 **월세 분기** — 보증금 상한 + 월세 범위 (mock-calculator·run-real)
- `result-utils` — `formatWolse("보증금 X억 / 월 Y만 (추정)")` + `formatBudgetFilter` 월세 라벨
- `validators`·`saved-search` 월세 필드(하위호환)

### 회귀 0 (전세/매매)
필터는 `if (wolse) … else { 기존 코드 그대로 }` — 전세/매매 분기는 **바이트 동일**. `wolseEstimate`는 dealType=wolse 시만 채움. priceRange 무변경. → 전세/매매 무회귀.

### 정직성
월세는 데이터 미보유 → 전월세전환율 환산값이라 **"추정" 명시**. 보증금 10%면 90%를 월세로 전환해 **월세가 다소 높게** 나옴(현실 반전세는 보증금 비중↑) — 상수 1개라 라이브 보고 튜닝 가능.

### 결정 반영 (사용자)
플랫 확장 / 보증금 상한+월세 상한 / 보증금 10% 반전세.

### 범위 밖 (2-B)
월세 토글 활성화 + 월세 입력칸(보증금+월세) + what-if + 카드 표시.

### 검증
- ✅ `tsc --noEmit` 통과 · ✅ ESLint 0 · ✅ 인코딩 정상
- 토글 disabled라 화면 변화 0 — 머지 후 라이브에서 전세/매매 기존 동일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)