### PR TITLE
feat(price): 시세 3-B — 국토부 실거래 동네별 중앙값 사전계산(price-index)

### DIFF
--- a/onday-app/package.json
+++ b/onday-app/package.json
@@ -17,7 +17,8 @@
     "postinstall": "npx prisma generate",
     "check:coverage": "npx tsx scripts/check-coverage.ts",
     "build:schools": "npx tsx scripts/build-schools-index.ts",
-    "build:lawd": "npx tsx scripts/build-lawd-mapping.ts"
+    "build:lawd": "npx tsx scripts/build-lawd-mapping.ts",
+    "build:price": "npx tsx scripts/build-price-index.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/onday-app/scripts/build-price-index.ts
+++ b/onday-app/scripts/build-price-index.ts
@@ -1,0 +1,274 @@
+// 시세 3-B — 국토부 실거래(아파트 매매·전월세) 엑셀 6개 → 동네별 거래유형 중앙값 사전계산.
+//   학교/공원(build-schools-index) 패턴 답습: 원본(data-raw, git 미추적) + 스크립트 + provenance + 결측 방어.
+//   실행: npm run build:price   (사전: data-raw 에 아래 6개 xlsx)
+//
+//   ★ 조인: 실거래 '시군구' 셀 = "시도 시군구 법정동" 한 셀(숫자 LAWD 없음) → PRICE_DONG_MAPPING(3-A, 사람 큐레이션)으로
+//     (시군구 + 법정동) 텍스트 매칭. legalDong 전략이라도 표본이 매매<20 또는 전월세<30 이면 자동 시군구 폴백.
+//   ★ 면적 60~85㎡(국민주택규모) 한정 — 소형/대형 혼합 평균 왜곡 방지(Phase 0 권고).
+//   ★ 결측은 null. 추정 환산(JEONSE_RATIO 등)으로 메우지 않음(#59 옵션2 — 날조 금지).
+//   ★ 매매 파일 3개는 파일명 선행 공백 주의(" apt-trade_*"). 전월세는 공백 없음.
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import * as XLSX from "xlsx";
+
+import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
+import { PRICE_DONG_MAPPING } from "./price-dong-mapping";
+
+const DIR = join(process.cwd(), "data-raw");
+const OUT = join(process.cwd(), "src/lib/data/price-index.json");
+const RETRIEVED_AT = new Date().toISOString().slice(0, 10);
+const AREA_MIN = 60;
+const AREA_MAX = 85;
+const MIN_TRADE = 20; // 매매 표본 임계(미만 → 시군구 폴백)
+const MIN_RENT = 30; // 전월세 표본 임계
+
+const TRADE_FILES = [" apt-trade_서울.xlsx", " apt-trade_경기도.xlsx", " apt-trade_인천.xlsx"];
+const RENT_FILES = ["apt-rent_서울.xlsx", "apt-rent_경기도.xlsx", "apt-rent_인천.xlsx"];
+
+interface Bucket {
+  maemae: number[];
+  jeonseDeposit: number[];
+  wolseDeposit: number[];
+  wolseMonthly: number[];
+}
+const newBucket = (): Bucket => ({ maemae: [], jeonseDeposit: [], wolseDeposit: [], wolseMonthly: [] });
+
+// 실거래 시군구 셀 → { sigungu(표준형), legalDong }. 인천은 "인천 " 접두로 서울 중구 등과 구분.
+function parseSigunguCell(cell: string): { sigungu: string; legalDong: string } | null {
+  const t = cell.trim().split(/\s+/);
+  if (t.length < 3) return null;
+  const sido = t[0];
+  const legalDong = t[t.length - 1];
+  const middle = t.slice(1, t.length - 1).join(" ");
+  const sigungu = sido.startsWith("인천") ? `인천 ${middle}` : middle;
+  return { sigungu, legalDong };
+}
+
+const num = (v: unknown): number => Number(String(v).replace(/,/g, "").trim());
+
+function median(arr: number[]): number {
+  if (!arr.length) return NaN;
+  const s = [...arr].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : Math.round((s[m - 1] + s[m]) / 2);
+}
+
+// 필요한 sigungu 만 수집(메모리 절약).
+const neededSigungu = new Set(Object.values(PRICE_DONG_MAPPING).map((m) => m.sigungu));
+const bySigungu = new Map<string, Bucket>(); // sigungu 전체(폴백용)
+const byDong = new Map<string, Bucket>(); // `${sigungu}|${legalDong}`
+const get = (map: Map<string, Bucket>, key: string) => {
+  let b = map.get(key);
+  if (!b) { b = newBucket(); map.set(key, b); }
+  return b;
+};
+
+function loadSheet(file: string): { header: string[]; aoa: unknown[][]; hi: number } {
+  const fp = join(DIR, file);
+  if (!existsSync(fp)) throw new Error(`원본 없음: data-raw/${file} (국토부 실거래가공개시스템 다운로드 필요)`);
+  const wb = XLSX.read(readFileSync(fp), { type: "buffer" });
+  const aoa = XLSX.utils.sheet_to_json(wb.Sheets[wb.SheetNames[0]], { header: 1, defval: "", raw: false }) as unknown[][];
+  const hi = aoa.findIndex((r) => r.some((c) => String(c).trim() === "전용면적(㎡)"));
+  if (hi < 0) throw new Error(`헤더(전용면적(㎡)) 못 찾음: ${file}`);
+  const header = aoa[hi].map((c) => String(c).trim());
+  return { header, aoa, hi };
+}
+
+let tradeRows = 0, rentRows = 0;
+
+for (const file of TRADE_FILES) {
+  const { header, aoa, hi } = loadSheet(file);
+  const iSig = header.indexOf("시군구");
+  const iArea = header.indexOf("전용면적(㎡)");
+  const iPrice = header.indexOf("거래금액(만원)");
+  if (iSig < 0 || iArea < 0 || iPrice < 0) throw new Error(`매매 컬럼 매핑 실패: ${file}`);
+  for (let r = hi + 1; r < aoa.length; r++) {
+    const row = aoa[r];
+    const parsed = parseSigunguCell(String(row[iSig] ?? ""));
+    if (!parsed || !neededSigungu.has(parsed.sigungu)) continue;
+    const area = num(row[iArea]);
+    if (!(area >= AREA_MIN && area <= AREA_MAX)) continue;
+    const price = num(row[iPrice]);
+    if (!Number.isFinite(price) || price <= 0) continue;
+    get(bySigungu, parsed.sigungu).maemae.push(price);
+    get(byDong, `${parsed.sigungu}|${parsed.legalDong}`).maemae.push(price);
+    tradeRows++;
+  }
+}
+
+for (const file of RENT_FILES) {
+  const { header, aoa, hi } = loadSheet(file);
+  const iSig = header.indexOf("시군구");
+  const iType = header.indexOf("전월세구분");
+  const iArea = header.indexOf("전용면적(㎡)");
+  const iDep = header.indexOf("보증금(만원)");
+  const iMon = header.indexOf("월세금(만원)");
+  if ([iSig, iType, iArea, iDep, iMon].some((i) => i < 0)) throw new Error(`전월세 컬럼 매핑 실패: ${file}`);
+  for (let r = hi + 1; r < aoa.length; r++) {
+    const row = aoa[r];
+    const parsed = parseSigunguCell(String(row[iSig] ?? ""));
+    if (!parsed || !neededSigungu.has(parsed.sigungu)) continue;
+    const area = num(row[iArea]);
+    if (!(area >= AREA_MIN && area <= AREA_MAX)) continue;
+    const type = String(row[iType] ?? "").trim();
+    const deposit = num(row[iDep]);
+    if (!Number.isFinite(deposit) || deposit < 0) continue;
+    const sg = get(bySigungu, parsed.sigungu);
+    const dg = get(byDong, `${parsed.sigungu}|${parsed.legalDong}`);
+    if (type === "전세") {
+      sg.jeonseDeposit.push(deposit);
+      dg.jeonseDeposit.push(deposit);
+    } else if (type === "월세") {
+      const monthly = num(row[iMon]);
+      if (!Number.isFinite(monthly) || monthly <= 0) continue;
+      sg.wolseDeposit.push(deposit);
+      sg.wolseMonthly.push(monthly);
+      dg.wolseDeposit.push(deposit);
+      dg.wolseMonthly.push(monthly);
+    } else continue;
+    rentRows++;
+  }
+}
+
+// legalDong 복수 OR 합산
+function gather(sigungu: string, legalDong: string[]): Bucket {
+  const out = newBucket();
+  for (const ld of legalDong) {
+    const b = byDong.get(`${sigungu}|${ld}`);
+    if (!b) continue;
+    out.maemae.push(...b.maemae);
+    out.jeonseDeposit.push(...b.jeonseDeposit);
+    out.wolseDeposit.push(...b.wolseDeposit);
+    out.wolseMonthly.push(...b.wolseMonthly);
+  }
+  return out;
+}
+
+interface PriceEntry {
+  maemae: { median: number; count: number } | null;
+  jeonse: { median: number; count: number } | null;
+  wolse: { depositMedian: number; monthlyMedian: number; count: number } | null;
+  source: "legalDong" | "sigungu-fallback";
+  matchedSigungu: string;
+  matchedLegalDong: string[];
+  _source: string;
+  period: string;
+  areaFilter: string;
+  retrievedAt: string;
+}
+
+const SOURCE_LABEL = "국토교통부 실거래가공개시스템 아파트 매매/전월세";
+const PERIOD = "2025-12 ~ 2026-06";
+const AREA_LABEL = `${AREA_MIN}-${AREA_MAX}㎡`;
+
+const byId: Record<string, PriceEntry> = {};
+const thresholdFallbackIds: string[] = []; // legalDong 전략이었으나 표본 임계 미달로 폴백된 동네
+const missingMap: string[] = [];
+
+for (const n of MOCK_NEIGHBORHOODS) {
+  const map = PRICE_DONG_MAPPING[n.id];
+  if (!map) { missingMap.push(n.id); continue; }
+
+  let bucket: Bucket;
+  let source: "legalDong" | "sigungu-fallback";
+  let matchedLegalDong: string[];
+
+  if (map.strategy === "legalDong" && map.legalDong.length) {
+    const ldBucket = gather(map.sigungu, map.legalDong);
+    const rentCount = ldBucket.jeonseDeposit.length + ldBucket.wolseDeposit.length;
+    if (ldBucket.maemae.length < MIN_TRADE || rentCount < MIN_RENT) {
+      // 임계 미달 → 시군구 폴백
+      bucket = bySigungu.get(map.sigungu) ?? newBucket();
+      source = "sigungu-fallback";
+      matchedLegalDong = [];
+      thresholdFallbackIds.push(n.id);
+    } else {
+      bucket = ldBucket;
+      source = "legalDong";
+      matchedLegalDong = map.legalDong;
+    }
+  } else {
+    // 3-A 명시 시군구 폴백(legalDong=[])
+    bucket = bySigungu.get(map.sigungu) ?? newBucket();
+    source = "sigungu-fallback";
+    matchedLegalDong = [];
+  }
+
+  const jeonse = bucket.jeonseDeposit.length
+    ? { median: median(bucket.jeonseDeposit), count: bucket.jeonseDeposit.length }
+    : null;
+  const maemae = bucket.maemae.length
+    ? { median: median(bucket.maemae), count: bucket.maemae.length }
+    : null;
+  const wolse = bucket.wolseDeposit.length
+    ? {
+        depositMedian: median(bucket.wolseDeposit),
+        monthlyMedian: median(bucket.wolseMonthly),
+        count: bucket.wolseDeposit.length,
+      }
+    : null;
+
+  byId[n.id] = {
+    maemae, jeonse, wolse, source,
+    matchedSigungu: map.sigungu,
+    matchedLegalDong,
+    _source: SOURCE_LABEL, period: PERIOD, areaFilter: AREA_LABEL, retrievedAt: RETRIEVED_AT,
+  };
+}
+
+const out = {
+  _meta: {
+    description: "동네별 아파트 거래유형(매매/전세/월세) 중앙값 — 국토부 실거래 사전계산. 시세 실데이터 3단계(데이터).",
+    source: SOURCE_LABEL,
+    period: PERIOD,
+    areaFilter: `전용 ${AREA_LABEL}(국민주택규모) 한정`,
+    method: "PRICE_DONG_MAPPING(3-A 사람 큐레이션)으로 (시군구+법정동) 텍스트 조인 후 중앙값. 숫자 LAWD 미존재.",
+    threshold: `법정동 표본 매매<${MIN_TRADE} 또는 전월세<${MIN_RENT} 이면 자동 시군구 폴백`,
+    fallbackTotal: Object.values(byId).filter((e) => e.source === "sigungu-fallback").length,
+    fallbackThresholdTriggered: thresholdFallbackIds.length,
+    generatedFrom: "scripts/build-price-index.ts + scripts/price-dong-mapping.ts",
+    retrievedAt: RETRIEVED_AT,
+    note: "동 단위 중앙값(단지·평형별 편차 있음). 60~85㎡ 한정. 폴백=구 평균(동 데이터 부족). 결측은 null(추정 환산 없음).",
+  },
+  byId,
+};
+
+writeFileSync(OUT, JSON.stringify(out, null, 2) + "\n");
+if (!existsSync(OUT)) throw new Error("price-index.json 쓰기 실패");
+
+// ── 콘솔 리포트 ───────────────────────────────────────────────
+const man = (v: number) => (v / 10000).toFixed(2) + "억";
+console.log(`\n실거래 수집: 매매 ${tradeRows} / 전월세 ${rentRows} 행 (60~85㎡, 필요 시군구만)`);
+console.log(`\n══ 44개 동네 산출 (매매median / 전세median / source) ══`);
+for (const n of MOCK_NEIGHBORHOODS) {
+  const e = byId[n.id];
+  if (!e) { console.log(`  ${n.dong} — 매핑 없음`); continue; }
+  const mm = e.maemae ? `${man(e.maemae.median)}(${e.maemae.count})` : "—";
+  const js = e.jeonse ? `${man(e.jeonse.median)}(${e.jeonse.count})` : "—";
+  const tag = e.source === "sigungu-fallback" ? "⚠️구폴백" : "";
+  console.log(`  ${n.dong.padEnd(8)} 매매 ${mm.padEnd(14)} 전세 ${js.padEnd(14)} ${e.source}${tag ? " " + tag : ""}`);
+}
+
+const dongOf = (id: string) => MOCK_NEIGHBORHOODS.find((n) => n.id === id)?.dong;
+const allFallback = MOCK_NEIGHBORHOODS.filter((n) => byId[n.id]?.source === "sigungu-fallback").map((n) => n.dong);
+console.log(`\n── 시군구 폴백 총 ${allFallback.length}건: ${allFallback.join(", ")}`);
+console.log(`   ├ 3-A 명시 폴백: ${allFallback.filter((d) => !thresholdFallbackIds.map(dongOf).includes(d)).join(", ")}`);
+console.log(`   └ 임계(20/30) 미달 자동: ${thresholdFallbackIds.map(dongOf).join(", ")}`);
+const missMaemae = MOCK_NEIGHBORHOODS.filter((n) => byId[n.id] && !byId[n.id].maemae).map((n) => n.dong);
+const missJeonse = MOCK_NEIGHBORHOODS.filter((n) => byId[n.id] && !byId[n.id].jeonse).map((n) => n.dong);
+const missWolse = MOCK_NEIGHBORHOODS.filter((n) => byId[n.id] && !byId[n.id].wolse).map((n) => n.dong);
+console.log(`── 결측 매매 ${missMaemae.length}: ${missMaemae.join(", ") || "없음"}`);
+console.log(`── 결측 전세 ${missJeonse.length}: ${missJeonse.join(", ") || "없음"}`);
+console.log(`── 결측 월세 ${missWolse.length}: ${missWolse.join(", ") || "없음"}`);
+if (missingMap.length) console.error(`❌ PRICE_DONG_MAPPING 누락 id: ${missingMap.join(", ")}`);
+
+console.log(`\n── 상식 점검(고가 동네) ──`);
+for (const dong of ["역삼동", "잠실동", "송도동", "광교동", "목동", "동탄"]) {
+  const n = MOCK_NEIGHBORHOODS.find((x) => x.dong === dong);
+  const e = n && byId[n.id];
+  if (e) console.log(`  ${dong}: 매매 ${e.maemae ? man(e.maemae.median) : "—"} / 전세 ${e.jeonse ? man(e.jeonse.median) : "—"} (${e.source})`);
+}
+
+console.log(`\n✅ price-index.json — ${Object.keys(byId).length}/${MOCK_NEIGHBORHOODS.length} 동네. retrievedAt=${RETRIEVED_AT}`);
+if (missingMap.length) process.exitCode = 1;

