### PR TITLE
fix(price): dealType을 budget 종속에서 filters 최상위로 분리 — 거래유형 유실 버그 해소

### DIFF
--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -14,6 +14,7 @@ import { StickyCTABar } from "@/components/layout/sticky-cta-bar";
 import { Button } from "@/components/ui/button";
 import { LogoutButton } from "@/components/auth/logout-button";
 import { useCreateDiagnosis } from "@/features/diagnosis/use-diagnosis";
+import { liftLegacyDealType } from "@/features/diagnosis/result-utils";
 // ★ UI-002: 사전 작업 444 lines ↔ CMD-DIAG-001 useGeocode 통합 (★ adapter Hook 패턴 § NEW).
 // ★ Mismatch ⑪/⑫/⑭ 정정: useDebounce + MOCK_NEIGHBORHOODS filter → useAddressSuggest adapter (★ adapter 내부 처리).
 import { useAddressSuggest } from "@/features/diagnosis/use-address-suggest";
@@ -94,7 +95,7 @@ export default function DiagnosisPage() {
   //   budget은 억 단위 input + 내부 만원 변환 (★ formatBudgetFilter "X-Y억" 표시 정합).
   //   min/max 둘 다 박힘 + > 0 시점 store budget 박힘. 그 외 = undefined.
   // 전세/매매 = 억~억 단일 금액. 월세는 별도 입력(아래) — 억 input 은 비전세 시 비움.
-  const isWolseBudget = filters.budget?.dealType === "wolse";
+  const isWolseBudget = filters.dealType === "wolse";
   const [budgetMinInput, setBudgetMinInput] = React.useState(
     filters.budget && !isWolseBudget ? String(filters.budget.min / 10000) : "",
   );
@@ -111,42 +112,36 @@ export default function DiagnosisPage() {
     isWolseBudget ? String(filters.budget!.max) : "",
   );
   const [dealType, setDealType] = React.useState<DealType>(
-    filters.budget?.dealType ?? "jeonse",
+    filters.dealType ?? "jeonse",
   );
 
-  // 전세/매매 — 억~억 단일 금액 범위.
+  // 전세/매매 — 억~억 단일 금액 범위. ★ dealType 은 budget 과 독립으로 항상 보존(예산 비워도 유실 X).
   const syncBudget = (minStr: string, maxStr: string, dt: DealType = dealType) => {
     const minNum = Number(minStr);
     const maxNum = Number(maxStr);
-    if (minStr !== "" && maxStr !== "" && minNum > 0 && maxNum > 0) {
-      setFilters({
-        ...filters,
-        budget: { dealType: dt, min: minNum * 10000, max: maxNum * 10000 },
-      });
-    } else {
-      setFilters({ ...filters, budget: undefined });
-    }
+    const hasBudget = minStr !== "" && maxStr !== "" && minNum > 0 && maxNum > 0;
+    setFilters({
+      ...filters,
+      dealType: dt,
+      budget: hasBudget ? { min: minNum * 10000, max: maxNum * 10000 } : undefined,
+    });
   };
 
   // 월세 — 월세 상한(만원, 必) + 보증금 상한(억→만원, 옵션). 월세 상한 없으면 budget 해제.
   //   Infinity 미저장(JSON null화 방지) — 보증금 미입력 시 depositMax=undefined(필터가 ??로 처리).
   const syncWolse = (depStr: string, monStr: string) => {
     const monNum = Number(monStr);
-    if (monStr !== "" && monNum > 0) {
-      const depNum = Number(depStr);
-      const hasDep = depStr !== "" && depNum > 0;
-      setFilters({
-        ...filters,
-        budget: {
-          dealType: "wolse",
-          min: 0,
-          max: monNum,
-          depositMax: hasDep ? depNum * 10000 : undefined,
-        },
-      });
-    } else {
-      setFilters({ ...filters, budget: undefined });
-    }
+    const depNum = Number(depStr);
+    const hasDep = depStr !== "" && depNum > 0;
+    const hasBudget = monStr !== "" && monNum > 0;
+    // ★ dealType="wolse" 는 항상 보존(월세 상한 비워도 유실 X). budget 은 월세 상한 있을 때만.
+    setFilters({
+      ...filters,
+      dealType: "wolse",
+      budget: hasBudget
+        ? { min: 0, max: monNum, depositMax: hasDep ? depNum * 10000 : undefined }
+        : undefined,
+    });
   };
 
   // 거래유형 변경 — dealType 반영 + 해당 입력값으로 budget 재동기화.
@@ -242,8 +237,8 @@ export default function DiagnosisPage() {
       setLeisureA(config.leisureA ?? "", config.leisureCoordA ?? undefined);
       setLeisureB(config.leisureB ?? "", config.leisureCoordB ?? undefined);
       setMode(config.mode ?? "couple");
-      // ★ Issue #102 ㊿ — legacy timeRange → commuteSchedule 자가 치유.
-      setFilters(migrateLegacyTimeRange(config.filters ?? {}));
+      // ★ Issue #102 ㊿ — legacy timeRange → commuteSchedule 자가 치유 + 레거시 budget.dealType → filters.dealType 승격.
+      setFilters(liftLegacyDealType(migrateLegacyTimeRange(config.filters ?? {})));
       // ★ local query state 동기화 (★ AddressInput value prop)
       setQueryA(config.addressA ?? "");
       setQueryB(config.addressB ?? "");
@@ -251,16 +246,13 @@ export default function DiagnosisPage() {
       setQueryL2(config.leisureB ?? "");
       // 불러온 조건에 여가거점2가 있으면 입력창 펼침(점진 공개 자동 해제).
       setShowL2(Boolean(config.leisureB));
-      // Issue #112 — budget local state sync (★ filters.budget 자가 치유와 별개 영역).
+      // Issue #112 — budget local state sync. ★ dealType 은 budget 과 독립(최상위), 레거시는 budget.dealType 폴백.
       const nextBudget = (config.filters?.budget ?? undefined) as
-        | {
-            dealType?: DealType;
-            min: number;
-            max: number;
-            depositMax?: number;
-          }
+        | { min: number; max: number; depositMax?: number; dealType?: DealType }
         | undefined;
-      const nextIsWolse = nextBudget?.dealType === "wolse";
+      const nextDealType: DealType =
+        config.filters?.dealType ?? nextBudget?.dealType ?? "jeonse";
+      const nextIsWolse = nextDealType === "wolse";
       setBudgetMinInput(
         nextBudget && !nextIsWolse ? String(nextBudget.min / 10000) : "",
       );
@@ -272,8 +264,8 @@ export default function DiagnosisPage() {
           ? String(nextBudget.depositMax / 10000)
           : "",
       );
-      setMonthlyMaxInput(nextIsWolse ? String(nextBudget!.max) : "");
-      setDealType(nextBudget?.dealType ?? "jeonse");
+      setMonthlyMaxInput(nextIsWolse && nextBudget ? String(nextBudget.max) : "");
+      setDealType(nextDealType);
       pushToast({ variant: "default", message: "이전 조건을 불러왔습니다 ✨" });
     } catch {
       pushToast({ variant: "default", message: "이전 조건 불러오기 실패" });

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -106,7 +106,7 @@ function recomputeWhatIf(
         if (maxC > filters.maxCommuteTime) return false;
       }
       if (filters.budget) {
-        if (filters.budget.dealType === "wolse") {
+        if (filters.dealType === "wolse") {
           // 월세 — 추정 보증금/월세로 재필터 (priceRange 는 전세 scale 라 부적합).
           const w = c.wolseEstimate;
           if (w) {
@@ -223,10 +223,10 @@ export function ResultContent({
       });
       return;
     }
-    // what-if 는 금액만 조정 — dealType(거래유형)은 진단 시점 값 보존. depositMax 는 월세 전용.
+    // what-if 는 금액만 조정 — dealType(거래유형)은 filters.dealType 에 보존(...filters). budget 은 금액만.
     const newFilters = {
       ...filters,
-      budget: { dealType: filters.budget?.dealType, min, max, depositMax },
+      budget: { min, max, depositMax },
     };
     setFilters(newFilters);
     const next = recomputeWhatIf(
@@ -433,7 +433,7 @@ export function ResultContent({
         selectedCandidate,
         "couple",
         undefined,
-        filters.budget?.dealType,
+        filters.dealType,
       ),
     );
     pushToast({
@@ -468,7 +468,7 @@ export function ResultContent({
           },
           filters.budget != null && {
             label: "예산",
-            value: formatBudgetFilter(filters.budget),
+            value: formatBudgetFilter(filters.budget, filters.dealType),
             // Issue #112 — what-if 옵션 inline 박힘 토글 (★ #111 답습).
             onClick: () => setShowBudgetOptions((prev) => !prev),
           },
@@ -499,7 +499,7 @@ export function ResultContent({
           baseMin={filters.budget.min}
           baseMax={filters.budget.max}
           baseDepositMax={filters.budget.depositMax}
-          dealType={filters.budget.dealType}
+          dealType={filters.dealType}
           onConfirm={handleBudgetWhatIf}
         />
       )}
@@ -589,9 +589,9 @@ export function ResultContent({
                   : []),
               ]}
               price={
-                filters.budget?.dealType === "wolse"
+                filters.dealType === "wolse"
                   ? formatWolse(c.wolseEstimate)
-                  : formatPrice(c.priceRange, filters.budget?.dealType)
+                  : formatPrice(c.priceRange, filters.dealType)
               }
               tagReason={buildPreferenceReason(priorityKey, c) ?? undefined}
               onClick={() => open(c.id)}

--- a/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
@@ -18,6 +18,7 @@ import { AppHeader } from "@/components/layout/app-header";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
+import { liftLegacyDealType } from "@/features/diagnosis/result-utils";
 import { useDiagnosis } from "@/features/diagnosis/use-diagnosis";
 import { trackDiagnosisCompleted } from "@/lib/analytics/mixpanel";
 import { generateRelaxationSuggestions } from "@/lib/diagnosis/generate-suggestions";
@@ -53,7 +54,7 @@ export function ResultView({ id }: ResultViewProps) {
   React.useEffect(() => {
     if (!inSync && query.data) {
       setResult(query.data.id, query.data.candidates);
-      setFilters(query.data.filters);
+      setFilters(liftLegacyDealType(query.data.filters));
     }
   }, [inSync, query.data, setResult, setFilters]);
 

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -29,7 +29,11 @@ import {
 import { getSafetyByGu } from "@/features/single/safety-index";
 import { getCommunityByGu } from "@/lib/diagnosis/community-index";
 import { buildSinglePills, buildSingleMetrics } from "@/features/single/detail-mapper";
-import { formatWolse, markerLabel } from "@/features/diagnosis/result-utils";
+import {
+  formatWolse,
+  liftLegacyDealType,
+  markerLabel,
+} from "@/features/diagnosis/result-utils";
 import { buildCommuteRows, buildLines } from "@/features/diagnosis/detail-mapper";
 import { latLngToPixel } from "@/lib/coordinate-transform";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
@@ -214,12 +218,13 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   const storeCandidates = useDiagnosisStore((s) => s.candidates);
   const storeAddressA = useDiagnosisStore((s) => s.addressA);
   const setResult = useDiagnosisStore((s) => s.setResult);
+  const setFilters = useDiagnosisStore((s) => s.setFilters);
   // 지도 마커용 좌표 — 부부 모드와 동일하게 store 직접 참조(같은 세션에서만 표시).
   const coordinateA = useDiagnosisStore((s) => s.coordinateA);
   const leisureCoordA = useDiagnosisStore((s) => s.leisureCoordA);
   const leisureCoordB = useDiagnosisStore((s) => s.leisureCoordB);
   const priorityKey = useDiagnosisStore((s) => s.filters.priorities?.[0]);
-  const dealType = useDiagnosisStore((s) => s.filters.budget?.dealType);
+  const dealType = useDiagnosisStore((s) => s.filters.dealType);
   const favorites = useFavoritesStore((s) => s.favorites);
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
 
@@ -229,8 +234,10 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   React.useEffect(() => {
     if (!inSync && query.data) {
       setResult(query.data.id, query.data.candidates);
+      // 재오픈 시 거래유형 복원(레거시 budget.dealType 승격 포함) — 시세 표시 dealType 보존.
+      setFilters(liftLegacyDealType(query.data.filters));
     }
-  }, [inSync, query.data, setResult]);
+  }, [inSync, query.data, setResult, setFilters]);
 
   const candidates = React.useMemo<CandidateArea[]>(
     () => (inSync ? storeCandidates : query.data?.candidates ?? []),

--- a/onday-app/src/features/diagnosis/mock-calculator.ts
+++ b/onday-app/src/features/diagnosis/mock-calculator.ts
@@ -89,8 +89,10 @@ async function computeOneCandidate(
 
   // Issue #123 — 예산 범위 외 제외 (★ maxCommuteTime 답습 정합).
   //   사용자 시각 검증 짚음: "예산 4~5억 박힘 + 결과 카드 4~5억 사이 X = 다양 박힘" → 범위 외 카드 제외 박힘.
+  // 거래유형 — filters.dealType 단일 소스(budget 과 독립). 미지정=전세.
+  const dealType = filters.dealType ?? "jeonse";
   if (filters.budget) {
-    if (filters.budget.dealType === "wolse") {
+    if (dealType === "wolse") {
       // 월세 — 보증금(상한) + 월세(범위) 2축. 실거래 median(price-index) 기준.
       //   median 결측이면 예산 충족 확인 불가 → 제외(임의 통과 금지, 가짜 결과 방지).
       const w = wolseMedian(neighborhood.id);
@@ -113,7 +115,7 @@ async function computeOneCandidate(
       }
     } else {
       // 전세/매매 — 실거래 median. 미지정=전세. median 결측이면 제외(임의 통과 금지).
-      const price = comparableMedian(neighborhood.id, filters.budget.dealType);
+      const price = comparableMedian(neighborhood.id, dealType);
       if (price == null) {
         return {
           status: "rejected",
@@ -169,11 +171,11 @@ async function computeOneCandidate(
           : undefined,
       score,
       safetyGrade: mode === "single" ? neighborhood.safetyGrade : undefined,
-      // priceRange = 거래유형 median ±15%(만원). 실거래 median 기준(분위수 미보유 → 밴드 유지). 결측 시 undefined.
-      priceRange: priceRangeFor(neighborhood.id, filters.budget?.dealType),
+      // priceRange = 거래유형 median ±15%(만원). filters.dealType 기준(예산 미입력해도 거래유형 반영). 결측 시 undefined.
+      priceRange: priceRangeFor(neighborhood.id, dealType),
       // 월세 — dealType=wolse 시만 채움(표시는 보증금/월). 실거래 median, 결측 시 undefined.
       wolseEstimate:
-        filters.budget?.dealType === "wolse"
+        dealType === "wolse"
           ? (wolseMedian(neighborhood.id) ?? undefined)
           : undefined,
       facilities: neighborhood.facilities,

--- a/onday-app/src/features/diagnosis/result-utils.ts
+++ b/onday-app/src/features/diagnosis/result-utils.ts
@@ -1,5 +1,10 @@
 import type { CommuteMode as ChipMode } from "@/components/data/commute-chip";
-import type { CandidateArea, CommuteMode, DealType } from "@/lib/types";
+import type {
+  CandidateArea,
+  CommuteMode,
+  DealType,
+  DiagnosisFilters,
+} from "@/lib/types";
 
 export type SortKey = "score" | "commute" | "price";
 
@@ -73,24 +78,32 @@ export function formatCommuteFilter(maxMinutes: number | undefined): string {
 export function formatBudgetFilter(
   budget:
     | {
-        dealType?: DealType;
         min: number;
         max: number;
         depositMin?: number;
         depositMax?: number;
       }
     | undefined,
+  dealType?: DealType, // 거래유형은 filters.dealType(budget 과 독립) 에서 전달
 ): string {
   if (!budget) return "전체";
-  if (budget.dealType === "wolse") {
+  if (dealType === "wolse") {
     // 월세 — 보증금 상한(억) + 월세 상한(만원).
     const dep = ((budget.depositMax ?? 0) / 10000).toFixed(1);
     return `월세 보증금 ${dep}억↓ / 월 ${budget.max}만↓`;
   }
   const min = (budget.min / 10000).toFixed(0);
   const max = (budget.max / 10000).toFixed(0);
-  const label = DEAL_LABEL[budget.dealType ?? "jeonse"];
+  const label = DEAL_LABEL[dealType ?? "jeonse"];
   return `${label} ${min}-${max}억`;
+}
+
+// 레거시 자가치유 — 구 데이터(budget.dealType, top-level dealType 없음)를 filters.dealType 으로 승격.
+//   localStorage '이전 조건'·기존 저장 진단 재오픈 시 거래유형 보존(읽기 단일 소스 = filters.dealType).
+export function liftLegacyDealType(filters: DiagnosisFilters): DiagnosisFilters {
+  if (filters.dealType) return filters;
+  const legacy = (filters.budget as { dealType?: DealType } | undefined)?.dealType;
+  return legacy ? { ...filters, dealType: legacy } : filters;
 }
 
 export function markerLabel(dong: string): string {

--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -152,8 +152,10 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
         if (maxCommute > filters.maxCommuteTime) return null;
       }
       // 필터 — 예산 범위
+      // 거래유형 — filters.dealType 단일 소스(budget 과 독립). 미지정=전세.
+      const dealType = filters.dealType ?? "jeonse";
       if (filters.budget) {
-        if (filters.budget.dealType === "wolse") {
+        if (dealType === "wolse") {
           // 월세 — 보증금(상한) + 월세(범위) 2축. 실거래 median 기준. 결측이면 제외(임의 통과 금지).
           const w = wolseMedian(n.id);
           if (!w) return null;
@@ -163,7 +165,7 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
           if (!depositOk || !monthlyOk) return null;
         } else {
           // 전세/매매 — 실거래 median. 미지정=전세. median 결측이면 제외(임의 통과 금지).
-          const price = comparableMedian(n.id, filters.budget.dealType);
+          const price = comparableMedian(n.id, dealType);
           if (price == null) return null;
           if (price < filters.budget.min || price > filters.budget.max) {
             return null;
@@ -202,13 +204,11 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
         leisureB: leisureB ?? undefined,
         score,
         safetyGrade: mode === "single" ? n.safetyGrade : undefined,
-        // priceRange = 거래유형 median ±15%(만원). 실거래 median 기준(분위수 미보유 → 밴드 유지). 결측 시 undefined.
-        priceRange: priceRangeFor(n.id, filters.budget?.dealType),
+        // priceRange = 거래유형 median ±15%(만원). filters.dealType 기준(예산 미입력해도 거래유형 반영). 결측 시 undefined.
+        priceRange: priceRangeFor(n.id, dealType),
         // 월세 — dealType=wolse 시만 채움. 실거래 median, 결측 시 undefined.
         wolseEstimate:
-          filters.budget?.dealType === "wolse"
-            ? (wolseMedian(n.id) ?? undefined)
-            : undefined,
+          dealType === "wolse" ? (wolseMedian(n.id) ?? undefined) : undefined,
         facilities: n.facilities,
         lines: n.lines,
         listingsCount: n.listingsCount,

--- a/onday-app/src/lib/mocks/diagnosis/get-diagnosis.ts
+++ b/onday-app/src/lib/mocks/diagnosis/get-diagnosis.ts
@@ -21,7 +21,8 @@ export const MOCK_DIAGNOSIS_ENTITY = {
   addressB: '서울 중구 세종대로 110',
   filters: {
     maxCommuteTime: 60,
-    budget: { dealType: 'jeonse', min: 8000, max: 15000 },
+    dealType: 'jeonse',
+    budget: { min: 8000, max: 15000 },
     commuteSchedule: { days: ['mon', 'tue', 'wed', 'thu', 'fri'], departureTime: '08:00' },
     priorities: ['safety', 'commute'],
   },

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -56,11 +56,11 @@ export interface CommuteSchedule {
 
 export interface DiagnosisFilters {
   maxCommuteTime?: number; // minutes
-  // dealType 미지정 = 전세 (기존 {min,max} 하위호환). 단위 = 만원.
-  //   jeonse/maemae: min/max = 금액 범위 (maemae 비교가는 comparablePrice 환산).
-  //   wolse: min/max = 월세 범위, depositMin/Max = 보증금 범위 (상한만 입력 시 min=0).
+  // 거래유형 — ★ budget 과 독립(예산 미입력해도 유실 안 됨). 미지정 = 전세. 표시·median 선택의 단일 소스.
+  dealType?: DealType;
+  // 예산(금액)만. 거래유형 정보는 위 filters.dealType 단일 소스. 단위 = 만원.
+  //   jeonse/maemae: min/max = 금액 범위 / wolse: min/max = 월세 범위, depositMin/Max = 보증금 범위.
   budget?: {
-    dealType?: DealType;
     min: number;
     max: number;
     depositMin?: number;

--- a/onday-app/src/lib/types/saved-search.ts
+++ b/onday-app/src/lib/types/saved-search.ts
@@ -28,8 +28,8 @@ export interface SearchParams {
   coordinateB?: { lat: number; lng: number };
   filters?: {
     maxCommuteTime?: number;
+    dealType?: "jeonse" | "maemae" | "wolse"; // 거래유형 — budget 과 독립 최상위(미지정=전세)
     budget?: {
-      dealType?: "jeonse" | "maemae" | "wolse";
       min: number;
       max: number;
       depositMin?: number;

--- a/onday-app/src/lib/validators/diagnosis.ts
+++ b/onday-app/src/lib/validators/diagnosis.ts
@@ -16,9 +16,10 @@ export const diagnosisInputSchema = z.object({
   leisureCoordB: coordinateSchema.optional(),
   filters: z.object({
     maxCommuteTime: z.number().min(10).max(120).optional(),
+    // 거래유형 — budget 과 독립 최상위. 미지정 = 전세. (서버 왕복 시 strip 방지 위해 스키마 포함 필수)
+    dealType: z.enum(["jeonse", "maemae", "wolse"]).optional(),
     budget: z
       .object({
-        dealType: z.enum(["jeonse", "maemae", "wolse"]).optional(), // 미지정 = 전세 (하위호환)
         min: z.number().min(0),
         max: z.number().min(0),
         depositMin: z.number().min(0).optional(), // 월세 전용 — 보증금 범위(만원)

--- a/onday-app/src/stores/favorites.ts
+++ b/onday-app/src/stores/favorites.ts
@@ -32,7 +32,7 @@ export interface FavoriteItem {
 }
 
 // 후보 → 찜 스냅샷. grade는 호출처가 모드별 소스로 넘김(싱글=resolveGrade).
-//   dealType은 진단 filters.budget?.dealType — 시세 표시용. wolseEstimate는 후보에 이미 박힘.
+//   dealType은 진단 filters.dealType(budget 과 독립) — 시세 표시용. wolseEstimate는 후보에 이미 박힘.
 export function toFavoriteSnapshot(
   c: CandidateArea,
   mode: DiagnosisMode,


### PR DESCRIPTION
## 버그

거래유형(dealType)이 `filters.budget.dealType` 안에만 저장돼, **예산 금액을 안 넣으면 `budget`이 통째로 `undefined`가 되며 고른 거래유형도 유실** → 결과가 전세값으로 폴백. **매매/월세를 골라도 예산을 비워두면 전세값**(예: 광교동 7.2억)이 표시되던 문제.

근본 원인: 거래유형(예산과 독립된 사용자 의도)이 예산 객체에 종속된 데이터 모델.

## 해소

`dealType`을 **`filters.dealType` 최상위 단일 소스**로 분리(budget과 독립). 예산 입력 여부와 무관하게 거래유형이 결과까지 전달.

| 파일 | 변경 |
|---|---|
| `types.ts` / `validators/diagnosis.ts` / `types/saved-search.ts` | dealType을 filters 최상위로(budget에서 제거). **★ Zod 스키마에 top-level dealType 추가** — mock/real 둘 다 `/api/diagnosis` Zod 경유라 안 넣으면 서버 왕복 시 strip됨 |
| `diagnosis/page.tsx` | `syncBudget`/`syncWolse`가 금액 미입력으로 `budget=undefined`가 돼도 `filters.dealType`은 항상 보존. 기본 jeonse 유지 |
| `mock-calculator.ts` / `run-real-diagnosis.ts` | dealType 소스 `filters.budget?.dealType` → `filters.dealType`. 예산 미설정+매매여도 priceRange/wolseEstimate는 매매 median |
| `result-content.tsx` / `single-result-view.tsx` / `favorites`(스냅샷 소스) | 표시 3곳 dealType 소스 통일 → `filters.dealType` |
| `result-utils.ts` | `liftLegacyDealType` — 구 데이터(`budget.dealType`)를 `filters.dealType`으로 승격 |
| `result-view.tsx` / `single-result-view.tsx` | DB 재오픈 시 `liftLegacyDealType(query.data.filters)` 복원 → 부부/싱글 거래유형 보존 |
| `mocks/diagnosis/get-diagnosis.ts` | 픽스처 dealType 최상위로 이동 |

4-A 가격 배선(price-index median)·`comparableMedian`/`wolseEstimate` 로직은 **무변경**(유실이 문제였지 함수가 문제 아님).

## 검증 (tsx 직접 호출, 커밋 안 함)

- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- **★ 예산 금액 미입력 상태에서**:

| 거래유형 | 광교동 표시 |
|---|---|
| 전세 | priceRange **7.20억** (전세 median) |
| **매매** | priceRange **12.75억** (매매 median) ← 수정 핵심 |
| **월세** | wolseEstimate **보증금 3.0억 / 월 168** |
| 미지정 | 7.20억 (기본 전세) |

- **예산 입력 시**: 매매+10~15억 → 광교 12.75억 표시 + 필터 정상.
- **회귀 0**: 매매 8~15억 **14/44**, 전세 4~7억 **21/44** (Phase 0/4-A와 동일).
- mock/real 동일 소스 · 잔재 `budget.dealType` 코드 **0** · 저장 진단 재오픈 dealType 보존.

## 범위 밖
- what-if 천장(15억) → **4-B**
- "(추정)" 라벨 제거·폴백 "구 평균" 라벨 → **5단계**

🤖 Generated with [Claude Code](https://claude.com/claude-code)