### PR TITLE
fix(safety): #59 야간안전 no_data "준비중" 표시 + mock 등급/점수 정직화

### DIFF
--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -47,14 +47,12 @@ interface SingleResultViewProps {
   id: string;
 }
 
-// #57 — 종합 야간안전 지수(getSafetyByGu)가 등급 소스.
-//   ★ 랜덤 id-해시 날조 제거 (실 데이터 전환 의미 정면 위배 방지).
-//   no_data(비수도권 or 미수집 시군구)는 등급 날조 대신 전환 브리지(기존 mock grade, 랜덤 아님).
-//   TODO(#59 UI-013): no_data → "데이터 준비중" 배지/회색 처리로 표현 (표현은 #59 범위).
-function resolveGrade(c: CandidateArea): SafetyGrade {
+// #57/#59 — 종합 야간안전 지수(getSafetyByGu)가 유일한 등급 소스.
+//   ★ no_data(비수도권 or CCTV 미수집 시군구)는 mock 등급 날조 금지(E-2 합의) → null 전파.
+//   UI(SafetyCard/배지/Stat)가 null 을 "준비중"으로 표현한다.
+function resolveGrade(c: CandidateArea): SafetyGrade | null {
   const safety = getSafetyByGu(c.gu);
-  if (safety.status === "ok") return safety.grade;
-  return c.safetyGrade ?? "C";
+  return safety.status === "ok" ? safety.grade : null;
 }
 
 // 거래유형별 시세 표시 — 부부 result-content 와 동일 패턴.
@@ -75,10 +73,14 @@ function sortByLayer(
 ): CandidateArea[] {
   const arr = [...list];
   switch (layer) {
-    case "safety":
-      return arr.sort(
-        (a, b) => GRADE_ORDER[resolveGrade(a)] - GRADE_ORDER[resolveGrade(b)],
-      );
+    case "safety": {
+      // no_data(준비중)는 등급이 없으므로 맨 뒤로 (Infinity). 점수 정렬과 무관.
+      const rank = (c: CandidateArea) => {
+        const g = resolveGrade(c);
+        return g ? GRADE_ORDER[g] : Infinity;
+      };
+      return arr.sort((a, b) => rank(a) - rank(b));
+    }
     case "convenience":
       return arr.sort(
         (a, b) =>
@@ -99,7 +101,10 @@ function buildLayerStat(c: CandidateArea, layer: SingleLayer) {
   switch (layer) {
     case "safety": {
       const grade = resolveGrade(c);
-      return { label: "범죄", value: `${getNightCrimeRate(grade)}건` };
+      return {
+        label: "범죄",
+        value: grade ? `${getNightCrimeRate(grade)}건` : "준비중",
+      };
     }
     case "convenience":
       return {
@@ -474,13 +479,13 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                       name={`${c.gu} ${c.dong}`}
                       sub={getRadiusSub(c.facilities)}
                       grade={grade}
-                      gradeLabel={getNightGradeLabel(grade)}
+                      gradeLabel={grade ? getNightGradeLabel(grade) : ""}
                       metric={{
                         label: "야간 범죄율 (10만명당)",
-                        value: getNightCrimeRate(grade),
+                        value: grade ? getNightCrimeRate(grade) : 0,
                         unit: "건",
                       }}
-                      barPercent={getCrimePercent(grade)}
+                      barPercent={grade ? getCrimePercent(grade) : 0}
                       stats={[
                         { label: "통근", value: `${c.commuteA.time}분` },
                         { label: "시세", value: priceText(c, dealType) },

--- a/onday-app/src/components/card/safety-card.tsx
+++ b/onday-app/src/components/card/safety-card.tsx
@@ -16,7 +16,8 @@ import { cn } from "@/lib/utils";
 interface SafetyCardProps {
   name: string;
   sub: string;
-  grade: SafetyGrade;
+  /** null = no_data(미수집 시군구) → 배지/바 자리에 "준비중" (#59). metric·barPercent 무시. */
+  grade: SafetyGrade | null;
   gradeLabel: string;
   metric: { label: string; value: number; unit?: string };
   barPercent: number;
@@ -42,10 +43,13 @@ export function SafetyCard({
   className,
 }: SafetyCardProps) {
   const interactive = Boolean(href || onClick);
-  // 종합 aria-label (스크린리더): 동네 + 등급 + 핵심 지표
-  const ariaLabel = `${name}, ${gradeLabel}, ${metric.label} ${metric.value}${
-    metric.unit ?? ""
-  }`;
+  // 종합 aria-label (스크린리더): 동네 + 등급 + 핵심 지표. no_data 는 "준비중".
+  const ariaLabel =
+    grade === null
+      ? `${name}, 야간 안전 데이터 준비중`
+      : `${name}, ${gradeLabel}, ${metric.label} ${metric.value}${
+          metric.unit ?? ""
+        }`;
 
   const inner = (
     <>
@@ -54,16 +58,23 @@ export function SafetyCard({
           <h3 className="text-title font-bold text-ink">{name}</h3>
           <p className="mt-0.5 text-caption text-ink-3">{sub}</p>
         </div>
-        <SafetyGradeBadge grade={grade} label={gradeLabel} />
+        <SafetyGradeBadge grade={grade} label={grade ? gradeLabel : undefined} />
       </header>
 
-      <SafetyBar
-        label={metric.label}
-        value={metric.value}
-        unit={metric.unit ?? ""}
-        percent={barPercent}
-        grade={grade}
-      />
+      {grade === null ? (
+        // no_data → 막대/수치 날조 대신 회색 안내 (CCTV 미수집 시군구).
+        <p className="text-caption text-ink-3">
+          야간 안전 데이터 준비중 — CCTV 미수집 시군구
+        </p>
+      ) : (
+        <SafetyBar
+          label={metric.label}
+          value={metric.value}
+          unit={metric.unit ?? ""}
+          percent={barPercent}
+          grade={grade}
+        />
+      )}
 
       <div className="grid grid-cols-3 gap-s-2">
         {stats.map((s) => (

--- a/onday-app/src/components/data/safety-grade-badge.tsx
+++ b/onday-app/src/components/data/safety-grade-badge.tsx
@@ -25,7 +25,8 @@ const GRADE_LABELS: Record<SafetyGrade, string> = {
 };
 
 interface SafetyGradeBadgeProps {
-  grade: SafetyGrade;
+  /** null = no_data(미수집 시군구) → 등급 날조 대신 중립 "준비중" 배지 (#59, E-2 합의). */
+  grade: SafetyGrade | null;
   label?: string;
   className?: string;
 }
@@ -35,6 +36,25 @@ export function SafetyGradeBadge({
   label,
   className,
 }: SafetyGradeBadgeProps) {
+  // no_data → 중립 회색 "준비중" (letter 자리 "—"). letter+label+색 3중 표기 유지.
+  if (grade === null) {
+    return (
+      <span
+        role="img"
+        aria-label="야간 안전 데이터 준비중"
+        className={cn(
+          "grade-badge inline-flex w-fit items-center gap-1 rounded-sm px-s-2 py-1 text-caption-xs font-extrabold bg-bg text-ink-3",
+          className,
+        )}
+      >
+        <span aria-hidden className="font-black tracking-tight">
+          —
+        </span>
+        <span aria-hidden>·</span>
+        <span aria-hidden>준비중</span>
+      </span>
+    );
+  }
   const text = label ?? GRADE_LABELS[grade];
   return (
     <span

--- a/onday-app/src/features/diagnosis/preference-reason.ts
+++ b/onday-app/src/features/diagnosis/preference-reason.ts
@@ -3,7 +3,7 @@ import { getCommunityByGu } from "@/lib/diagnosis/community-index";
 import type { CandidateArea } from "@/lib/types";
 
 // 선호 태그(⑥) 데이터별 정직 근거 — 카드/시트에 "왜 이 동네"를 그 후보의 실제 지표로.
-//   safety = #57 종합 야간안전 지수(getSafetyByGu, 부부·싱글 공통) → 등급. no_data 시 mock grade.
+//   safety = #57 종합 야간안전 지수(getSafetyByGu, 부부·싱글 공통) → 등급. no_data 시 "준비중"(날조 금지, #59).
 //   convenience/hotplace/quiet = facilities(파생 포함) 실측 수치 기반 티어.
 
 const SAFETY_REASON: Record<string, string> = {
@@ -19,10 +19,10 @@ export function buildPreferenceReason(
 ): string | null {
   switch (key) {
     case "safety": {
+      // no_data(미수집 시군구)는 mock 등급으로 사유 날조 금지 → "준비중" (#59).
       const safety = getSafetyByGu(c.gu);
-      const grade = safety.status === "ok" ? safety.grade : c.safetyGrade;
-      if (!grade) return "야간 치안 반영";
-      return `${SAFETY_REASON[grade]} (${grade}등급)`;
+      if (safety.status !== "ok") return "야간 치안 데이터 준비중";
+      return `${SAFETY_REASON[safety.grade]} (${safety.grade}등급)`;
     }
     case "convenience": {
       const n = c.facilities?.convenience ?? 0;

--- a/onday-app/src/features/single/detail-mapper.ts
+++ b/onday-app/src/features/single/detail-mapper.ts
@@ -18,11 +18,14 @@ interface MetricItem {
 export function buildSinglePills(
   c: CandidateArea,
   rank: number,
-  grade: SafetyGrade,
+  grade: SafetyGrade | null,
 ): PillItem[] {
   const pills: PillItem[] = [];
   if (rank === 1) pills.push({ variant: "solid", label: "BEST 매칭" });
-  pills.push({ variant: "neutral", label: `야간안전 ${grade}등급` });
+  pills.push({
+    variant: "neutral",
+    label: grade ? `야간안전 ${grade}등급` : "야간안전 준비중",
+  });
   if (c.listingsCount != null)
     pills.push({ variant: "neutral", label: `매물 ${c.listingsCount}건` });
   return pills;
@@ -32,13 +35,13 @@ export function buildSinglePills(
 //   여가거점 미입력 시 통근(직장A)로 대체 → 3칸 항상 채움.
 export function buildSingleMetrics(
   c: CandidateArea,
-  grade: SafetyGrade,
+  grade: SafetyGrade | null,
 ): MetricItem[] {
   const metrics: MetricItem[] = [
     {
       label: "야간 범죄율",
-      value: `${getNightCrimeRate(grade)}건`,
-      sub: "10만명당",
+      value: grade ? `${getNightCrimeRate(grade)}건` : "준비중",
+      sub: grade ? "10만명당" : "데이터 준비중",
     },
   ];
   if (c.priceRange) {

--- a/onday-app/src/features/single/safety-index.ts
+++ b/onday-app/src/features/single/safety-index.ts
@@ -5,8 +5,8 @@ import safetyIndexData from "@/lib/data/safety-index.json";
 //   ★ 명세 역방향 정합: 명세의 getNightSafetyGrade(coord) 좌표 반경 검색 대신
 //   getSafetyByGu(gu) 구 룩업으로 대체 (동단위 데이터 미수집 → 시군구 단위 채택).
 //   소스: 행안부 지역안전지수(범죄) ×0.7 + 시군구 CCTV 밀집도 ×0.3.
-//   ★ couple 모드 scoring(scoring.ts safetyBonus)은 neighborhoods.ts 의 hardcoded
-//   safetyGrade 를 계속 사용 — 본 모듈은 single 모드 표시용 데이터 소스 (영향 없음).
+//   ★ scoring.ts safetyBonus 는 neighborhoods.ts 의 hardcoded safetyGrade 로 가산하되,
+//   getSafetyByGu(gu) 가 no_data 인 시군구는 가산 0 (#59 옵션2 — 표시 "준비중"과 일관, 날조 금지).
 
 interface SafetyIndexEntry {
   sigungu: string;

--- a/onday-app/src/lib/diagnosis/scoring.ts
+++ b/onday-app/src/lib/diagnosis/scoring.ts
@@ -1,4 +1,5 @@
 import type { SafetyGrade } from "@/lib/types";
+import { getSafetyByGu } from "@/features/single/safety-index";
 
 import { getCommunityByGu } from "./community-index";
 
@@ -33,6 +34,8 @@ function priorityBonus(
 ): number {
   switch (priority) {
     case "safety": {
+      // no_data(미수집 시군구)는 mock 등급 가산 금지(#59 옵션2) — 표시 "준비중"과 일관.
+      if (getSafetyByGu(n.gu).status !== "ok") return 0;
       const b: Record<string, number> = { A: 10, B: 5, C: 0, D: -10 };
       return b[n.safetyGrade] ?? 0;
     }
@@ -74,9 +77,11 @@ export function scoreCandidate({
   const avgCommute = commuteB != null ? (commuteA + commuteB) / 2 : commuteA;
   score -= Math.min(40, avgCommute * 0.8);
 
-  // 안전등급 가산
+  // 안전등급 가산 — no_data(미수집 시군구)는 mock 등급 가산 금지(#59 옵션2, 표시 "준비중"과 일관).
   const safetyBonus: Record<string, number> = { A: 10, B: 5, C: 0, D: -10 };
-  score += safetyBonus[neighborhood.safetyGrade] ?? 0;
+  if (getSafetyByGu(neighborhood.gu).status === "ok") {
+    score += safetyBonus[neighborhood.safetyGrade] ?? 0;
+  }
 
   // 편의시설 가산 — 실데이터(편의점+카페 반경1km). 합 분포 ~12~828(중앙 213) → /40 으로 0~10.
   //   (구 /10 은 mock(합~70) 기준 — 실데이터선 전부 10 saturate → /40 재튜닝.)

--- a/onday-app/src/stores/favorites.ts
+++ b/onday-app/src/stores/favorites.ts
@@ -36,7 +36,7 @@ export interface FavoriteItem {
 export function toFavoriteSnapshot(
   c: CandidateArea,
   mode: DiagnosisMode,
-  grade?: SafetyGrade,
+  grade?: SafetyGrade | null,
   dealType?: DealType,
   savedAt: number = Date.now(),
 ): FavoriteItem {
@@ -45,7 +45,9 @@ export function toFavoriteSnapshot(
     gu: c.gu,
     dong: c.dong,
     score: c.score,
-    safetyGrade: grade ?? c.safetyGrade,
+    // grade===null = no_data(준비중) → mock 폴백 금지(#59), 배지 없이 점수 표시.
+    //   grade 미전달(undefined, 부부)만 후보 mock 등급으로 폴백(레거시 유지).
+    safetyGrade: grade === null ? undefined : (grade ?? c.safetyGrade),
     commuteA: c.commuteA.time,
     commuteB: c.commuteB?.time,
     priceRange: c.priceRange,


### PR DESCRIPTION
## 문제
야간안전이 no_data 인 동네(수원/광교동, CCTV 미수집)가 화면에 **하드코딩 mock 등급 "A"** 로 떠서 가짜 등급이 표시됨. `resolveGrade`(single-result-view.tsx)가 no_data 를 mock `safetyGrade` 로 폴백한 것이 원인. (E-2 합의: 가짜 등급 날조 금지)

## 변경
- **폴백 제거**: `resolveGrade` → `SafetyGrade | null`, no_data 시 null 전파 (mock 폴백 삭제)
- **"준비중" UI**: `SafetyGradeBadge`/`SafetyCard`/`buildSinglePills`/`buildSingleMetrics` 가 null → 중립 회색 "준비중" (letter `—` · 색 3중 표기 유지). SafetyBar 자리엔 "CCTV 미수집 시군구" 안내.
- **정렬**: safety 레이어에서 no_data 는 맨 뒤로(Infinity). 점수 정렬 무영향.
- **찜 스냅샷**: no_data 는 mock 등급 저장 금지(배지 없이 점수 표시). 부부 모드(grade 미전달)는 레거시 유지.
- **선호태그 사유**: `buildPreferenceReason(safety)` no_data → "야간 치안 데이터 준비중" (mock 등급 날조 제거).
- **scoring 정직화 (옵션2)**: `getSafetyByGu` 가 no_data 인 시군구는 `safetyBonus`·`priorityBonus[safety]` 둘 다 **가산 0**. 표시 "준비중"과 점수가 동일 no_data 판정 공유.

## 영향 범위
- no_data 동네 = **수원시 영통구(광교동) 1곳뿐** (44개 중). 나머지 43개 등급/점수 무변경.
- **부부 결과 카드 UI 무변경** (안전등급 미표시 + CandidateArea.safetyGrade=undefined). 공통 모듈 preference-reason 만 정직화.

## scoring 정책
**옵션 2 (점수도 정직)** 채택 — 표시만 "준비중"이고 점수엔 mock 가산이 남는 미묘함 제거. 수원(광교동) priority=safety 점수 **100→80** 검증(mock "A" 가산 +20 제거).

## 검증
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ (0 errors; 기존 무관 warning 10건만)
- 데이터 검증: 44개 중 no_data=1(수원), `getSafetyByGu("수원시")` → `{status:"no_data", grade:null}`
- 수원 점수(priority=safety) 80 = safety 가산 0 반영 확인
- 한글 인코딩(U+FFFD) 검사 통과

범위 외(후속): `use-address-suggest.ts` 입력단 mock 힌트 정리.

Closes #59