### PR TITLE
refactor(single): 레이어 출처를 공원·도서관 캡션 스타일로 통일 (#163 후속)

### DIFF
--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { AlertCircle, ChevronLeft, Filter, FileDown } from "lucide-react";
 
 import { SafetyCard } from "@/components/card/safety-card";
-import { DataSourceBadge } from "@/components/data/data-source-badge";
 import { LegendBar } from "@/components/data/legend-bar";
 import { MapCanvas } from "@/components/map/map-canvas";
 import type { MapWorkplace, MapLine } from "@/components/map/map-canvas";
@@ -132,7 +131,7 @@ const LEGEND_META: Record<SingleLayer, { title: string; meta: string }> = {
     meta: "편의점 + 약국 + 24시간 매장 · 반경 1km",
   },
   community: {
-    // 출처("data.go.kr 표준데이터")는 LAYER_SOURCES → DataSourceBadge 로 이관(하드코딩 제거).
+    // 출처("data.go.kr 표준데이터")는 LAYER_SOURCES 캡션 한 줄로 이관(하드코딩 제거).
     title: "공원·공공도서관 (시군구 단위)",
     meta: "구 전체 등록 수",
   },
@@ -171,17 +170,9 @@ const LAYER_SOURCES: Record<SingleLayer, SourceMeta[]> = {
   ],
 };
 
-// 결측 지표 "준비중" 칩 (출처 없음) — DataSourceBadge on-light 톤과 정렬된 중립 회색.
-function PendingSourceChip({ label }: { label: string }) {
-  return (
-    <span className="inline-flex w-fit items-center gap-1.5 rounded-sm border border-line-2 bg-bg px-s-2 py-1 text-caption-xs font-bold text-ink-3">
-      <span aria-hidden className="size-1.5 rounded-full bg-line-2" />
-      <span>{label} · 준비중</span>
-    </span>
-  );
-}
-
-// 활성 레이어의 출처 배지 행. 표시 후보(candidates) 중 결측이 있으면 해당 지표는 출처 대신 "준비중".
+// 활성 레이어의 출처 — 공원·도서관 기존 캡션과 동일한 작은 회색 텍스트 한 줄(text-caption).
+//   지표 여러 개(야간안전 범죄/CCTV)는 가운뎃점(·)으로 연결. 표시 후보에 결측이 섞이면
+//   그 지표는 가짜 출처 대신 "준비중"(#59 결측 판정 공유 — 새 판정 로직 없음).
 function LayerSources({
   layer,
   candidates,
@@ -189,7 +180,6 @@ function LayerSources({
   layer: SingleLayer;
   candidates: CandidateArea[];
 }) {
-  // #59 와 동일한 결측 판정 공유 (새 판정 로직 만들지 않음).
   const someSafetyNoData = candidates.some(
     (c) => getSafetyByGu(c.gu).status !== "ok",
   );
@@ -197,29 +187,22 @@ function LayerSources({
     (c) => getCommunityByGu(c.gu).status !== "ok",
   );
 
+  const parts = LAYER_SOURCES[layer].map((m) => {
+    // 야간안전 CCTV: 결측(예: 수원)이 섞이면 출처 대신 "준비중". 범죄는 항상 표기.
+    if (layer === "safety" && m.indicator === "CCTV" && someSafetyNoData) {
+      return "CCTV: 준비중";
+    }
+    // 공원·도서관: 결측이면 출처 억제(가짜 출처 방지) → "준비중".
+    if (layer === "community" && someCommunityNoData) {
+      return `${m.indicator}: 준비중`;
+    }
+    return `${m.indicator}: ${m.source}`;
+  });
+
   return (
-    <div className="mt-s-2 flex flex-wrap gap-s-2" aria-label="데이터 출처">
-      {LAYER_SOURCES[layer].map((m) => {
-        // 야간안전 CCTV: 표시 후보에 결측(예: 수원)이 섞이면 출처 대신 "준비중".
-        //   (범죄는 수도권 전 시군구 보유 → 항상 표기. 한 줄로 묶지 않음.)
-        if (layer === "safety" && m.indicator === "CCTV" && someSafetyNoData) {
-          return <PendingSourceChip key={m.indicator} label="CCTV" />;
-        }
-        // 공원·도서관: 결측이면 출처 억제(가짜 출처 방지) → "준비중".
-        if (layer === "community" && someCommunityNoData) {
-          return <PendingSourceChip key={m.indicator} label={m.indicator} />;
-        }
-        return (
-          <DataSourceBadge
-            key={m.indicator}
-            kind={m.kind}
-            source={`${m.indicator} · ${m.source}`}
-            updatedAt={m.updatedAt}
-            tone="on-light"
-          />
-        );
-      })}
-    </div>
+    <p className="mt-1 text-caption text-ink-3" aria-label="데이터 출처">
+      {parts.join(" · ")}
+    </p>
   );
 }
 


### PR DESCRIPTION
## 배경
PR #163에서 야간안전·편의시설 출처를 `DataSourceBadge`(박스 배지)로 붙였으나, 글씨가 크고 박스라 기존 공원·도서관의 작은 캡션 한 줄(`text-caption text-ink-3`)과 형식이 갈렸음. 전부 공원·도서관처럼 **작은 회색 텍스트 한 줄**로 통일.

## 변경
- `DataSourceBadge`(박스)·`PendingSourceChip` 제거. 모든 레이어 출처를 **캡션 한 줄**(`text-caption text-ink-3`)로 렌더.
- 지표 여러 개(야간안전 범죄/CCTV)는 가운뎃점(·)으로 연결:
  - 일반 동네: `범죄: 행안부 지역안전지수 · CCTV: 공공데이터 CCTV현황`
  - 편의시설: `편의점·카페: 소상공인 상가정보`
  - 공원·도서관: `공원·도서관: data.go.kr 표준데이터`
- 결측(수원 CCTV)은 그 자리에 `CCTV: 준비중` 텍스트만 — 가짜 출처 금지(#59 원칙 유지).
- `single-result-view.tsx`의 `DataSourceBadge` import 제거(미사용 정리).

## 유지 (안 건드림)
- `LAYER_SOURCES` 상수 / 런타임 status 게이팅(`getSafetyByGu`/`getCommunityByGu`) / community 결측 판정 공유 — 그대로. **표시 "형식"만 배지→캡션으로 변경.**

## 검증
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ (0 errors; 기존 무관 warning 10건만)
- 렌더 문자열 검증:
  - 일반(강남구) 야간안전: `범죄: 행안부 지역안전지수 · CCTV: 공공데이터 CCTV현황`
  - 수원 포함 야간안전: `범죄: 행안부 지역안전지수 · CCTV: 준비중`
  - 편의시설/공원·도서관 각 한 줄 캡션
- `DataSourceBadge`/`PendingSourceChip` 잔재 없음 (import 포함)
- 한글 인코딩(U+FFFD) 검사 통과
- **커플/공유 무변경**