### PR TITLE
fix(favorites): 찜 목록 월세/매매 거래유형별 시세 표시

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -428,7 +428,14 @@ export function ResultContent({
   const handleLike = () => {
     if (!selectedCandidate) return;
     const wasLiked = Boolean(favorites[selectedCandidate.id]);
-    toggleFavorite(toFavoriteSnapshot(selectedCandidate, "couple"));
+    toggleFavorite(
+      toFavoriteSnapshot(
+        selectedCandidate,
+        "couple",
+        undefined,
+        filters.budget?.dealType,
+      ),
+    );
     pushToast({
       variant: wasLiked ? "default" : "ok",
       message: wasLiked

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -339,7 +339,12 @@ export function SingleResultView({ id }: SingleResultViewProps) {
     if (!selectedCandidate) return;
     const wasLiked = Boolean(favorites[selectedCandidate.id]);
     toggleFavorite(
-      toFavoriteSnapshot(selectedCandidate, "single", resolveGrade(selectedCandidate)),
+      toFavoriteSnapshot(
+        selectedCandidate,
+        "single",
+        resolveGrade(selectedCandidate),
+        dealType,
+      ),
     );
     pushToast({
       variant: wasLiked ? "default" : "ok",

--- a/onday-app/src/components/favorites/favorites-menu.tsx
+++ b/onday-app/src/components/favorites/favorites-menu.tsx
@@ -6,7 +6,7 @@ import { Heart, X, ExternalLink } from "lucide-react";
 import { SafetyGradeBadge } from "@/components/data/safety-grade-badge";
 import { BottomSheet } from "@/components/sheet/bottom-sheet";
 import { IconButton } from "@/components/ui/icon-button";
-import { formatPrice } from "@/features/diagnosis/result-utils";
+import { formatPrice, formatWolse } from "@/features/diagnosis/result-utils";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
 import { cn } from "@/lib/utils";
 import { useFavoritesStore } from "@/stores/favorites";
@@ -159,14 +159,19 @@ export function FavoritesMenu() {
                     <p className="mt-1 truncate text-caption text-ink-3">
                       통근 {it.commuteA}분
                       {it.commuteB != null && ` · 배우자 ${it.commuteB}분`} ·{" "}
-                      {formatPrice(it.priceRange)}
+                      {it.dealType === "wolse"
+                        ? formatWolse(it.wolseEstimate)
+                        : formatPrice(it.priceRange, it.dealType)}
                     </p>
                   </div>
 
                   <a
                     href={buildNaverRealEstateUrl(
                       `${it.gu} ${it.dong}`,
-                      it.priceRange ? { priceMax: it.priceRange.max } : {},
+                      // 월세는 priceRange(전세 scale)를 가격 상한으로 쓰면 오값 → 생략.
+                      it.dealType === "wolse" || !it.priceRange
+                        ? {}
+                        : { priceMax: it.priceRange.max },
                     )}
                     target="_blank"
                     rel="noopener noreferrer"

--- a/onday-app/src/stores/favorites.ts
+++ b/onday-app/src/stores/favorites.ts
@@ -1,7 +1,12 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
-import type { CandidateArea, DiagnosisMode, SafetyGrade } from "@/lib/types";
+import type {
+  CandidateArea,
+  DealType,
+  DiagnosisMode,
+  SafetyGrade,
+} from "@/lib/types";
 
 // 저장한 동네 (즐겨찾기) — localStorage persist.
 // ★ id만 저장하면 새로고침 후 후보 상세(이름·등급·통근·시세)를 못 그림(diagnosis-store는 메모리).
@@ -18,15 +23,21 @@ export interface FavoriteItem {
   commuteA: number;
   commuteB?: number;
   priceRange?: { min: number; max: number };
+  // 진단 시점 거래유형 + 월세 추정 — 시세 표시 정합(월세 "보증금/월 추정", 매매 "추정").
+  //   레거시 스냅샷은 미보유 → 전세로 간주(formatPrice 경로).
+  dealType?: DealType;
+  wolseEstimate?: { deposit: number; monthly: number };
   mode: DiagnosisMode;
   savedAt: number;
 }
 
 // 후보 → 찜 스냅샷. grade는 호출처가 모드별 소스로 넘김(싱글=resolveGrade).
+//   dealType은 진단 filters.budget?.dealType — 시세 표시용. wolseEstimate는 후보에 이미 박힘.
 export function toFavoriteSnapshot(
   c: CandidateArea,
   mode: DiagnosisMode,
   grade?: SafetyGrade,
+  dealType?: DealType,
   savedAt: number = Date.now(),
 ): FavoriteItem {
   return {
@@ -38,6 +49,8 @@ export function toFavoriteSnapshot(
     commuteA: c.commuteA.time,
     commuteB: c.commuteB?.time,
     priceRange: c.priceRange,
+    dealType,
+    wolseEstimate: c.wolseEstimate,
     mode,
     savedAt,
   };


### PR DESCRIPTION
## 찜 목록 월세/매매 "추정" 표시 (월세 작업 마지막 정직성 조각)

싱글(#158)과 동일한 갭 — 찜 목록도 `formatPrice(it.priceRange)`만 써서 **월세 찜이 전세 scale "4.5억" 오값**을 노출했습니다.

### 이 PR이 하는 일
- `FavoriteItem` + `toFavoriteSnapshot`에 **`dealType` + `wolseEstimate` 스냅샷** 추가
  - `wolseEstimate`는 후보(CandidateArea)에 이미 박혀 있어 복사만, `dealType`은 호출처 `filters.budget?.dealType`
- `favorites-menu`: 월세→`formatWolse`(보증금/월 추정) / 매매→`formatPrice` 추정 / 전세→기존
  - 네이버 매물 URL: 월세는 `priceMax`(전세 scale) 생략
- 호출처 2곳(result-content `couple`, single-result-view `single`)에서 dealType 전달

### 부부/싱글 패턴 재사용
`formatWolse`/`formatPrice`/`DealType` 그대로 — #158 싱글 수정과 동일 패턴.

### 회귀 0
레거시 찜 스냅샷은 `dealType` 미보유 → 전세로 간주(`formatPrice` 경로, 기존 동일). 신규 월세/매매 찜만 표시 보강.

### 검증
- ✅ `tsc --noEmit` 통과 · ✅ ESLint 0 · ✅ 인코딩 정상
- 머지 후 라이브: 월세 진단 → 찜 → **찜 목록에 "보증금 X억 / 월 Y만 (추정)"** (더 이상 "4.5억" 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)