### PR TITLE
feat(deadline): 학군 PR2 — 급매 카드에 인근 초등학교 + 네이버 검색 아웃링크

### DIFF
--- a/onday-app/src/components/deadline/listing-card.tsx
+++ b/onday-app/src/components/deadline/listing-card.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { ArrowUpRight, Clock } from "lucide-react";
+import { ArrowUpRight, Clock, GraduationCap } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
-import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
+import { buildNaverRealEstateUrl, buildSchoolSearchUrl } from "@/lib/deadline/naver-url-builder";
+import { getNearestSchool } from "@/lib/schools-index";
 import type { ListingItem } from "@/lib/types/deadline";
 
 // 급매 매물 카드 — 정보 표시 + 네이버 부동산 아웃링크 (자체 매물 DB 없음, REQ-FUNC-016).
+// 학군 PR2 — 인근 초등학교 한 줄 + 네이버 검색 아웃링크 (REQ-FUNC-018 "학교" 충족).
+//   ★ 카드를 div 로 감싸고 부동산/학교 두 아웃링크를 형제로 둠 (<a> 중첩 금지).
 // 보안: target="_blank" + rel="noopener noreferrer" (window.opener 차단 + Referer 미전송).
 
 interface ListingCardProps {
@@ -15,36 +18,55 @@ interface ListingCardProps {
 
 export function ListingCard({ listing }: ListingCardProps) {
   const url = buildNaverRealEstateUrl(listing.areaName, { roomType: "apartment" });
+  // 좌표 최근접 초등학교 (PR1 사전계산). 없으면 학교 줄 미렌더 (빈 값/에러 표시 금지).
+  const school = getNearestSchool(listing.neighborhoodId);
 
   return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label={`${listing.areaName} ${listing.dealType} ${listing.priceLabel}, 네이버 부동산에서 보기 (새 창)`}
-      className="flex items-center gap-s-3 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 shadow-card transition-colors hover:bg-bg focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
-    >
-      <div className="min-w-0 flex-1 space-y-1">
-        <div className="flex items-center gap-s-2">
-          <p className="truncate text-body-sm font-bold text-ink">
-            {listing.areaName}
+    <div className="overflow-hidden rounded-lg border border-card-border bg-surface shadow-card">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`${listing.areaName} ${listing.dealType} ${listing.priceLabel}, 네이버 부동산에서 보기 (새 창)`}
+        className="flex items-center gap-s-3 px-s-4 py-s-3 transition-colors hover:bg-bg focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary"
+      >
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-s-2">
+            <p className="truncate text-body-sm font-bold text-ink">
+              {listing.areaName}
+            </p>
+            <Badge variant="danger" size="xs">
+              급매 -{listing.discountPercent}%
+            </Badge>
+          </div>
+          <p className="text-caption text-ink-2">
+            {listing.dealType} {listing.priceLabel} · {listing.pyeong}평
           </p>
-          <Badge variant="danger" size="xs">
-            급매 -{listing.discountPercent}%
-          </Badge>
+          <p className="flex items-center gap-1 text-caption-xs text-ink-3">
+            <Clock aria-hidden className="size-3" />
+            등록 {listing.elapsedDays}일 경과
+          </p>
         </div>
-        <p className="text-caption text-ink-2">
-          {listing.dealType} {listing.priceLabel} · {listing.pyeong}평
-        </p>
-        <p className="flex items-center gap-1 text-caption-xs text-ink-3">
-          <Clock aria-hidden className="size-3" />
-          등록 {listing.elapsedDays}일 경과
-        </p>
-      </div>
-      <span className="flex shrink-0 items-center gap-0.5 text-caption font-bold text-primary">
-        네이버
-        <ArrowUpRight aria-hidden className="size-3.5" />
-      </span>
-    </a>
+        <span className="flex shrink-0 items-center gap-0.5 text-caption font-bold text-primary">
+          네이버
+          <ArrowUpRight aria-hidden className="size-3.5" />
+        </span>
+      </a>
+
+      {school && (
+        <a
+          href={buildSchoolSearchUrl(school.name)}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`인근 초등학교 ${school.name}, 네이버 검색 (새 창)`}
+          className="flex items-center gap-1 border-t border-card-border px-s-4 py-s-2 text-caption text-ink-3 transition-colors hover:bg-bg focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary"
+        >
+          <GraduationCap aria-hidden className="size-3 shrink-0" />
+          인근 초등학교:
+          <span className="truncate font-bold text-primary">{school.name}</span>
+          <ArrowUpRight aria-hidden className="size-3 shrink-0" />
+        </a>
+      )}
+    </div>
   );
 }

