### PR TITLE
feat(diagnosis): 월세 UX 활성화 — 월세 Stage 2-B (마지막)

### DIFF
--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -93,17 +93,28 @@ export default function DiagnosisPage() {
   // Issue #112 — maxCommuteTime + budget 입력 영역 (★ 단방향 input → store 동기화, "이전 조건 불러오기" 시점 별도 sync).
   //   budget은 억 단위 input + 내부 만원 변환 (★ formatBudgetFilter "X-Y억" 표시 정합).
   //   min/max 둘 다 박힘 + > 0 시점 store budget 박힘. 그 외 = undefined.
+  // 전세/매매 = 억~억 단일 금액. 월세는 별도 입력(아래) — 억 input 은 비전세 시 비움.
+  const isWolseBudget = filters.budget?.dealType === "wolse";
   const [budgetMinInput, setBudgetMinInput] = React.useState(
-    filters.budget ? String(filters.budget.min / 10000) : "",
+    filters.budget && !isWolseBudget ? String(filters.budget.min / 10000) : "",
   );
   const [budgetMaxInput, setBudgetMaxInput] = React.useState(
-    filters.budget ? String(filters.budget.max / 10000) : "",
+    filters.budget && !isWolseBudget ? String(filters.budget.max / 10000) : "",
   );
-  // 거래유형(전세/매매) — 월세는 Stage 2(준비중). budget 에 함께 박힘.
+  // 월세 전용 — 보증금 상한(억) + 월세 상한(만원). 월세 상한이 主(필수), 보증금은 옵션.
+  const [depositMaxInput, setDepositMaxInput] = React.useState(
+    isWolseBudget && filters.budget?.depositMax
+      ? String(filters.budget.depositMax / 10000)
+      : "",
+  );
+  const [monthlyMaxInput, setMonthlyMaxInput] = React.useState(
+    isWolseBudget ? String(filters.budget!.max) : "",
+  );
   const [dealType, setDealType] = React.useState<DealType>(
     filters.budget?.dealType ?? "jeonse",
   );
 
+  // 전세/매매 — 억~억 단일 금액 범위.
   const syncBudget = (minStr: string, maxStr: string, dt: DealType = dealType) => {
     const minNum = Number(minStr);
     const maxNum = Number(maxStr);
@@ -117,10 +128,32 @@ export default function DiagnosisPage() {
     }
   };
 
-  // 거래유형 변경 — dealType 즉시 반영 + 입력값 있으면 budget 재동기화(새 dealType 로).
+  // 월세 — 월세 상한(만원, 必) + 보증금 상한(억→만원, 옵션). 월세 상한 없으면 budget 해제.
+  //   Infinity 미저장(JSON null화 방지) — 보증금 미입력 시 depositMax=undefined(필터가 ??로 처리).
+  const syncWolse = (depStr: string, monStr: string) => {
+    const monNum = Number(monStr);
+    if (monStr !== "" && monNum > 0) {
+      const depNum = Number(depStr);
+      const hasDep = depStr !== "" && depNum > 0;
+      setFilters({
+        ...filters,
+        budget: {
+          dealType: "wolse",
+          min: 0,
+          max: monNum,
+          depositMax: hasDep ? depNum * 10000 : undefined,
+        },
+      });
+    } else {
+      setFilters({ ...filters, budget: undefined });
+    }
+  };
+
+  // 거래유형 변경 — dealType 반영 + 해당 입력값으로 budget 재동기화.
   const handleDealType = (dt: DealType) => {
     setDealType(dt);
-    syncBudget(budgetMinInput, budgetMaxInput, dt);
+    if (dt === "wolse") syncWolse(depositMaxInput, monthlyMaxInput);
+    else syncBudget(budgetMinInput, budgetMaxInput, dt);
   };
 
   const { suggestions: suggestionsA } = useAddressSuggest(queryA);
@@ -220,10 +253,26 @@ export default function DiagnosisPage() {
       setShowL2(Boolean(config.leisureB));
       // Issue #112 — budget local state sync (★ filters.budget 자가 치유와 별개 영역).
       const nextBudget = (config.filters?.budget ?? undefined) as
-        | { dealType?: DealType; min: number; max: number }
+        | {
+            dealType?: DealType;
+            min: number;
+            max: number;
+            depositMax?: number;
+          }
         | undefined;
-      setBudgetMinInput(nextBudget ? String(nextBudget.min / 10000) : "");
-      setBudgetMaxInput(nextBudget ? String(nextBudget.max / 10000) : "");
+      const nextIsWolse = nextBudget?.dealType === "wolse";
+      setBudgetMinInput(
+        nextBudget && !nextIsWolse ? String(nextBudget.min / 10000) : "",
+      );
+      setBudgetMaxInput(
+        nextBudget && !nextIsWolse ? String(nextBudget.max / 10000) : "",
+      );
+      setDepositMaxInput(
+        nextIsWolse && nextBudget?.depositMax
+          ? String(nextBudget.depositMax / 10000)
+          : "",
+      );
+      setMonthlyMaxInput(nextIsWolse ? String(nextBudget!.max) : "");
       setDealType(nextBudget?.dealType ?? "jeonse");
       pushToast({ variant: "default", message: "이전 조건을 불러왔습니다 ✨" });
     } catch {
@@ -401,7 +450,7 @@ export default function DiagnosisPage() {
               />
               분
             </label>
-            {/* 거래유형(전세/매매) — 월세는 Stage 2(준비중·disabled). 선택 시 예산 라벨도 전환. */}
+            {/* 거래유형(전세/매매/월세) — 선택 시 예산 입력칸·라벨 전환. */}
             <div className="space-y-s-2">
               <p className="text-body-sm text-ink-2">거래유형</p>
               <div className="flex gap-s-2" role="group" aria-label="거래유형 선택">
@@ -409,6 +458,7 @@ export default function DiagnosisPage() {
                   [
                     { key: "jeonse", label: "전세" },
                     { key: "maemae", label: "매매" },
+                    { key: "wolse", label: "월세" },
                   ] as const
                 ).map((opt) => {
                   const active = dealType === opt.key;
@@ -430,47 +480,77 @@ export default function DiagnosisPage() {
                     </button>
                   );
                 })}
-                <button
-                  type="button"
-                  disabled
-                  aria-disabled="true"
-                  title="월세는 준비 중입니다"
-                  className="cursor-not-allowed rounded-sm border border-card-border bg-surface px-s-3 py-s-1 text-body-sm font-bold text-ink-3 opacity-60"
-                >
-                  월세{" "}
-                  <span className="text-caption font-normal">준비중</span>
-                </button>
               </div>
             </div>
-            <label className="flex flex-wrap items-center gap-s-2 text-body-sm text-ink-2">
-              {dealType === "maemae" ? "매매가" : "전세 보증금"}
-              <input
-                type="number"
-                min={1}
-                value={budgetMinInput}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setBudgetMinInput(v);
-                  syncBudget(v, budgetMaxInput);
-                }}
-                placeholder="3"
-                className="w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-              />
-              억 ~
-              <input
-                type="number"
-                min={1}
-                value={budgetMaxInput}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setBudgetMaxInput(v);
-                  syncBudget(budgetMinInput, v);
-                }}
-                placeholder="5"
-                className="w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-              />
-              억
-            </label>
+            {dealType === "wolse" ? (
+              <div className="space-y-s-2">
+                <label className="flex flex-wrap items-center gap-s-2 text-body-sm text-ink-2">
+                  보증금
+                  <input
+                    type="number"
+                    min={0}
+                    value={depositMaxInput}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      setDepositMaxInput(v);
+                      syncWolse(v, monthlyMaxInput);
+                    }}
+                    placeholder="1"
+                    className="w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  />
+                  억 이하
+                </label>
+                <label className="flex flex-wrap items-center gap-s-2 text-body-sm text-ink-2">
+                  월세
+                  <input
+                    type="number"
+                    min={1}
+                    value={monthlyMaxInput}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      setMonthlyMaxInput(v);
+                      syncWolse(depositMaxInput, v);
+                    }}
+                    placeholder="100"
+                    className="w-20 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  />
+                  만원 이하
+                </label>
+                <p className="text-caption text-ink-3">
+                  동네 시세는 전월세전환율 기준 추정값입니다.
+                </p>
+              </div>
+            ) : (
+              <label className="flex flex-wrap items-center gap-s-2 text-body-sm text-ink-2">
+                {dealType === "maemae" ? "매매가" : "전세 보증금"}
+                <input
+                  type="number"
+                  min={1}
+                  value={budgetMinInput}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setBudgetMinInput(v);
+                    syncBudget(v, budgetMaxInput);
+                  }}
+                  placeholder="3"
+                  className="w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                />
+                억 ~
+                <input
+                  type="number"
+                  min={1}
+                  value={budgetMaxInput}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setBudgetMaxInput(v);
+                    syncBudget(budgetMinInput, v);
+                  }}
+                  placeholder="5"
+                  className="w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1 text-body-sm font-bold text-ink tabular focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                />
+                억
+              </label>
+            )}
           </div>
         </section>
 

