### PR TITLE
feat(price): 시세 4-A — 예산필터·priceRange를 실거래 median(price-index)에 배선

### DIFF
--- a/onday-app/src/features/diagnosis/mock-calculator.ts
+++ b/onday-app/src/features/diagnosis/mock-calculator.ts
@@ -12,7 +12,8 @@ import {
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
 // ScoringEngine (#27) — 점수 로직은 공용 모듈로 추출. client(실 ODsay) + server(mock) 공유.
 import { scoreCandidate } from "@/lib/diagnosis/scoring";
-import { comparablePrice, estimateWolse } from "@/lib/diagnosis/price";
+// 시세 4-A — 예산 필터·priceRange 가 실거래 median(price-index)을 사용. price.ts 추정 환산 제거.
+import { comparableMedian, wolseMedian, priceRangeFor } from "@/lib/diagnosis/price-index";
 
 interface ComputeResult {
   status: "fulfilled";
@@ -90,24 +91,36 @@ async function computeOneCandidate(
   //   사용자 시각 검증 짚음: "예산 4~5억 박힘 + 결과 카드 4~5억 사이 X = 다양 박힘" → 범위 외 카드 제외 박힘.
   if (filters.budget) {
     if (filters.budget.dealType === "wolse") {
-      // 월세 — 보증금(상한) + 월세(범위) 2축. 추정값(estimateWolse) 기준.
-      const { deposit, monthly } = estimateWolse(neighborhood.avgPrice);
-      const depositOk = deposit <= (filters.budget.depositMax ?? Infinity);
+      // 월세 — 보증금(상한) + 월세(범위) 2축. 실거래 median(price-index) 기준.
+      //   median 결측이면 예산 충족 확인 불가 → 제외(임의 통과 금지, 가짜 결과 방지).
+      const w = wolseMedian(neighborhood.id);
+      if (!w) {
+        return {
+          status: "rejected",
+          neighborhoodId: neighborhood.id,
+          reason: "Wolse median 결측(price-index)",
+        };
+      }
+      const depositOk = w.deposit <= (filters.budget.depositMax ?? Infinity);
       const monthlyOk =
-        monthly >= filters.budget.min && monthly <= filters.budget.max;
+        w.monthly >= filters.budget.min && w.monthly <= filters.budget.max;
       if (!depositOk || !monthlyOk) {
         return {
           status: "rejected",
           neighborhoodId: neighborhood.id,
-          reason: `Wolse deposit ${deposit}/monthly ${monthly} outside budget`,
+          reason: `Wolse deposit ${w.deposit}/monthly ${w.monthly} outside budget`,
         };
       }
     } else {
-      // 전세/매매 — 단일 금액. 매매 시 전세가율로 환산(추정). 미지정=전세(기존과 동일).
-      const price = comparablePrice(
-        neighborhood.avgPrice,
-        filters.budget.dealType,
-      );
+      // 전세/매매 — 실거래 median. 미지정=전세. median 결측이면 제외(임의 통과 금지).
+      const price = comparableMedian(neighborhood.id, filters.budget.dealType);
+      if (price == null) {
+        return {
+          status: "rejected",
+          neighborhoodId: neighborhood.id,
+          reason: "Price median 결측(price-index)",
+        };
+      }
       if (price < filters.budget.min || price > filters.budget.max) {
         return {
           status: "rejected",
@@ -156,18 +169,12 @@ async function computeOneCandidate(
           : undefined,
       score,
       safetyGrade: mode === "single" ? neighborhood.safetyGrade : undefined,
-      // priceRange 는 거래유형 scale — 매매는 전세가율 환산값 기준(추정). 전세=avgPrice 그대로(동일).
-      priceRange: (() => {
-        const base = comparablePrice(
-          neighborhood.avgPrice,
-          filters.budget?.dealType,
-        );
-        return { min: Math.round(base * 0.85), max: Math.round(base * 1.15) };
-      })(),
-      // 월세 추정 — dealType=wolse 시만 채움(표시는 보증금/월). 그 외 undefined.
+      // priceRange = 거래유형 median ±15%(만원). 실거래 median 기준(분위수 미보유 → 밴드 유지). 결측 시 undefined.
+      priceRange: priceRangeFor(neighborhood.id, filters.budget?.dealType),
+      // 월세 — dealType=wolse 시만 채움(표시는 보증금/월). 실거래 median, 결측 시 undefined.
       wolseEstimate:
         filters.budget?.dealType === "wolse"
-          ? estimateWolse(neighborhood.avgPrice)
+          ? (wolseMedian(neighborhood.id) ?? undefined)
           : undefined,
       facilities: neighborhood.facilities,
       lines: neighborhood.lines,

--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -12,7 +12,8 @@ import {
   estimateTransfers,
 } from "@/lib/haversine";
 import { scoreCandidate } from "@/lib/diagnosis/scoring";
-import { comparablePrice, estimateWolse } from "@/lib/diagnosis/price";
+// 시세 4-A — 예산 필터·priceRange 가 실거래 median(price-index)을 사용. price.ts 추정 환산 제거.
+import { comparableMedian, wolseMedian, priceRangeFor } from "@/lib/diagnosis/price-index";
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
 import { KakaoCarClient } from "@/lib/external/kakao-car";
 
@@ -153,15 +154,17 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
       // 필터 — 예산 범위
       if (filters.budget) {
         if (filters.budget.dealType === "wolse") {
-          // 월세 — 보증금(상한) + 월세(범위) 2축. 추정값 기준.
-          const { deposit, monthly } = estimateWolse(n.avgPrice);
-          const depositOk = deposit <= (filters.budget.depositMax ?? Infinity);
+          // 월세 — 보증금(상한) + 월세(범위) 2축. 실거래 median 기준. 결측이면 제외(임의 통과 금지).
+          const w = wolseMedian(n.id);
+          if (!w) return null;
+          const depositOk = w.deposit <= (filters.budget.depositMax ?? Infinity);
           const monthlyOk =
-            monthly >= filters.budget.min && monthly <= filters.budget.max;
+            w.monthly >= filters.budget.min && w.monthly <= filters.budget.max;
           if (!depositOk || !monthlyOk) return null;
         } else {
-          // 전세/매매 — 단일 금액. 매매 시 전세가율로 환산(추정). 미지정=전세(기존과 동일).
-          const price = comparablePrice(n.avgPrice, filters.budget.dealType);
+          // 전세/매매 — 실거래 median. 미지정=전세. median 결측이면 제외(임의 통과 금지).
+          const price = comparableMedian(n.id, filters.budget.dealType);
+          if (price == null) return null;
           if (price < filters.budget.min || price > filters.budget.max) {
             return null;
           }
@@ -199,15 +202,12 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
         leisureB: leisureB ?? undefined,
         score,
         safetyGrade: mode === "single" ? n.safetyGrade : undefined,
-        // priceRange 는 거래유형 scale — 매매는 전세가율 환산값 기준(추정). 전세=avgPrice 그대로(동일).
-        priceRange: (() => {
-          const base = comparablePrice(n.avgPrice, filters.budget?.dealType);
-          return { min: Math.round(base * 0.85), max: Math.round(base * 1.15) };
-        })(),
-        // 월세 추정 — dealType=wolse 시만 채움. 그 외 undefined.
+        // priceRange = 거래유형 median ±15%(만원). 실거래 median 기준(분위수 미보유 → 밴드 유지). 결측 시 undefined.
+        priceRange: priceRangeFor(n.id, filters.budget?.dealType),
+        // 월세 — dealType=wolse 시만 채움. 실거래 median, 결측 시 undefined.
         wolseEstimate:
           filters.budget?.dealType === "wolse"
-            ? estimateWolse(n.avgPrice)
+            ? (wolseMedian(n.id) ?? undefined)
             : undefined,
         facilities: n.facilities,
         lines: n.lines,

--- a/onday-app/src/lib/diagnosis/price-index.ts
+++ b/onday-app/src/lib/diagnosis/price-index.ts
@@ -1,0 +1,59 @@
+// 시세 4-A — 국토부 실거래 median(price-index.json) 접근자.
+//   예산 필터·priceRange 가 mock avgPrice 추정 환산(price.ts) 대신 실거래 median 을 쓰도록 배선.
+//   단위는 전부 만원(budget.min/max, median 모두) — 변환 없음.
+//   결측(id 없음/해당 dealType median null)은 null 반환 → 호출부가 "임의 통과" 금지(가짜 결과 방지).
+
+import type { DealType } from "@/lib/types";
+import priceIndex from "@/lib/data/price-index.json";
+
+interface MedianCount {
+  median: number;
+  count: number;
+}
+interface WolseMedian {
+  depositMedian: number;
+  monthlyMedian: number;
+  count: number;
+}
+export interface PriceEntry {
+  maemae: MedianCount | null;
+  jeonse: MedianCount | null;
+  wolse: WolseMedian | null;
+  source: "legalDong" | "sigungu-fallback";
+  matchedSigungu: string;
+  matchedLegalDong: string[];
+}
+
+const BY_ID = (priceIndex as { byId: Record<string, PriceEntry> }).byId;
+
+export function getPriceEntry(id: string): PriceEntry | null {
+  return BY_ID[id] ?? null;
+}
+
+/**
+ * 전세/매매 비교 점값(만원). dealType 미지정·wolse → 전세 median(기존 avgPrice 자리 대체).
+ *   결측(id 없음 / 해당 median null)이면 null — 호출부는 예산 필터에서 통과시키지 말 것.
+ */
+export function comparableMedian(id: string, dealType?: DealType): number | null {
+  const e = BY_ID[id];
+  if (!e) return null;
+  if (dealType === "maemae") return e.maemae?.median ?? null;
+  return e.jeonse?.median ?? null;
+}
+
+/** 월세 {deposit, monthly} 중앙값(만원). 결측 null. */
+export function wolseMedian(id: string): { deposit: number; monthly: number } | null {
+  const w = BY_ID[id]?.wolse;
+  return w ? { deposit: w.depositMedian, monthly: w.monthlyMedian } : null;
+}
+
+/** priceRange 표시·정렬용 ±15% 밴드(만원). median 결측이면 undefined(분위수 p25/p75 미보유 → 밴드 유지). */
+export function priceRangeFor(
+  id: string,
+  dealType?: DealType,
+): { min: number; max: number } | undefined {
+  // 월세는 priceRange 를 전세 scale 로 표기(기존 동작 보존 — 월세 표시는 wolseEstimate 사용).
+  const base = comparableMedian(id, dealType === "wolse" ? "jeonse" : dealType);
+  if (base == null) return undefined;
+  return { min: Math.round(base * 0.85), max: Math.round(base * 1.15) };
+}

--- a/onday-app/src/lib/diagnosis/price.ts
+++ b/onday-app/src/lib/diagnosis/price.ts
@@ -1,5 +1,9 @@
 import type { DealType } from "@/lib/types";
 
+// ⚠️ DEPRECATED (시세 4-A) — 예산 필터·priceRange 가 실거래 median(@/lib/diagnosis/price-index)으로 교체됨.
+//   아래 추정 환산(JEONSE_RATIO/comparablePrice/estimateWolse)은 현재 어떤 모듈도 import 하지 않음(격하).
+//   결측 안전망/참고로만 잔존. 완전 삭제는 4-B 이후. 신규 코드는 price-index 접근자를 쓸 것.
+
 // 전세가율 추정치 — 매매가 ≈ 전세 ÷ 0.55 (서울 아파트 대략치).
 //   동네 데이터는 avgPrice(전세 추정 보증금) 단일값만 보유 → 매매 시세를 보유하지 않아
 //   이 상수로 파생(추정)한다. 표시 시 "추정" 명시 필수(날조 금지).


### PR DESCRIPTION
## 무엇을 / 왜

mock/real 진단의 **가격 로직**을 mock `avgPrice` 추정 환산(`price.ts`의 `JEONSE_RATIO` 등) 대신 **`price-index.json` 실거래 median**으로 교체. 단위가 전부 만원이라 변환 없음.

회귀 위험 핵심 PR이라 **4-B(파생 정합)·5(표시 라벨)와 분리**.

- `Closes` 없음. 4단계 데이터→로직 배선의 첫 PR(4-A).

## 변경

| 파일 | 내용 |
|---|---|
| `lib/diagnosis/price-index.ts` (신규) | `byId` 룩업 접근자. `comparableMedian(id,dealType)`=전세/매매 median, `wolseMedian(id)`={deposit,monthly}, `priceRangeFor(id,dealType)`=median±15%. 결측 시 `null`/`undefined`. |
| `features/diagnosis/mock-calculator.ts` | 예산 hard exclusion + priceRange + wolseEstimate → price-index. |
| `features/diagnosis/run-real-diagnosis.ts` | 동일(mock/real 한쪽만 고치면 불일치 → 둘 다). |
| `lib/diagnosis/price.ts` | `comparablePrice/estimateWolse/JEONSE_RATIO` **격하(DEPRECATED 주석)**. 어떤 모듈도 import 안 함. 완전 삭제는 4-B 이후. |

**dealType 매핑**: jeonse→`jeonse.median` / maemae→`maemae.median` / wolse→`{depositMedian, monthlyMedian}`.

**★ null-guard**: budget 설정 + median 결측이면 **제외**(임의 통과 금지 — 가짜 결과 방지). budget 미설정이면 필터 자체 미적용.

## 검증 (tsx 직접 호출, 커밋 안 함)

- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존 파일)
- **결측 0**: 44개 jeonse/maemae/wolse median 전부 non-null.
- **★ 예산별 생존 = Phase 0 예측 정확 일치**:

| 입력 | 생존 | Phase 0 예측 |
|---|---|---|
| 매매 8~15억 | **14/44** | 14 ✅ |
| 매매 4~6억 | **8/44** | 8 ✅ |
| 전세 4~7억 | **21/44** | 21 ✅ |
| 전세 5~10억 | **25/44** | 25 ✅ |

- **기본 진단(budget undefined)**: 필터 미적용 → 44 전부 통과(`runMockDiagnosis` top8 정상 반환).
- **priceRange = median±15%** 정상: 공덕동 전세 81000 → `{min:68850, max:93150}`. 역삼동 매매 23.8억은 8~15억 범위 밖이라 올바르게 제외됨.
- **mock/real 동일 접근자**(`comparableMedian`/`wolseMedian`) → 같은 동네에 같은 median 적용.
- 정렬·트레이드오프·급매·아웃링크는 `priceRange` 추종 → **무수정·무파손**(undefined도 기존 `?? Infinity/50000` fallback으로 graceful).

## ★ 회귀 아닌 "교정"

결과 동네 구성이 바뀌는 건 mock avgPrice의 체계적 편향(경기/인천 신도시 과대평가 — 송도 0.39배·동탄 0.47배·판교 0.58배, 평창동 0.42배)을 실거래가 **교정**한 결과입니다. 저장검색/테스트 기준이 옛 mock에 맞춰져 있으면 이동하나, 방향은 정확도 향상입니다.

## 범위 밖 (후속)
- `generate-suggestions.ts` 천장(15억)/스텝 → **4-B**
- `use-address-suggest.ts` "매가" 라벨 정정 → **4-B**
- 폴백 "구 평균" 라벨 · "추정" 라벨 제거 · provenance 배지 → **5단계**
- priceRange 분위수화(p25/p75) → 별도 후속(현재 ±15% 밴드 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)