--- a/onday-app/src/lib/deadline/naver-url-builder.ts
+++ b/onday-app/src/lib/deadline/naver-url-builder.ts
@@ -17,3 +17,13 @@ export function buildNaverRealEstateUrl(
   }
   return `${NAVER_LAND_BASE}?${params.toString()}`;
 }
+
+// 학군 PR2 — 인근 초등학교명 → 네이버 통합검색 아웃링크.
+//   학교는 부동산(land.naver.com)이 아니라 search.naver.com. URLSearchParams 가 한글 인코딩 처리.
+//   ★ 좌표 최근접 "인근" 학교 — 정확한 배정 학군은 검색 결과에서 사용자가 확인하는 흐름.
+const NAVER_SEARCH_BASE = "https://search.naver.com/search.naver";
+
+export function buildSchoolSearchUrl(schoolName: string): string {
+  const params = new URLSearchParams({ query: schoolName });
+  return `${NAVER_SEARCH_BASE}?${params.toString()}`;
+}

--- a/onday-app/src/lib/mocks/deadline/listings.ts
+++ b/onday-app/src/lib/mocks/deadline/listings.ts
@@ -19,6 +19,7 @@ function listingsForArea(c: CandidateArea): ListingItem[] {
     const discounted = basePrice * (1 - discountPercent / 100);
     return {
       id: `${c.id}-listing-${i}`,
+      neighborhoodId: c.id,
       areaName,
       dealType: DEAL_TYPES[(i + c.gu.length) % 2],
       priceLabel: `${Math.round(discounted / 1000) / 10}억`, // 만원 → 억 (1자리)

--- a/onday-app/src/lib/types/deadline.ts
+++ b/onday-app/src/lib/types/deadline.ts
@@ -11,6 +11,7 @@ export interface ListingFilters {
 
 export interface ListingItem {
   id: string;
+  neighborhoodId: string; // 후보 동네 id — 인근 초등학교(getNearestSchool) 조회 키.
   areaName: string; // "강남구 역삼동"
   dealType: "매매" | "전세";
   priceLabel: string; // "4.5억"


### PR DESCRIPTION
## 목표
데드라인 모드 급매 매물 카드(`ListingCard`)에 **"인근 초등학교: OO초등학교"** 한 줄 + 학교명 클릭 시 네이버 검색 아웃링크. PR1(#166)의 `getNearestSchool(id)` 데이터 활용. **REQ-FUNC-018 "학교" 항목 충족.**

## 변경
- **`buildSchoolSearchUrl`** (`naver-url-builder.ts`): `search.naver.com/search.naver?query=<학교명>` (URLSearchParams 한글 인코딩). 학교는 부동산이 아니라 통합검색.
- **`ListingItem.neighborhoodId`** 추가 → 학교 조회 키. `buildMockListings`에서 `c.id` 주입.
- **`ListingCard`**: `<a>` 중첩 금지 → 카드를 `<div>`로 감싸고 **부동산/학교 두 아웃링크를 형제로** 배치. `getNearestSchool` null이면 학교 줄 미렌더(빈 값/에러 표시 없음). 기존 카드 데이터 항목(가격/평형/할인율/등록경과 등) 무변경. 보안 패턴(`target=_blank rel=noopener noreferrer`) 두 링크 모두 재사용.

## 정직성
- **"배정"이 아니라 "인근"** — 좌표 최근접 ≠ 학구도 배정. 카드 문구·aria 모두 "인근 초등학교". 정확한 배정 학군은 네이버 검색 결과에서 사용자가 확인하는 흐름.
- 거리 표기는 이번엔 생략(카드 간결). 필요 시 후속.

## 검증
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ (0 errors; 기존 무관 warning 10건만)
- 급매 카드 인근 초등학교 (PR1 json 대조):
  - 종로3가 → 서울교동초등학교 / 공덕동 → 서울공덕초등학교 (정확)
- 학교명 클릭 → 네이버 검색 새 창, 한글 정확 인코딩 (`서울교동초등학교` → `query=%EC...`, 디코딩 복원 확인)
- `getNearestSchool` null 케이스(없는 id) → 학교 줄 미표시 확인
- 기존 카드 데이터 항목 회귀 없음 / 한글 인코딩(U+FFFD) 검사 통과

## 후속 (이번 범위 외)
- 통근 시간: 진짜 통근 데이터 연동 시 카드에 추가(가짜 숫자 금지 — 미추가).
- 정확한 "배정": 전국학교학구도연계정보표준데이터(`15021158`)로 업그레이드.

(Closes 없음 — REQ-FUNC-018 관련 이슈 있으면 링크만)