--- a/onday-app/src/app/diagnosis/result/[id]/budget-chip-options.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/budget-chip-options.tsx
@@ -8,23 +8,76 @@ import { cn } from "@/lib/utils";
 // Issue #112 — what-if 명시적 확인 UX (★ TimeChipOptions 답습 + 억 단위 2 number input + 내부 만원 변환).
 //   사용자 억 입력 → pending 박힘 → "변경" 버튼 클릭 또는 Enter 키 → onConfirm(min만원, max만원).
 //   pending == baseValue 시 버튼 disabled. min > max 또는 ≤ 0 시 invalid.
-//   baseMin/baseMax 변경 시 컴포넌트 재마운트 = 부모 영역 `key={baseMin}-${baseMax}` 박힘.
+//   baseMin/baseMax 변경 시 컴포넌트 재마운트 = 부모 영역 `key=...` 박힘.
+//   월세(Stage 2-B)는 보증금/월세 2축이라 WolseChipOptions 로 분기 — 전세/매매 코드 무변경.
 interface BudgetChipOptionsProps {
   baseMin: number; // 만원 단위
-  baseMax: number; // 만원 단위
-  onConfirm: (min: number, max: number) => void; // 만원 단위
+  baseMax: number; // 만원 단위 (월세 시 = 월세 상한)
+  baseDepositMax?: number; // 만원 단위 — 월세 전용 보증금 상한
+  onConfirm: (min: number, max: number, depositMax?: number) => void; // 만원 단위
   disabled?: boolean;
-  dealType?: DealType; // 라벨용(읽기전용) — 거래유형은 진단 시점 고정, what-if 는 min/max 만 조정.
+  dealType?: DealType;
 }
