### PR TITLE
fix(price): 월세+예산미입력 마운트 크래시 핫픽스 (page.tsx:112 budget! 가드)

### DIFF
--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -109,7 +109,8 @@ export default function DiagnosisPage() {
       : "",
   );
   const [monthlyMaxInput, setMonthlyMaxInput] = React.useState(
-    isWolseBudget ? String(filters.budget!.max) : "",
+    // ★ dealType="wolse" 라도 budget 은 undefined 일 수 있음(#171 분리) → 옵셔널 가드(옆줄 패턴).
+    isWolseBudget && filters.budget ? String(filters.budget.max) : "",
   );
   const [dealType, setDealType] = React.useState<DealType>(
     filters.dealType ?? "jeonse",


### PR DESCRIPTION
## 버그 (긴급)

거래유형 **월세** 선택 시 라이브에서 "Application error: client-side exception"(앱 죽음).

`dealType="wolse"` + `budget=undefined` 상태로 `DiagnosisPage` 마운트 시, `monthlyMaxInput` 초기화의 **`filters.budget!.max`** 가 `undefined.max` 접근 → `TypeError` → 렌더 throw.

## 원인 — #171 후속 잔재 (4-A 아님)

#171이 `dealType`을 budget에서 **독립 분리**하면서 "월세라도 budget 없을 수 있음"이 가능해졌는데, **line 112만 옛 불변식(월세 ⟹ budget 존재)을 가정한 비널 단언(`budget!`)을 남김**.

| 시점 | `isWolseBudget` | `budget!.max` |
|---|---|---|
| #171 이전 | `filters.budget?.dealType === "wolse"` | wolse ⟹ budget 존재 → 안전 |
| #171 이후 | `filters.dealType === "wolse"` | wolse라도 budget undefined 가능 → **크래시** |

옆줄(`budgetMin/Max` 100·102, `depositMax` 106)은 이미 옵셔널 가드됨 — 112만 누락.

> hint #4(키 불일치)는 **무혐의**: `wolseMedian`이 `{depositMedian,monthlyMedian}` → `{deposit,monthly}`로 변환해 `formatWolse`와 일치. wolseMedian/formatWolse 무변경.

## 수정 — 단일 라인

```diff
-    isWolseBudget ? String(filters.budget!.max) : "",
+    isWolseBudget && filters.budget ? String(filters.budget.max) : "",
```

`budget!` 비널 단언을 옆줄 패턴대로 옵셔널 가드로 교체. 다른 로직 무변경.

## 검증

- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- **`budget!` 잔재 0건**(grep 전체 확인 — 이 한 곳뿐이었음).
- 초기화 로직 검증:

| 상태 | monthlyMaxInput | 비고 |
|---|---|---|
| 월세+예산미입력(크래시였던 상태) | `""` | **무크래시** |
| 월세+예산입력 | `"120"` | 회귀 없음(값 보존) |
| 전세 / 매매 / 미지정 | `""` | 회귀 없음 |

- 변경 범위: 1 file, +2 −1 (가드 한 줄 + 주석).

## 유지
#171 dealType 분리·4-A 가격 배선·`wolseMedian`/`formatWolse` 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)