--- a/onday-app/scripts/price-dong-mapping.ts
+++ b/onday-app/scripts/price-dong-mapping.ts
@@ -1,0 +1,187 @@
+// 시세 3-A — 사람이 검수·승인한 동네 ↔ 실거래(국토부) 법정동 조인표.
+//   build-price-index.ts(3-B)가 소비. lawd-mapping.json(카카오 자동 생성)과 달리 이건 "사람 결정"이라
+//   성격이 다르므로 src/lib/data(생성물)와 분리해 scripts 아래 둔다.
+//
+//   sigungu = 실거래 '시군구' 셀의 시군구부(시도 제외) 표준형.
+//     - 서울/경기: "강남구", "화성시 동탄구"(일반구 포함)처럼 그대로.
+//     - 인천: 실거래 시도='인천광역시'라 모호(서울 중구 vs 인천 중구) → "인천 " 접두로 구분("인천 서구","인천 중구").
+//   legalDong = 법정동명 1+개(OR 매칭). 복수=집계(성수동1·2가), 빈 배열=시군구 폴백.
+//   strategy = "legalDong"(법정동 정밀) | "sigungu-fallback"(구 단위 평균, 동 데이터 부족).
+//
+//   ★ 3-A 결정 요약:
+//     - 다수의 dong 불일치는 "우리 dong이 실제 법정동이고 매칭이 더 큼" → dong 채택(불광/풍무/산본/시흥/평촌/상동).
+//     - 좌표가 경계라 카카오가 인접 법정동을 준 경우 우리 dong이 법정동 아님 → kakao 법정동 채택(왕십리→행당동 등).
+//     - override 2건(역삼/사당): 좌표는 인접 구지만 의도 동네의 실제 법정동으로.
+//     - 동탄/상동: 실거래 텍스트가 일반구 포함("화성시 동탄구","부천시 원미구") → sigungu 정정.
+//     - apt 희박/저볼륨(종로3가·신포동·성신여대입구·신촌동·동탄)은 시군구 폴백.
+
+export interface PriceDongMap {
+  sigungu: string; // 실거래 시군구부 표준형(위 규칙)
+  legalDong: string[]; // 법정동명 0+개. []=시군구 폴백
+  strategy: "legalDong" | "sigungu-fallback";
+  note?: string;
+}
+
+// key = neighborhood id (MOCK_NEIGHBORHOODS)
+export const PRICE_DONG_MAPPING: Record<string, PriceDongMap> = {
+  // ── 자동/단순 dong 채택 (dong = 실제 법정동, 매칭 양호) ──
+  "mapo-gondeok": { sigungu: "마포구", legalDong: ["공덕동"], strategy: "legalDong" },
+  "yongsan-itaewon": { sigungu: "용산구", legalDong: ["이태원동"], strategy: "legalDong" },
+  "songpa-jamsil": { sigungu: "송파구", legalDong: ["잠실동"], strategy: "legalDong" },
+  "yeongdeungpo-yeouido": { sigungu: "영등포구", legalDong: ["여의도동"], strategy: "legalDong" },
+  "nowon-junggye": { sigungu: "노원구", legalDong: ["중계동"], strategy: "legalDong" },
+  "gwanak-bongcheon": { sigungu: "관악구", legalDong: ["봉천동"], strategy: "legalDong" },
+  "yangcheon-mokdong": { sigungu: "양천구", legalDong: ["목동"], strategy: "legalDong" },
+  "dobong-chang": { sigungu: "도봉구", legalDong: ["창동"], strategy: "legalDong" },
+  "jungnang-myeonmok": { sigungu: "중랑구", legalDong: ["면목동"], strategy: "legalDong" },
+  "gangseo-yeomchang": { sigungu: "강서구", legalDong: ["염창동"], strategy: "legalDong" },
+  "gangbuk-mia": { sigungu: "강북구", legalDong: ["미아동"], strategy: "legalDong" },
+  "jongno-pyeongchang": { sigungu: "종로구", legalDong: ["평창동"], strategy: "legalDong" },
+  "gimpo-sau": { sigungu: "김포시", legalDong: ["사우동"], strategy: "legalDong" },
+  "gimpo-janggi": { sigungu: "김포시", legalDong: ["장기동"], strategy: "legalDong" },
+  "ilsan-madu": { sigungu: "고양시 일산동구", legalDong: ["마두동"], strategy: "legalDong" },
+  "ilsan-janghang": { sigungu: "고양시 일산동구", legalDong: ["장항동"], strategy: "legalDong" },
+  "bundang-seohyeon": { sigungu: "성남시 분당구", legalDong: ["서현동"], strategy: "legalDong" },
+  "bundang-jeongja": { sigungu: "성남시 분당구", legalDong: ["정자동"], strategy: "legalDong" },
+  "bundang-pangyo": { sigungu: "성남시 분당구", legalDong: ["판교동"], strategy: "legalDong" },
+  "incheon-cheongna": { sigungu: "인천 서구", legalDong: ["청라동"], strategy: "legalDong" },
+  "incheon-songdo": { sigungu: "인천 연수구", legalDong: ["송도동"], strategy: "legalDong" },
+  "incheon-bupyeong": { sigungu: "인천 부평구", legalDong: ["부평동"], strategy: "legalDong" },
+  "gwangjin-jayang": { sigungu: "광진구", legalDong: ["자양동"], strategy: "legalDong" },
+
+  // ── override (좌표=인접 구지만 의도 동네의 실제 법정동) ──
+  "gangnam-station": {
+    sigungu: "강남구",
+    legalDong: ["역삼동"],
+    strategy: "legalDong",
+    note: "override: 좌표=강남역(서초동)이나 의도=역삼동",
+  },
+  "dongjak-sadang": {
+    sigungu: "동작구",
+    legalDong: ["사당동"],
+    strategy: "legalDong",
+    note: "override: 좌표=사당역(관악구 경계)이나 의도=동작구 사당동",
+  },
+
+  // ── dong 채택 (우리 dong이 실제 법정동이고 매칭이 kakao 대안보다 큼) ──
+  "guro-gasan": {
+    sigungu: "금천구",
+    legalDong: ["가산동"],
+    strategy: "legalDong",
+    note: "가산동=금천구 소재(이전 구로구 오라벨 정정, #168)",
+  },
+  "eunpyeong-bulgwang": {
+    sigungu: "은평구",
+    legalDong: ["불광동"],
+    strategy: "legalDong",
+    note: "dong 채택(kakao 대조동보다 매칭 큼)",
+  },
+  "gimpo-pungmu": {
+    sigungu: "김포시",
+    legalDong: ["풍무동"],
+    strategy: "legalDong",
+    note: "dong 채택(kakao 고촌읍=0건)",
+  },
+  "gunpo-sanbon": {
+    sigungu: "군포시",
+    legalDong: ["산본동"],
+    strategy: "legalDong",
+    note: "dong 채택(kakao 금정동보다 매칭 큼)",
+  },
+  "geumcheon-siheung": {
+    sigungu: "금천구",
+    legalDong: ["시흥동"],
+    strategy: "legalDong",
+    note: "라벨일치 우선(독산동 대안 있으나 동네명 일치 채택)",
+  },
+  "anyang-pyeongchon": {
+    sigungu: "안양시 동안구",
+    legalDong: ["평촌동"],
+    strategy: "legalDong",
+    note: "라벨일치 우선(호계동 대안 있으나 동네명 일치 채택)",
+  },
+  "bucheon-jung": {
+    sigungu: "부천시 원미구",
+    legalDong: ["상동"],
+    strategy: "legalDong",
+    note: "상동=실제 법정동. 신설 일반구 '부천시 원미구' 포함",
+  },
+
+  // ── kakao 법정동 채택 (우리 dong이 행정동/신도시명이라 법정동 아님) ──
+  "seongdong-wangsimni": {
+    sigungu: "성동구",
+    legalDong: ["행당동"],
+    strategy: "legalDong",
+    note: "왕십리=행정동 → 법정동 행당동",
+  },
+  "suwon-yeongtong": {
+    sigungu: "수원시 영통구",
+    legalDong: ["이의동"],
+    strategy: "legalDong",
+    note: "광교=신도시 → 법정동 이의동",
+  },
+  "seongnam-wirye": {
+    sigungu: "성남시 수정구",
+    legalDong: ["창곡동"],
+    strategy: "legalDong",
+    note: "위례=신도시 → 법정동 창곡동",
+  },
+  "seongnam-sujeong": {
+    sigungu: "성남시 수정구",
+    legalDong: ["신흥동"],
+    strategy: "legalDong",
+    note: "수정동(행정동) → 법정동 신흥동",
+  },
+  "gwangjin-gundae": {
+    sigungu: "광진구",
+    legalDong: ["화양동"],
+    strategy: "legalDong",
+    note: "건대입구=역명 → 법정동 화양동",
+  },
+  "incheon-geomdan": {
+    sigungu: "인천 서구",
+    legalDong: ["금곡동"],
+    strategy: "legalDong",
+    note: "검단신도시 분산 저볼륨 → 임계 미달 시 자동 시군구 폴백",
+  },
+
+  // ── 집계(legalDong 복수) ──
+  "seongdong-seongsu": {
+    sigungu: "성동구",
+    legalDong: ["성수동1가", "성수동2가"],
+    strategy: "legalDong",
+    note: "성수동=법정동 1·2가로 분할 → 집계",
+  },
+
+  // ── 시군구 폴백 (apt 희박/저볼륨) ──
+  "hwaseong-dongtan": {
+    sigungu: "화성시 동탄구",
+    legalDong: [],
+    strategy: "sigungu-fallback",
+    note: "'동탄' 법정동 없음(동탄신도시=다수 법정동) → 동탄구 집계",
+  },
+  "jong-3": {
+    sigungu: "종로구",
+    legalDong: [],
+    strategy: "sigungu-fallback",
+    note: "종로3가=상업지, apt 거의 없음 → 종로구 평균",
+  },
+  "incheon-sinpo": {
+    sigungu: "인천 중구",
+    legalDong: [],
+    strategy: "sigungu-fallback",
+    note: "신포동=구도심, apt 희박 → 인천 중구 평균",
+  },
+  "seongbuk-seongshin": {
+    sigungu: "성북구",
+    legalDong: [],
+    strategy: "sigungu-fallback",
+    note: "성신여대입구 인근 법정동 거의 없음 → 성북구 평균",
+  },
+  "seodaemun-sinchon": {
+    sigungu: "서대문구",
+    legalDong: [],
+    strategy: "sigungu-fallback",
+    note: "신촌(창천동) 저볼륨 → 서대문구 평균",
+  },
+};