+
+const INPUT_CLASS = cn(
+  "w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1",
+  "text-body-sm font-bold text-ink tabular",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+  "disabled:opacity-50 disabled:cursor-not-allowed",
+);
+
+const CONFIRM_BTN_CLASS = cn(
+  "rounded-sm bg-primary px-s-3 py-s-1 text-body-sm font-bold text-primary-foreground",
+  "transition-all hover:brightness-95",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+  "disabled:opacity-50 disabled:cursor-not-allowed",
+);
 
 export function BudgetChipOptions({
   baseMin,
   baseMax,
+  baseDepositMax,
   onConfirm,
   disabled,
   dealType,
 }: BudgetChipOptionsProps) {
+  if (dealType === "wolse") {
+    return (
+      <WolseChipOptions
+        baseMonthly={baseMax}
+        baseDepositMax={baseDepositMax}
+        onConfirm={onConfirm}
+        disabled={disabled}
+      />
+    );
+  }
+
   const budgetLabel = dealType === "maemae" ? "매매가" : "전세 보증금";
+  return (
+    <BudgetRangeChip
+      baseMin={baseMin}
+      baseMax={baseMax}
+      label={budgetLabel}
+      onConfirm={onConfirm}
+      disabled={disabled}
+    />
+  );
+}
+
+// 전세/매매 — 억~억 단일 금액 범위 (기존 로직 보존).
+function BudgetRangeChip({
+  baseMin,
+  baseMax,
+  label,
+  onConfirm,
+  disabled,
+}: {
+  baseMin: number;
+  baseMax: number;
+  label: string;
+  onConfirm: (min: number, max: number) => void;
+  disabled?: boolean;
+}) {
   // 내부 영역 = 억 단위 (★ UX 직관).
   const [pendingMin, setPendingMin] = React.useState(baseMin / 10000);
   const [pendingMax, setPendingMax] = React.useState(baseMax / 10000);
@@ -39,17 +92,10 @@ export function BudgetChipOptions({
     }
   };
 
-  const inputClass = cn(
-    "w-16 rounded-sm border border-card-border bg-surface px-s-2 py-s-1",
-    "text-body-sm font-bold text-ink tabular",
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-    "disabled:opacity-50 disabled:cursor-not-allowed",
-  );
-
   return (
-    <div className="pt-s-2" role="group" aria-label={`${budgetLabel} 범위 변경 입력`}>
+    <div className="pt-s-2" role="group" aria-label={`${label} 범위 변경 입력`}>
       <label className="flex flex-wrap items-center gap-s-2 text-caption font-bold text-ink-2">
-        {budgetLabel}
+        {label}
         <input
           type="number"
           min={1}
@@ -62,7 +108,7 @@ export function BudgetChipOptions({
             }
           }}
           disabled={disabled}
-          className={inputClass}
+          className={INPUT_CLASS}
         />
         억 ~
         <input
@@ -77,19 +123,96 @@ export function BudgetChipOptions({
             }
           }}
           disabled={disabled}
