### PR TITLE
feat(schools): 학군 PR1 — 동네별 최근접 초등학교 데이터(schools-index)

### DIFF
--- a/onday-app/package.json
+++ b/onday-app/package.json
@@ -15,7 +15,8 @@
     "db:seed": "npx prisma db seed",
     "db:push": "npx prisma db push",
     "postinstall": "npx prisma generate",
-    "check:coverage": "npx tsx scripts/check-coverage.ts"
+    "check:coverage": "npx tsx scripts/check-coverage.ts",
+    "build:schools": "npx tsx scripts/build-schools-index.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/onday-app/scripts/build-schools-index.ts
+++ b/onday-app/scripts/build-schools-index.ts
@@ -1,0 +1,134 @@
+// 학군 PR1 — 전국초중등학교위치표준데이터(학교알리미) xls → 각 neighborhood 최근접 초등학교
+//   1곳을 빌드타임 사전계산 → src/lib/data/schools-index.json.
+//   공원·도서관(build-community-index) 패턴 답습: 원본 + 스크립트 + _source 로 provenance 확보.
+//   실행: npx tsx scripts/build-schools-index.ts  (사전: data-raw/schools.xls)
+//
+//   ★ 최근접 = 동네 좌표 기준 Haversine. "배정"이 아니라 "인근"(학구도 폴리곤 미보유) — 라벨은 PR2.
+//   schools.xls: Sheet1, 1행 빈 행 → "학교명" 포함 행을 헤더로 자동 탐지.
+//   컬럼: 학교명 / 학교급구분("초등학교") / 위도 / 경도(십진도 WGS84) / 제공기관명 / 데이터기준일자.
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import * as XLSX from "xlsx";
+
+import type { Coordinate } from "@/lib/types";
+import { haversineDistance } from "@/lib/haversine";
+import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
+
+const XLS = join(process.cwd(), "data-raw", "schools.xls");
+const OUT = join(process.cwd(), "src/lib/data/schools-index.json");
+
+if (!existsSync(XLS)) {
+  throw new Error("data-raw/schools.xls 가 없음 (학교알리미 전국초중등학교위치표준데이터 다운로드 필요)");
+}
+
+const wb = XLSX.read(readFileSync(XLS), { type: "buffer" });
+const aoa = XLSX.utils.sheet_to_json(wb.Sheets[wb.SheetNames[0]], {
+  header: 1,
+  defval: "",
+}) as unknown[][];
+
+// 헤더 자동 탐지 — 표준데이터 xls 는 0행이 빈 행/제목일 수 있음 ("학교명" 포함 행을 헤더로).
+const hi = aoa.findIndex((r) => r.some((c) => String(c).trim() === "학교명"));
+if (hi < 0) throw new Error(`헤더 행(학교명) 못 찾음. 첫 행=${aoa[0]?.slice(0, 6)}`);
+const header = aoa[hi].map((c) => String(c).trim());
+
+function colIndex(name: string, required = true): number {
+  const i = header.indexOf(name);
+  if (i < 0 && required) throw new Error(`컬럼 없음: ${name}`);
+  return i;
+}
+const iName = colIndex("학교명");
+const iLevel = colIndex("학교급구분");
+const iLat = colIndex("위도");
+const iLng = colIndex("경도");
+const iOrg = colIndex("제공기관명", false);
+const iDate = colIndex("데이터기준일자", false);
+
+interface School extends Coordinate {
+  name: string;
+}
+
+const schools: School[] = [];
+let skipped = 0;
+let providerName = "";
+let dataDate = "";
+
+for (const r of aoa.slice(hi + 1)) {
+  if (String(r[iLevel]).trim() !== "초등학교") continue;
+  const name = String(r[iName]).trim();
+  const lat = Number(String(r[iLat]).trim());
+  const lng = Number(String(r[iLng]).trim());
+  // 좌표 결측/파싱 실패/0,0 더미는 skip (방어).
+  if (!name || !Number.isFinite(lat) || !Number.isFinite(lng) || lat === 0 || lng === 0) {
+    skipped++;
+    continue;
+  }
+  schools.push({ name, lat, lng });
+  if (!providerName && iOrg >= 0) providerName = String(r[iOrg]).trim();
+  if (!dataDate && iDate >= 0) dataDate = String(r[iDate]).trim();
+}
+console.log(`초등학교 ${schools.length}개 적재 (skip ${skipped})`);
+if (schools.length === 0) throw new Error("초등학교 0개 — 필터/컬럼 매핑 확인 필요");
+
+const source = providerName || "학교알리미 전국초중등학교위치표준데이터";
+const updatedAt = dataDate;
+
+interface NearestSchool {
+  name: string;
+  lat: number;
+  lng: number;
+  distanceKm: number;
+  _source: string;
+  updatedAt: string;
+}
+
+const byNeighborhood: Record<string, NearestSchool> = {};
+let maxDist = 0;
+let maxId = "";
+
+for (const n of MOCK_NEIGHBORHOODS) {
+  let best: School | null = null;
+  let bestD = Infinity;
+  for (const s of schools) {
+    const d = haversineDistance(n.coordinate, s);
+    if (d < bestD) {
+      bestD = d;
+      best = s;
+    }
+  }
+  if (!best) {
+    console.warn(`⚠️ ${n.id} 최근접 학교 없음`);
+    continue;
+  }
+  byNeighborhood[n.id] = {
+    name: best.name,
+    lat: best.lat,
+    lng: best.lng,
+    distanceKm: Math.round(bestD * 100) / 100,
+    _source: source,
+    updatedAt,
+  };
+  if (bestD > maxDist) {
+    maxDist = bestD;
+    maxId = n.id;
+  }
+}
+
+const out = {
+  _meta: {
+    description:
+      "각 neighborhood 좌표 기준 최근접 초등학교 1곳 (Haversine). '배정'이 아니라 '인근' (학구도 폴리곤 미보유).",
+    dataset: "학교알리미 전국초중등학교위치표준데이터 (data.go.kr)",
+    source,
+    updatedAt,
+    generatedFrom: "data-raw/schools.xls",
+    note: "scripts/build-schools-index.ts 로 생성(결정론적). 원본 xls 는 git 미추적. 정확한 배정은 학구도(15021158)로 업그레이드 가능.",
+  },
+  byNeighborhood,
+};
+
+writeFileSync(OUT, JSON.stringify(out, null, 2) + "\n");
+console.log(
+  `✅ schools-index.json — ${Object.keys(byNeighborhood).length}/${MOCK_NEIGHBORHOODS.length} 동네 매핑. 최대거리 ${maxDist.toFixed(2)}km (${maxId})`,
+);