--- a/onday-app/src/lib/data/price-index.json
+++ b/onday-app/src/lib/data/price-index.json
@@ -1,0 +1,1054 @@
+{
+  "_meta": {
+    "description": "동네별 아파트 거래유형(매매/전세/월세) 중앙값 — 국토부 실거래 사전계산. 시세 실데이터 3단계(데이터).",
+    "source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+    "period": "2025-12 ~ 2026-06",
+    "areaFilter": "전용 60-85㎡(국민주택규모) 한정",
+    "method": "PRICE_DONG_MAPPING(3-A 사람 큐레이션)으로 (시군구+법정동) 텍스트 조인 후 중앙값. 숫자 LAWD 미존재.",
+    "threshold": "법정동 표본 매매<20 또는 전월세<30 이면 자동 시군구 폴백",
+    "fallbackTotal": 10,
+    "fallbackThresholdTriggered": 5,
+    "generatedFrom": "scripts/build-price-index.ts + scripts/price-dong-mapping.ts",
+    "retrievedAt": "2026-06-06",
+    "note": "동 단위 중앙값(단지·평형별 편차 있음). 60~85㎡ 한정. 폴백=구 평균(동 데이터 부족). 결측은 null(추정 환산 없음)."
+  },
+  "byId": {
+    "jong-3": {
+      "maemae": {
+        "median": 112000,
+        "count": 134
+      },
+      "jeonse": {
+        "median": 75800,
+        "count": 190
+      },
+      "wolse": {
+        "depositMedian": 25000,
+        "monthlyMedian": 178,
+        "count": 153
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "종로구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "mapo-gondeok": {
+      "maemae": {
+        "median": 203500,
+        "count": 28
+      },
+      "jeonse": {
+        "median": 81000,
+        "count": 107
+      },
+      "wolse": {
+        "depositMedian": 40000,
+        "monthlyMedian": 170,
+        "count": 92
+      },
+      "source": "legalDong",
+      "matchedSigungu": "마포구",
+      "matchedLegalDong": [
+        "공덕동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gangnam-station": {
+      "maemae": {
+        "median": 238250,
+        "count": 40
+      },
+      "jeonse": {
+        "median": 120000,
+        "count": 118
+      },
+      "wolse": {
+        "depositMedian": 45000,
+        "monthlyMedian": 290,
+        "count": 171
+      },
+      "source": "legalDong",
+      "matchedSigungu": "강남구",
+      "matchedLegalDong": [
+        "역삼동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "yongsan-itaewon": {
+      "maemae": {
+        "median": 180000,
+        "count": 151
+      },
+      "jeonse": {
+        "median": 73500,
+        "count": 475
+      },
+      "wolse": {
+        "depositMedian": 20000,
+        "monthlyMedian": 200,
+        "count": 334
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "용산구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "songpa-jamsil": {
+      "maemae": {
+        "median": 327000,
+        "count": 187
+      },
+      "jeonse": {
+        "median": 113825,
+        "count": 610
+      },
+      "wolse": {
+        "depositMedian": 35000,
+        "monthlyMedian": 205,
+        "count": 546
+      },
+      "source": "legalDong",
+      "matchedSigungu": "송파구",
+      "matchedLegalDong": [
+        "잠실동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "yeongdeungpo-yeouido": {
+      "maemae": {
+        "median": 262500,
+        "count": 30
+      },
+      "jeonse": {
+        "median": 40450,
+        "count": 72
+      },
+      "wolse": {
+        "depositMedian": 10000,
+        "monthlyMedian": 135,
+        "count": 47
+      },
+      "source": "legalDong",
+      "matchedSigungu": "영등포구",
+      "matchedLegalDong": [
+        "여의도동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "seodaemun-sinchon": {
+      "maemae": {
+        "median": 95650,
+        "count": 740
+      },
+      "jeonse": {
+        "median": 64000,
+        "count": 957
+      },
+      "wolse": {
+        "depositMedian": 23000,
+        "monthlyMedian": 130,
+        "count": 495
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "서대문구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "dongjak-sadang": {
+      "maemae": {
+        "median": 145000,
+        "count": 143
+      },
+      "jeonse": {
+        "median": 69000,
+        "count": 295
+      },
+      "wolse": {
+        "depositMedian": 40000,
+        "monthlyMedian": 100,
+        "count": 137
+      },
+      "source": "legalDong",
+      "matchedSigungu": "동작구",
+      "matchedLegalDong": [
+        "사당동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "nowon-junggye": {
+      "maemae": {
+        "median": 83000,
+        "count": 241
+      },
+      "jeonse": {
+        "median": 56000,
+        "count": 337
+      },
+      "wolse": {
+        "depositMedian": 26500,
+        "monthlyMedian": 130,
+        "count": 132
+      },
+      "source": "legalDong",
+      "matchedSigungu": "노원구",
+      "matchedLegalDong": [
+        "중계동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gwanak-bongcheon": {
+      "maemae": {
+        "median": 109000,
+        "count": 317
+      },
+      "jeonse": {
+        "median": 59000,
+        "count": 366
+      },
+      "wolse": {
+        "depositMedian": 25000,
+        "monthlyMedian": 126,
+        "count": 208
+      },
+      "source": "legalDong",
+      "matchedSigungu": "관악구",
+      "matchedLegalDong": [
+        "봉천동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "seongdong-wangsimni": {
+      "maemae": {
+        "median": 180000,
+        "count": 45
+      },
+      "jeonse": {
+        "median": 75000,
+        "count": 152
+      },
+      "wolse": {
+        "depositMedian": 25000,
+        "monthlyMedian": 187,
+        "count": 120
+      },
+      "source": "legalDong",
+      "matchedSigungu": "성동구",
+      "matchedLegalDong": [
+        "행당동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "yangcheon-mokdong": {
+      "maemae": {
+        "median": 153250,
+        "count": 216
+      },
+      "jeonse": {
+        "median": 68000,
+        "count": 454
+      },
+      "wolse": {
+        "depositMedian": 35000,
+        "monthlyMedian": 123,
+        "count": 268
+      },
+      "source": "legalDong",
+      "matchedSigungu": "양천구",
+      "matchedLegalDong": [
+        "목동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "guro-gasan": {
+      "maemae": {
+        "median": 70500,
+        "count": 266
+      },
+      "jeonse": {
+        "median": 42640,
+        "count": 244
+      },
+      "wolse": {
+        "depositMedian": 15000,
+        "monthlyMedian": 100,
+        "count": 137
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "금천구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "dobong-chang": {
+      "maemae": {
+        "median": 85500,
+        "count": 225
+      },
+      "jeonse": {
+        "median": 42000,
+        "count": 269
+      },
+      "wolse": {
+        "depositMedian": 18500,
+        "monthlyMedian": 93,
+        "count": 128
+      },
+      "source": "legalDong",
+      "matchedSigungu": "도봉구",
+      "matchedLegalDong": [
+        "창동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "jungnang-myeonmok": {
+      "maemae": {
+        "median": 76500,
+        "count": 211
+      },
+      "jeonse": {
+        "median": 53250,
+        "count": 158
+      },
+      "wolse": {
+        "depositMedian": 29000,
+        "monthlyMedian": 100,
+        "count": 65
+      },
+      "source": "legalDong",
+      "matchedSigungu": "중랑구",
+      "matchedLegalDong": [
+        "면목동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gangseo-yeomchang": {
+      "maemae": {
+        "median": 105000,
+        "count": 200
+      },
+      "jeonse": {
+        "median": 58000,
+        "count": 214
+      },
+      "wolse": {
+        "depositMedian": 30000,
+        "monthlyMedian": 110,
+        "count": 85
+      },
+      "source": "legalDong",
+      "matchedSigungu": "강서구",
+      "matchedLegalDong": [
+        "염창동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "eunpyeong-bulgwang": {
+      "maemae": {
+        "median": 93000,
+        "count": 122
+      },
+      "jeonse": {
+        "median": 44000,
+        "count": 128
+      },
+      "wolse": {
+        "depositMedian": 20000,
+        "monthlyMedian": 100,
+        "count": 45
+      },
+      "source": "legalDong",
+      "matchedSigungu": "은평구",
+      "matchedLegalDong": [
+        "불광동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "seongbuk-seongshin": {
+      "maemae": {
+        "median": 93500,
+        "count": 929
+      },
+      "jeonse": {
+        "median": 55650,
+        "count": 950
+      },
+      "wolse": {
+        "depositMedian": 20000,
+        "monthlyMedian": 130,
+        "count": 455
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "성북구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gwangjin-gundae": {
+      "maemae": {
+        "median": 169000,
+        "count": 204
+      },
+      "jeonse": {
+        "median": 71400,
+        "count": 639
+      },
+      "wolse": {
+        "depositMedian": 35500,
+        "monthlyMedian": 131,
+        "count": 362
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "광진구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gangbuk-mia": {
+      "maemae": {
+        "median": 77450,
+        "count": 341
+      },
+      "jeonse": {
+        "median": 53000,
+        "count": 222
+      },
+      "wolse": {
+        "depositMedian": 10000,
+        "monthlyMedian": 145,
+        "count": 152
+      },
+      "source": "legalDong",
+      "matchedSigungu": "강북구",
+      "matchedLegalDong": [
+        "미아동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "jongno-pyeongchang": {
+      "maemae": {
+        "median": 112000,
+        "count": 134
+      },
+      "jeonse": {
+        "median": 75800,
+        "count": 190
+      },
+      "wolse": {
+        "depositMedian": 25000,
+        "monthlyMedian": 178,
+        "count": 153
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "종로구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "geumcheon-siheung": {
+      "maemae": {
+        "median": 57000,
+        "count": 118
+      },
+      "jeonse": {
+        "median": 38000,
+        "count": 102
+      },
+      "wolse": {
+        "depositMedian": 10000,
+        "monthlyMedian": 100,
+        "count": 57
+      },
+      "source": "legalDong",
+      "matchedSigungu": "금천구",
+      "matchedLegalDong": [
+        "시흥동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gimpo-sau": {
+      "maemae": {
+        "median": 46900,
+        "count": 47
+      },
+      "jeonse": {
+        "median": 30450,
+        "count": 51
+      },
+      "wolse": {
+        "depositMedian": 3500,
+        "monthlyMedian": 130,
+        "count": 10
+      },
+      "source": "legalDong",
+      "matchedSigungu": "김포시",
+      "matchedLegalDong": [
+        "사우동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gimpo-janggi": {
+      "maemae": {
+        "median": 44500,
+        "count": 244
+      },
+      "jeonse": {
+        "median": 31000,
+        "count": 347
+      },
+      "wolse": {
+        "depositMedian": 4550,
+        "monthlyMedian": 130,
+        "count": 145
+      },
+      "source": "legalDong",
+      "matchedSigungu": "김포시",
+      "matchedLegalDong": [
+        "장기동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gimpo-pungmu": {
+      "maemae": {
+        "median": 60000,
+        "count": 282
+      },
+      "jeonse": {
+        "median": 39175,
+        "count": 232
+      },
+      "wolse": {
+        "depositMedian": 5000,
+        "monthlyMedian": 120,
+        "count": 76
+      },
+      "source": "legalDong",
+      "matchedSigungu": "김포시",
+      "matchedLegalDong": [
+        "풍무동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "ilsan-madu": {
+      "maemae": {
+        "median": 57000,
+        "count": 79
+      },
+      "jeonse": {
+        "median": 42000,
+        "count": 129
+      },
+      "wolse": {
+        "depositMedian": 5000,
+        "monthlyMedian": 120,
+        "count": 39
+      },
+      "source": "legalDong",
+      "matchedSigungu": "고양시 일산동구",
+      "matchedLegalDong": [
+        "마두동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "ilsan-janghang": {
+      "maemae": {
+        "median": 95500,
+        "count": 88
+      },
+      "jeonse": {
+        "median": 57000,
+        "count": 166
+      },
+      "wolse": {
+        "depositMedian": 10000,
+        "monthlyMedian": 160,
+        "count": 65
+      },
+      "source": "legalDong",
+      "matchedSigungu": "고양시 일산동구",
+      "matchedLegalDong": [
+        "장항동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "bundang-seohyeon": {
+      "maemae": {
+        "median": 195500,
+        "count": 85
+      },
+      "jeonse": {
+        "median": 67500,
+        "count": 187
+      },
+      "wolse": {
+        "depositMedian": 30000,
+        "monthlyMedian": 138,
+        "count": 102
+      },
+      "source": "legalDong",
+      "matchedSigungu": "성남시 분당구",
+      "matchedLegalDong": [
+        "서현동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "bundang-jeongja": {
+      "maemae": {
+        "median": 171000,
+        "count": 72
+      },
+      "jeonse": {
+        "median": 71400,
+        "count": 193
+      },
+      "wolse": {
+        "depositMedian": 30000,
+        "monthlyMedian": 133,
+        "count": 118
+      },
+      "source": "legalDong",
+      "matchedSigungu": "성남시 분당구",
+      "matchedLegalDong": [
+        "정자동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "bundang-pangyo": {
+      "maemae": {
+        "median": 167000,
+        "count": 24
+      },
+      "jeonse": {
+        "median": 75000,
+        "count": 108
+      },
+      "wolse": {
+        "depositMedian": 32843,
+        "monthlyMedian": 67,
+        "count": 151
+      },
+      "source": "legalDong",
+      "matchedSigungu": "성남시 분당구",
+      "matchedLegalDong": [
+        "판교동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "suwon-yeongtong": {
+      "maemae": {
+        "median": 127500,
+        "count": 131
+      },
+      "jeonse": {
+        "median": 72000,
+        "count": 155
+      },
+      "wolse": {
+        "depositMedian": 30000,
+        "monthlyMedian": 168,
+        "count": 80
+      },
+      "source": "legalDong",
+      "matchedSigungu": "수원시 영통구",
+      "matchedLegalDong": [
+        "이의동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "anyang-pyeongchon": {
+      "maemae": {
+        "median": 109050,
+        "count": 232
+      },
+      "jeonse": {
+        "median": 54550,
+        "count": 312
+      },
+      "wolse": {
+        "depositMedian": 25000,
+        "monthlyMedian": 120,
+        "count": 104
+      },
+      "source": "legalDong",
+      "matchedSigungu": "안양시 동안구",
+      "matchedLegalDong": [
+        "평촌동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "hwaseong-dongtan": {
+      "maemae": {
+        "median": 70800,
+        "count": 3517
+      },
+      "jeonse": {
+        "median": 39000,
+        "count": 2293
+      },
+      "wolse": {
+        "depositMedian": 10000,
+        "monthlyMedian": 76,
+        "count": 1729
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "화성시 동탄구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "seongnam-wirye": {
+      "maemae": {
+        "median": 178000,
+        "count": 25
+      },
+      "jeonse": {
+        "median": 78725,
+        "count": 132
+      },
+      "wolse": {
+        "depositMedian": 35000,
+        "monthlyMedian": 179,
+        "count": 74
+      },
+      "source": "legalDong",
+      "matchedSigungu": "성남시 수정구",
+      "matchedLegalDong": [
+        "창곡동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gunpo-sanbon": {
+      "maemae": {
+        "median": 74750,
+        "count": 146
+      },
+      "jeonse": {
+        "median": 48300,
+        "count": 108
+      },
+      "wolse": {
+        "depositMedian": 20000,
+        "monthlyMedian": 100,
+        "count": 31
+      },
+      "source": "legalDong",
+      "matchedSigungu": "군포시",
+      "matchedLegalDong": [
+        "산본동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "bucheon-jung": {
+      "maemae": {
+        "median": 68000,
+        "count": 269
+      },
+      "jeonse": {
+        "median": 45575,
+        "count": 236
+      },
+      "wolse": {
+        "depositMedian": 10000,
+        "monthlyMedian": 120,
+        "count": 84
+      },
+      "source": "legalDong",
+      "matchedSigungu": "부천시 원미구",
+      "matchedLegalDong": [
+        "상동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "seongnam-sujeong": {
+      "maemae": {
+        "median": 133000,
+        "count": 210
+      },
+      "jeonse": {
+        "median": 59850,
+        "count": 320
+      },
+      "wolse": {
+        "depositMedian": 25000,
+        "monthlyMedian": 157,
+        "count": 163
+      },
+      "source": "legalDong",
+      "matchedSigungu": "성남시 수정구",
+      "matchedLegalDong": [
+        "신흥동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "incheon-cheongna": {
+      "maemae": {
+        "median": 67000,
+        "count": 321
+      },
+      "jeonse": {
+        "median": 36000,
+        "count": 410
+      },
+      "wolse": {
+        "depositMedian": 5000,
+        "monthlyMedian": 150,
+        "count": 159
+      },
+      "source": "legalDong",
+      "matchedSigungu": "인천 서구",
+      "matchedLegalDong": [
+        "청라동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "incheon-songdo": {
+      "maemae": {
+        "median": 70000,
+        "count": 1013
+      },
+      "jeonse": {
+        "median": 38850,
+        "count": 1339
+      },
+      "wolse": {
+        "depositMedian": 5000,
+        "monthlyMedian": 165,
+        "count": 791
+      },
+      "source": "legalDong",
+      "matchedSigungu": "인천 연수구",
+      "matchedLegalDong": [
+        "송도동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "incheon-geomdan": {
+      "maemae": {
+        "median": 55000,
+        "count": 2201
+      },
+      "jeonse": {
+        "median": 33500,
+        "count": 2235
+      },
+      "wolse": {
+        "depositMedian": 4600,
+        "monthlyMedian": 100,
+        "count": 1249
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "인천 서구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "incheon-bupyeong": {
+      "maemae": {
+        "median": 52500,
+        "count": 199
+      },
+      "jeonse": {
+        "median": 29000,
+        "count": 145
+      },
+      "wolse": {
+        "depositMedian": 4000,
+        "monthlyMedian": 110,
+        "count": 85
+      },
+      "source": "legalDong",
+      "matchedSigungu": "인천 부평구",
+      "matchedLegalDong": [
+        "부평동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "incheon-sinpo": {
+      "maemae": {
+        "median": 40000,
+        "count": 439
+      },
+      "jeonse": {
+        "median": 27000,
+        "count": 805
+      },
+      "wolse": {
+        "depositMedian": 3000,
+        "monthlyMedian": 110,
+        "count": 664
+      },
+      "source": "sigungu-fallback",
+      "matchedSigungu": "인천 중구",
+      "matchedLegalDong": [],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "seongdong-seongsu": {
+      "maemae": {
+        "median": 172500,
+        "count": 50
+      },
+      "jeonse": {
+        "median": 75000,
+        "count": 213
+      },
+      "wolse": {
+        "depositMedian": 35000,
+        "monthlyMedian": 210,
+        "count": 141
+      },
+      "source": "legalDong",
+      "matchedSigungu": "성동구",
+      "matchedLegalDong": [
+        "성수동1가",
+        "성수동2가"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    },
+    "gwangjin-jayang": {
+      "maemae": {
+        "median": 153000,
+        "count": 53
+      },
+      "jeonse": {
+        "median": 68000,
+        "count": 248
+      },
+      "wolse": {
+        "depositMedian": 31500,
+        "monthlyMedian": 138,
+        "count": 138
+      },
+      "source": "legalDong",
+      "matchedSigungu": "광진구",
+      "matchedLegalDong": [
+        "자양동"
+      ],
+      "_source": "국토교통부 실거래가공개시스템 아파트 매매/전월세",
+      "period": "2025-12 ~ 2026-06",
+      "areaFilter": "60-85㎡",
+      "retrievedAt": "2026-06-06"
+    }
+  }
+}


### PR DESCRIPTION
## 무엇을 / 왜

시세 실데이터 **3단계(데이터 트랙)**. 국토부 실거래 6파일(아파트 매매·전월세 × 서울/경기/인천)에서 **동네별 매매/전세/월세 중앙값**을 빌드타임 산출 → `price-index.json`. 학교/공원 인덱스 패턴 답습(스크립트 + provenance + 결측 방어).

- `Closes` 없음. **로직 교체(price.ts 대체)는 4단계** — 이번은 데이터 생성만.
- ⚠️ **PR #168 미머지 상태에서 main 분기.** 3-B는 lawd-mapping.json이 아니라 **사람이 큐레이션한 `PRICE_DONG_MAPPING`** 을 쓰고 동네를 `id`로만 조인 → #168과 독립적. 가산동 sigungu는 매핑표에 "금천구"로 직접 명시(neighborhoods.gu 무관).

## 변경

| 파일 | 내용 |
|---|---|
| `scripts/price-dong-mapping.ts` | 3-A 승인 조인표(사람 결정). dong채택 / kakao법정동 / 집계(성수동 1·2가) / 시군구폴백(동탄·종로3가·신포동·성신여대입구·신촌동). sigungu 표준형(일반구 포함 "화성시 동탄구"·"부천시 원미구", 인천은 "인천 서구"로 구분). |
| `scripts/build-price-index.ts` | 시군구+법정동 **텍스트** 조인(숫자 LAWD 없음). 전용 **60~85㎡** 한정. 매매 거래금액 median / 전세 보증금 median / 월세 보증금·월세 median. **임계 폴백**(매매<20 OR 전월세<30 → 시군구). **결측 null**(추정 환산 금지). 결정론적. 매매 파일명 선행 공백 처리. |
| `src/lib/data/price-index.json` | id별 `{maemae,jeonse,wolse,source,matchedSigungu,matchedLegalDong,_source,period,areaFilter,retrievedAt}` + `_meta`. |
| `package.json` | `build:price`. |
| (git 미추적) | `data-raw/` 실거래 6 xlsx (gitignore). |

## 검증

- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존 파일)
- **44/44 동네 산출, 결측 0**(매매 0 / 전세 0 / 월세 0). 결정론 재실행 해시 동일.
- 수집: 매매 26,963 / 전월세 57,562 행(60~85㎡, 필요 시군구만).

### 시군구 폴백 총 10건
- **3-A 명시 5**: 종로3가·신촌동·성신여대입구·동탄·신포동
- **임계(20/30) 미달 자동 5**: 이태원동·가산동·건대입구·평창동·검단동 (해당 법정동 60~85㎡ apt 희박 → 구 평균)

### 상식 점검 (60~85㎡ median)
| 동네 | 매매 | 전세 | source |
|---|---|---|---|
| 역삼동 | 23.82억(40) | 12.00억(118) | legalDong |
| 잠실동 | 32.70억(187) | 11.38억(610) | legalDong |
| 송도동 | 7.00억(1013) | 3.88억(1339) | legalDong |
| **광교동** | **12.75억(131)** | **7.20억(155)** | legalDong |
| 목동 | 15.32억(216) | 6.80억(454) | legalDong |
| 동탄 | 7.08억(3517) | 3.90억(2293) | sigungu-fallback |

0·음수·과도값 없음. 잠실 32.7억은 대형 84㎡ 위주라 다소 높은 편(이상치 아님). 여의도 전세 4.04억은 노후 단지+갱신 비중으로 낮게 잡힘(실데이터 그대로, 환산 없음).

## provenance / 한계 (정직)
- `_source`=국토부 실거래가공개시스템, `period`=2025-12~2026-06(6개월), `areaFilter`=60-85㎡.
- `_meta.note`: "동 단위 중앙값(단지·평형별 편차 있음). 60~85㎡ 한정. 폴백=구 평균. 결측은 null(추정 환산 없음)."
- 숫자 LAWD 부재 → 텍스트 조인. 폴백 동네는 `source="sigungu-fallback"` → UI 라벨("구 평균, 동 데이터 부족") 근거(라벨은 5단계).

## 유지(미변경)
- `price.ts`·`neighborhoods.ts`·예산필터·결과뷰 무변경(diff 0). 로직 교체는 4단계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)