### PR TITLE
fix(single): 싱글 모드 거래유형별 시세 표시 — 월세 오값 수정

### DIFF
--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -29,13 +29,13 @@ import {
 import { getSafetyByGu } from "@/features/single/safety-index";
 import { getCommunityByGu } from "@/lib/diagnosis/community-index";
 import { buildSinglePills, buildSingleMetrics } from "@/features/single/detail-mapper";
-import { markerLabel } from "@/features/diagnosis/result-utils";
+import { formatWolse, markerLabel } from "@/features/diagnosis/result-utils";
 import { buildCommuteRows, buildLines } from "@/features/diagnosis/detail-mapper";
 import { latLngToPixel } from "@/lib/coordinate-transform";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import { cn } from "@/lib/utils";
-import type { CandidateArea, SafetyGrade } from "@/lib/types";
+import type { CandidateArea, DealType, SafetyGrade } from "@/lib/types";
 import { FavoritesMenu } from "@/components/favorites/favorites-menu";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useFavoritesStore, toFavoriteSnapshot } from "@/stores/favorites";
@@ -57,10 +57,14 @@ function resolveGrade(c: CandidateArea): SafetyGrade {
   return c.safetyGrade ?? "C";
 }
 
-function priceText(c: CandidateArea): string {
+// 거래유형별 시세 표시 — 부부 result-content 와 동일 패턴.
+//   wolse: 보증금/월 추정 · maemae: 억 + (추정) · jeonse/미지정: 기존 bare 억 (회귀 0)
+function priceText(c: CandidateArea, dealType?: DealType): string {
+  if (dealType === "wolse") return formatWolse(c.wolseEstimate);
   if (!c.priceRange) return "—";
   const avg = (c.priceRange.min + c.priceRange.max) / 2;
-  return `${(avg / 10000).toFixed(1)}억`;
+  const suffix = dealType === "maemae" ? " (추정)" : "";
+  return `${(avg / 10000).toFixed(1)}억${suffix}`;
 }
 
 const GRADE_ORDER: Record<SafetyGrade, number> = { A: 0, B: 1, C: 2, D: 3 };
@@ -138,6 +142,7 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   const leisureCoordA = useDiagnosisStore((s) => s.leisureCoordA);
   const leisureCoordB = useDiagnosisStore((s) => s.leisureCoordB);
   const priorityKey = useDiagnosisStore((s) => s.filters.priorities?.[0]);
+  const dealType = useDiagnosisStore((s) => s.filters.budget?.dealType);
   const favorites = useFavoritesStore((s) => s.favorites);
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
 
@@ -473,7 +478,7 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                       barPercent={getCrimePercent(grade)}
                       stats={[
                         { label: "통근", value: `${c.commuteA.time}분` },
-                        { label: "시세", value: priceText(c) },
+                        { label: "시세", value: priceText(c, dealType) },
                         buildLayerStat(c, layer),
                       ]}
                       tagReason={buildPreferenceReason(priorityKey, c) ?? undefined}
@@ -555,9 +560,10 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                   onClick: () => {
                     const url = buildNaverRealEstateUrl(
                       `${selectedCandidate.gu} ${selectedCandidate.dong}`,
-                      selectedCandidate.priceRange
-                        ? { priceMax: selectedCandidate.priceRange.max }
-                        : {},
+                      // 월세는 priceRange(전세 scale)를 가격 상한으로 쓰면 오값 → 생략(사용자가 네이버에서 월세 필터).
+                      dealType === "wolse" || !selectedCandidate.priceRange
+                        ? {}
+                        : { priceMax: selectedCandidate.priceRange.max },
                     );
                     window.open(url, "_blank", "noopener,noreferrer");
                   },


### PR DESCRIPTION
## 싱글 모드 결과에 거래유형별 시세 표시 (월세 "4.5억" 오값 수정)

부부 결과(result-content)는 1-B/2-B로 거래유형 표시가 됐지만, **싱글 결과는 별도 뷰**(single-result-view)라 자체 `priceText`가 `priceRange`만 `"X억"`으로 보여줬습니다. → **월세 진단 시 전세 scale 값("4.5억")을 잘못 노출** = 사용자 오해/정직성 갭.

입력 폼·필터·데이터(`wolseEstimate`)는 mode 무관이라 **이미 싱글에도 동작** — 이 **표시 1곳만** 누락이었습니다.

### 이 PR이 하는 일 (single-result-view.tsx 1파일)
- `priceText(c, dealType)` — wolse→`formatWolse`(보증금/월 추정) · maemae→`억 (추정)` · jeonse→**기존 bare 억(회귀 0)**
- store에서 `dealType` 읽기(`priorityKey` 패턴 답습) — `wolseEstimate`는 후보에 이미 채워짐
- 네이버 매물 URL: **월세는 `priceMax`(전세 scale) 생략** → 오값 전달 방지(사용자가 네이버에서 월세 필터)

### 부부 패턴 재사용
`formatWolse`/`DealType` 그대로 재사용, 데이터/필터/입력 추가 작업 0. 표시 함수만 부부와 동일하게 분기.

### 회귀 0
전세 표시 **바이트 동일**. 매매/월세만 표시 보강.

### 검증
- ✅ `tsc --noEmit` 통과 · ✅ ESLint 0 · ✅ 인코딩 정상
- 머지 후 라이브 싱글 모드: 전세(기존 동일) / 매매("억 (추정)") / **월세("보증금 X억 / 월 Y만 (추정)")**

🤖 Generated with [Claude Code](https://claude.com/claude-code)