--- a/onday-app/src/lib/data/schools-index.json
+++ b/onday-app/src/lib/data/schools-index.json
@@ -1,0 +1,364 @@
+{
+  "_meta": {
+    "description": "각 neighborhood 좌표 기준 최근접 초등학교 1곳 (Haversine). '배정'이 아니라 '인근' (학구도 폴리곤 미보유).",
+    "dataset": "학교알리미 전국초중등학교위치표준데이터 (data.go.kr)",
+    "source": "한국교육시설안전원",
+    "updatedAt": "2026-03-20",
+    "generatedFrom": "data-raw/schools.xls",
+    "note": "scripts/build-schools-index.ts 로 생성(결정론적). 원본 xls 는 git 미추적. 정확한 배정은 학구도(15021158)로 업그레이드 가능."
+  },
+  "byNeighborhood": {
+    "jong-3": {
+      "name": "서울교동초등학교",
+      "lat": 37.57500567,
+      "lng": 126.9881513,
+      "distanceKm": 0.55,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "mapo-gondeok": {
+      "name": "서울공덕초등학교",
+      "lat": 37.54580335,
+      "lng": 126.9548231,
+      "distanceKm": 0.34,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gangnam-station": {
+      "name": "서울서초초등학교",
+      "lat": 37.49904877,
+      "lng": 127.0248915,
+      "distanceKm": 0.27,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "yongsan-itaewon": {
+      "name": "서울이태원초등학교",
+      "lat": 37.53647771,
+      "lng": 126.9876727,
+      "distanceKm": 0.65,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "songpa-jamsil": {
+      "name": "서울신천초등학교",
+      "lat": 37.5140111,
+      "lng": 127.0950476,
+      "distanceKm": 0.45,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "yeongdeungpo-yeouido": {
+      "name": "서울윤중초등학교",
+      "lat": 37.51964164,
+      "lng": 126.9225908,
+      "distanceKm": 0.3,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "seodaemun-sinchon": {
+      "name": "이화여자대학교사범대학부속초등학교",
+      "lat": 37.56115022,
+      "lng": 126.9427504,
+      "distanceKm": 0.36,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "dongjak-sadang": {
+      "name": "서울이수초등학교",
+      "lat": 37.47837133,
+      "lng": 126.9844171,
+      "distanceKm": 0.32,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "nowon-junggye": {
+      "name": "서울청계초등학교",
+      "lat": 37.64503406,
+      "lng": 127.0661389,
+      "distanceKm": 0.16,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gwanak-bongcheon": {
+      "name": "서울원당초등학교",
+      "lat": 37.48128046,
+      "lng": 126.9562493,
+      "distanceKm": 0.29,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "seongdong-wangsimni": {
+      "name": "서울행당초등학교",
+      "lat": 37.55701913,
+      "lng": 127.0348734,
+      "distanceKm": 0.52,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "yangcheon-mokdong": {
+      "name": "서울목운초등학교",
+      "lat": 37.52700952,
+      "lng": 126.8730442,
+      "distanceKm": 0.2,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "guro-gasan": {
+      "name": "서울영일초등학교",
+      "lat": 37.48564539,
+      "lng": 126.8838134,
+      "distanceKm": 0.52,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "dobong-chang": {
+      "name": "서울창동초등학교",
+      "lat": 37.65536304,
+      "lng": 127.0448329,
+      "distanceKm": 0.35,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "jungnang-myeonmok": {
+      "name": "서울면동초등학교",
+      "lat": 37.58535152,
+      "lng": 127.0865922,
+      "distanceKm": 0.33,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gangseo-yeomchang": {
+      "name": "서울염동초등학교",
+      "lat": 37.55209548,
+      "lng": 126.8723509,
+      "distanceKm": 0.36,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "eunpyeong-bulgwang": {
+      "name": "서울불광초등학교",
+      "lat": 37.61342945,
+      "lng": 126.9307187,
+      "distanceKm": 0.37,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "seongbuk-seongshin": {
+      "name": "서울돈암초등학교",
+      "lat": 37.59371444,
+      "lng": 127.0131036,
+      "distanceKm": 0.31,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gwangjin-gundae": {
+      "name": "서울동자초등학교",
+      "lat": 37.53505821,
+      "lng": 127.0721792,
+      "distanceKm": 0.61,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gangbuk-mia": {
+      "name": "서울화계초등학교",
+      "lat": 37.62388498,
+      "lng": 127.0297162,
+      "distanceKm": 0.2,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "jongno-pyeongchang": {
+      "name": "서울세검정초등학교",
+      "lat": 37.60346883,
+      "lng": 126.9609387,
+      "distanceKm": 1.6,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "geumcheon-siheung": {
+      "name": "서울금나래초등학교",
+      "lat": 37.45823,
+      "lng": 126.8962417,
+      "distanceKm": 0.49,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gimpo-sau": {
+      "name": "사우초등학교",
+      "lat": 37.62052677,
+      "lng": 126.7239749,
+      "distanceKm": 0.93,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gimpo-janggi": {
+      "name": "가현초등학교",
+      "lat": 37.63807828,
+      "lng": 126.6740076,
+      "distanceKm": 0.27,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gimpo-pungmu": {
+      "name": "금란초등학교",
+      "lat": 37.60765405,
+      "lng": 126.7511726,
+      "distanceKm": 0.88,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "ilsan-madu": {
+      "name": "금계초등학교",
+      "lat": 37.649601,
+      "lng": 126.7843119,
+      "distanceKm": 0.22,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "ilsan-janghang": {
+      "name": "낙민초등학교",
+      "lat": 37.65392838,
+      "lng": 126.7801004,
+      "distanceKm": 1,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "bundang-seohyeon": {
+      "name": "서현초등학교",
+      "lat": 37.38257622,
+      "lng": 127.12855,
+      "distanceKm": 0.56,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "bundang-jeongja": {
+      "name": "백현초등학교",
+      "lat": 37.37219331,
+      "lng": 127.1111656,
+      "distanceKm": 0.37,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "bundang-pangyo": {
+      "name": "낙생초등학교",
+      "lat": 37.39430405,
+      "lng": 127.0989134,
+      "distanceKm": 0.55,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "suwon-yeongtong": {
+      "name": "신풍초등학교",
+      "lat": 37.28639813,
+      "lng": 127.0531872,
+      "distanceKm": 0.28,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "anyang-pyeongchon": {
+      "name": "달안초등학교",
+      "lat": 37.39460528,
+      "lng": 126.9500874,
+      "distanceKm": 0.45,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "hwaseong-dongtan": {
+      "name": "솔빛초등학교",
+      "lat": 37.1966888294,
+      "lng": 127.0737903,
+      "distanceKm": 0.47,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "seongnam-wirye": {
+      "name": "위례고운초등학교",
+      "lat": 37.47148964,
+      "lng": 127.1457743,
+      "distanceKm": 0.23,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gunpo-sanbon": {
+      "name": "군포양정초등학교",
+      "lat": 37.35930627,
+      "lng": 126.9406945,
+      "distanceKm": 0.42,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "bucheon-jung": {
+      "name": "중흥초등학교",
+      "lat": 37.50668196,
+      "lng": 126.7732474,
+      "distanceKm": 0.39,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "seongnam-sujeong": {
+      "name": "희망대초등학교",
+      "lat": 37.44749919,
+      "lng": 127.1491148,
+      "distanceKm": 0.33,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "incheon-cheongna": {
+      "name": "인천경명초등학교",
+      "lat": 37.5369986,
+      "lng": 126.6373144,
+      "distanceKm": 0.36,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "incheon-songdo": {
+      "name": "인천해송초등학교",
+      "lat": 37.3809103,
+      "lng": 126.6492847,
+      "distanceKm": 0.53,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "incheon-geomdan": {
+      "name": "인천금곡초등학교",
+      "lat": 37.6054434,
+      "lng": 126.65061,
+      "distanceKm": 0.27,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "incheon-bupyeong": {
+      "name": "인천부평서초등학교",
+      "lat": 37.49511249,
+      "lng": 126.7218358,
+      "distanceKm": 0.08,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "incheon-sinpo": {
+      "name": "인성초등학교",
+      "lat": 37.4739458,
+      "lng": 126.624248,
+      "distanceKm": 0.25,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "seongdong-seongsu": {
+      "name": "서울경동초등학교",
+      "lat": 37.5438253,
+      "lng": 127.050074,
+      "distanceKm": 0.53,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    },
+    "gwangjin-jayang": {
+      "name": "서울성자초등학교",
+      "lat": 37.53149357,
+      "lng": 127.0834083,
+      "distanceKm": 0.41,
+      "_source": "한국교육시설안전원",
+      "updatedAt": "2026-03-20"
+    }
+  }
+}

--- a/onday-app/src/lib/schools-index.ts
+++ b/onday-app/src/lib/schools-index.ts
@@ -1,0 +1,23 @@
+import schoolsData from "@/lib/data/schools-index.json";
+
+// 학군 PR1 — 각 neighborhood 최근접 초등학교 1곳 (build-schools-index.ts 사전계산).
+//   ★ "배정"이 아니라 "인근" (학구도 폴리곤 미보유 — 정확한 배정은 외부 아웃링크에서, PR2).
+//   safety-index/community-index 와 동일 패턴: 정적 JSON + getXxx 룩업.
+
+export interface NearestSchool {
+  name: string;
+  lat: number;
+  lng: number;
+  distanceKm: number;
+  _source: string;
+  updatedAt: string;
+}
+
+const BY_NEIGHBORHOOD = (
+  schoolsData as { byNeighborhood: Record<string, NearestSchool> }
+).byNeighborhood;
+
+// neighborhood id → 최근접 초등학교. 미매핑 시 null (등급 날조 금지 원칙과 동일 — 없으면 없다고).
+export function getNearestSchool(neighborhoodId: string): NearestSchool | null {
+  return BY_NEIGHBORHOOD[neighborhoodId] ?? null;
+}


### PR DESCRIPTION
## 목표
`data-raw/schools.xls`(학교알리미 전국초중등학교위치표준데이터)에서 각 neighborhood **최근접 초등학교 1곳**을 빌드타임 사전계산 → `schools-index.json`. UI는 **PR2 별도** (이번엔 데이터만).

## 변경
- **`scripts/build-schools-index.ts`** (`build-community-index.ts` 패턴): `schools.xls` 읽기(헤더 2행 자동탐지) → `학교급구분 === "초등학교"` 필터(전국 6,303개, 수도권 인위 축소 안 함) → 각 `MOCK_NEIGHBORHOODS.coordinate` 기준 `haversineDistance`로 최근접 1곳. 좌표 결측/0·0 행 skip + 카운트 로그.
- **`src/lib/data/schools-index.json`**: neighborhood id별 `{name, lat, lng, distanceKm, _source, updatedAt}`.
- **`src/lib/schools-index.ts`**: `getNearestSchool(neighborhoodId)` 룩업(없으면 `null`).
- **`package.json`**: `build:schools` 스크립트.

## provenance (★ 편의시설 교훈 반영)
원본(학교알리미 위치표준데이터) + 생성 스크립트 + `_source` 기재로 **값 재현 가능**.
- `_source` = `"한국교육시설안전원"` (xls 제공기관명), `updatedAt` = `"2026-03-20"` (xls 데이터기준일자) — 코드 상수가 아니라 데이터에서 추출.
- 최근접 = **"배정"이 아니라 "인근"** (학구도 폴리곤 미보유). UI 라벨도 "인근"으로 (PR2).

## 검증
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ (0 errors; 기존 무관 warning 10건만)
- **44/44 동네 매핑** (누락 0). 샘플: 종로3가→서울교동초(0.55km), 수원 광교동→신풍초(0.28km), 평창동→서울세검정초(1.6km)
- 거리 분포: 최대 **1.60km**(평창동, 산지 주거지 — 합리적), **>5km 0건** (좌표/매핑 이상 없음)
- `build:schools` **재실행 시 동일 결과**(결정론적) 확인
- **`data-raw/schools.xls`는 git 미추적**(gitignore 확인) — 원본 xls 미커밋, `schools-index.json`만 커밋

## 후속
- **PR2 (UI 트랙)**: 데드라인 요약/매물 카드에 "인근 초등학교: OO초등학교" + 네이버 검색 아웃링크 → REQ-FUNC-018 "학교" 항목 충족.
- 정확한 "배정"은 전국학교학구도연계정보표준데이터(`15021158`)로 업그레이드 가능 — 딥하게 갈 때.

(Closes 없음 — 관련 이슈 있으면 링크만)