### PR TITLE
feat(safety): #57 수원시 범죄등급 추가 (CCTV 준비중) — 야간안전 66/66

### DIFF
--- a/onday-app/src/lib/data/safety-index.json
+++ b/onday-app/src/lib/data/safety-index.json
@@ -310,6 +310,14 @@
       "_cctvSource": "공공데이터15104287 인천방범CCTV(2025.09.30) ÷ 표준면적 (경제자유구역청3391 제외)"
     },
     {
+      "sigungu": "수원시",
+      "region1": "경기도",
+      "crimeGrade": 4,
+      "cctvPerKm2": null,
+      "_crimeSource": "행안부2025지역안전지수:경기 시/군 범죄분야",
+      "_cctvSource": "준비중 — 경기데이터드림 CCTV현황에 수원시 미수집(전국표준에도 누락). 범죄만 단계 수집."
+    },
+    {
       "sigungu": "성남시",
       "region1": "경기도",
       "crimeGrade": 4,


### PR DESCRIPTION
## #57 수원시 추가 — 야간안전 entry 66/66 완성

수도권 마지막 누락이던 **수원시**를 `safety-index.json`에 추가. 범죄등급은 실데이터, CCTV는 정직하게 준비중.

### 이 PR이 하는 일
- 수원시 entry 추가: **`crimeGrade: 4`** (행안부 2025 지역안전지수 경기 범죄분야 — hwpx에서 추출·검증) + **`cctvPerKm2: null`**(준비중)
- entry 65 → **66** (경기 30 → 31)

### CCTV를 null(준비중)로 둔 이유 (정직성)
- 경기 30개는 **경기데이터드림 CCTV현황**으로 냈는데, 수원시가 그 표준(및 data.go.kr 전국표준)에 **미수집**.
- 수원만 다른 출처로 억지로 채우면 출처 불일치 → `safety-index`의 **단계 수집 스키마**(두 지표 다 차야 종합등급)대로 **CCTV는 준비중**, 범죄만 먼저 수집.
- `getSafetyByGu("수원시")` → `no_data`(준비중) 정직 반환. CCTV 확보 시 종합등급 산출되어 완성. 날조 X.

### 검증
- ✅ JSON 유효, 66 entry, 수원 crimeGrade=4/cctv=null
- ✅ `tsc --noEmit` 통과 · ✅ 인코딩 정상

### 후속
- 수원 CCTV: 경기데이터드림에서 확보 시 `cctvPerKm2` 채우면 완성(별도).

🤖 Generated with [Claude Code](https://claude.com/claude-code)