-          className={inputClass}
+          className={INPUT_CLASS}
         />
         억
         <button
           type="button"
           onClick={handleConfirm}
           disabled={!canConfirm}
-          className={cn(
-            "rounded-sm bg-primary px-s-3 py-s-1 text-body-sm font-bold text-primary-foreground",
-            "transition-all hover:brightness-95",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-            "disabled:opacity-50 disabled:cursor-not-allowed",
-          )}
+          className={CONFIRM_BTN_CLASS}
+        >
+          변경
+        </button>
+      </label>
+    </div>
+  );
+}
+
+// 월세 — 보증금 상한(억) + 월세 상한(만원). 월세 상한이 主, 보증금 옵션(0=미설정).
+function WolseChipOptions({
+  baseMonthly,
+  baseDepositMax,
+  onConfirm,
+  disabled,
+}: {
+  baseMonthly: number; // 만원
+  baseDepositMax?: number; // 만원
+  onConfirm: (min: number, max: number, depositMax?: number) => void;
+  disabled?: boolean;
+}) {
+  const [pendingMonthly, setPendingMonthly] = React.useState(baseMonthly);
+  const [pendingDeposit, setPendingDeposit] = React.useState(
+    baseDepositMax ? baseDepositMax / 10000 : 0,
+  ); // 억
+  const isUnchanged =
+    pendingMonthly === baseMonthly &&
+    pendingDeposit * 10000 === (baseDepositMax ?? 0);
+  const isValid = pendingMonthly > 0 && pendingDeposit >= 0;
+  const canConfirm = !isUnchanged && !disabled && isValid;
+
+  const handleConfirm = () => {
+    if (canConfirm) {
+      onConfirm(
+        0,
+        pendingMonthly,
+        pendingDeposit > 0 ? pendingDeposit * 10000 : undefined,
+      );
+    }
+  };
+  const onEnter = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleConfirm();
+    }
+  };
+
+  return (
+    <div
+      className="space-y-s-2 pt-s-2"
+      role="group"
+      aria-label="월세 조건 변경 입력"
+    >
+      <label className="flex flex-wrap items-center gap-s-2 text-caption font-bold text-ink-2">
+        보증금
+        <input
+          type="number"
+          min={0}
+          value={pendingDeposit}
+          onChange={(e) => setPendingDeposit(Number(e.target.value))}
+          onKeyDown={onEnter}
+          disabled={disabled}
+          className={INPUT_CLASS}
+        />
+        억 이하
+      </label>
+      <label className="flex flex-wrap items-center gap-s-2 text-caption font-bold text-ink-2">
+        월세
+        <input
+          type="number"
+          min={1}
+          value={pendingMonthly}
+          onChange={(e) => setPendingMonthly(Number(e.target.value))}
+          onKeyDown={onEnter}
+          disabled={disabled}
+          className={INPUT_CLASS}
+        />
+        만원 이하
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={!canConfirm}
+          className={CONFIRM_BTN_CLASS}
         >
           변경
         </button>

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -22,6 +22,7 @@ import {
   formatBudgetFilter,
   formatCommuteFilter,
   formatPrice,
+  formatWolse,
   markerLabel,
   parseSortKey,
   sortCandidates,
@@ -104,9 +105,23 @@ function recomputeWhatIf(
         const maxC = Math.max(c.commuteA.time, c.commuteB?.time ?? 0);
         if (maxC > filters.maxCommuteTime) return false;
       }
-      if (filters.budget && c.priceRange) {
-        const avg = (c.priceRange.min + c.priceRange.max) / 2;
-        if (avg < filters.budget.min || avg > filters.budget.max) return false;
+      if (filters.budget) {
+        if (filters.budget.dealType === "wolse") {
+          // 월세 — 추정 보증금/월세로 재필터 (priceRange 는 전세 scale 라 부적합).
+          const w = c.wolseEstimate;
+          if (w) {
+            if (w.monthly > filters.budget.max) return false;
+            if (
+              filters.budget.depositMax != null &&
+              w.deposit > filters.budget.depositMax
+            ) {
+              return false;
+            }
+          }
+        } else if (c.priceRange) {
+          const avg = (c.priceRange.min + c.priceRange.max) / 2;
+          if (avg < filters.budget.min || avg > filters.budget.max) return false;
+        }
       }
       return true;
     });
@@ -196,7 +211,11 @@ export function ResultContent({
     if (diagnosisId) setResult(diagnosisId, next);
   };
 
-  const handleBudgetWhatIf = (min: number, max: number) => {
+  const handleBudgetWhatIf = (
+    min: number,
+    max: number,
+    depositMax?: number,
+  ) => {
     if (!coordinateA) {
       pushToast({
         variant: "default",
@@ -204,10 +223,10 @@ export function ResultContent({
       });
       return;
     }
-    // what-if 는 min/max 만 조정 — dealType(거래유형)은 진단 시점 값 보존.
+    // what-if 는 금액만 조정 — dealType(거래유형)은 진단 시점 값 보존. depositMax 는 월세 전용.
     const newFilters = {
       ...filters,
-      budget: { dealType: filters.budget?.dealType, min, max },
+      budget: { dealType: filters.budget?.dealType, min, max, depositMax },
     };
     setFilters(newFilters);
     const next = recomputeWhatIf(
@@ -469,9 +488,10 @@ export function ResultContent({
       )}
       {showBudgetOptions && filters.budget != null && (
         <BudgetChipOptions
-          key={`${filters.budget.min}-${filters.budget.max}`}
+          key={`${filters.budget.min}-${filters.budget.max}-${filters.budget.depositMax ?? ""}`}
           baseMin={filters.budget.min}
           baseMax={filters.budget.max}
+          baseDepositMax={filters.budget.depositMax}
           dealType={filters.budget.dealType}
           onConfirm={handleBudgetWhatIf}
         />
@@ -561,7 +581,11 @@ export function ResultContent({
                     ]
                   : []),
               ]}
-              price={formatPrice(c.priceRange, filters.budget?.dealType)}
+              price={
+                filters.budget?.dealType === "wolse"
+                  ? formatWolse(c.wolseEstimate)
+                  : formatPrice(c.priceRange, filters.budget?.dealType)
+              }
               tagReason={buildPreferenceReason(priorityKey, c) ?? undefined}
               onClick={() => open(c.id)}
             />


### PR DESCRIPTION
## 월세 Stage 2-B — UX 활성화 (월세 토글 시리즈 마지막)

2-A(구조/데이터) 위에 월세 입력·표시를 켭니다. 전세/매매 무회귀.

### 이 PR이 하는 일
- **월세 토글 활성화** (준비중 disabled 제거) + **조건부 입력칸**
  - 월세: `보증금 ___억 이하` + `월세 ___만 이하` (월세 상한이 主·필수, 보증금 옵션)
  - 그 외: 기존 `억 ~ 억`
  - `syncWolse` + 이전조건 불러오기 복원. **Infinity 미저장**(JSON null화 방지)
- **what-if**: `BudgetChipOptions` 월세 분기(`WolseChipOptions`) — 전세/매매는 `BudgetRangeChip`으로 **기존 로직 그대로(바이트 동일)**. `onConfirm`에 `depositMax` 옵션 인자 추가
- **recomputeWhatIf**: 월세는 `wolseEstimate`(보증금/월세)로 재필터 (priceRange는 전세 scale이라 부적합)
- **카드**: `dealType=wolse` 시 `formatWolse("보증금 X억 / 월 Y만 (추정)")`

### ★ "추정" 표기 일관성
추정은 **동네 파생 시세(카드)에만** 붙고, **사용자 입력(필터 뱃지)엔 안 붙습니다**. 전세가율(매매)+전월세전환율(월세) 이중 변환이어도 표기 위치는 한 곳 일관 — 혼란 없음.

### 회귀 0 (전세/매매)
폼 억~억 입력·sync, what-if(BudgetRangeChip), formatPrice, 카드 표시 전부 **무변경**. 월세는 조건부 분기로만 추가. 월세 토글만 disabled→활성.

### 검증
- ✅ `tsc --noEmit` 통과 · ✅ ESLint 0 · ✅ 인코딩 정상
- 머지 후 라이브: ① 전세/매매 기존 동일 ② 월세 토글 클릭 ③ 보증금/월세 상한 입력 → 그 조건 동네 ④ 카드 "보증금 X억 / 월 Y만 (추정)" ⑤ 뱃지 "월세 보증금 X억↓ / 월 Y만↓"

### 후속(범위 밖)
- 보증금 10% 비중 → 월세 다소 높음. 라이브 숫자 보고 상수 튜닝 가능
- `favorites-menu` 월세 "추정" 미표기(스냅샷 dealType 미보유) — 별도 후속

🤖 Generated with [Claude Code](https://claude.com/claude-code)