### PR TITLE
fix(price): 월세 상세(DetailSheet) 값이 카드 요약과 불일치 핫픽스

### DIFF
--- a/onday-app/src/features/diagnosis/detail-mapper.ts
+++ b/onday-app/src/features/diagnosis/detail-mapper.ts
@@ -1,6 +1,6 @@
 import { MODE_LABELS, type CommuteMode as ChipMode } from "@/components/data/commute-chip";
 import type { BadgeProps } from "@/components/ui/badge";
-import { toChipMode } from "@/features/diagnosis/result-utils";
+import { toChipMode, formatWolse } from "@/features/diagnosis/result-utils";
 import type { CandidateArea, CommuteInfo } from "@/lib/types";
 
 interface PillItem {
@@ -71,7 +71,15 @@ export function buildCommuteRows(
 
 export function buildMetrics(c: CandidateArea): MetricItem[] {
   const metrics: MetricItem[] = [];
-  if (c.priceRange) {
+  // 월세 진단(wolseEstimate 채워짐)은 카드 요약과 동일하게 formatWolse(보증금/월) 표기.
+  //   priceRange 는 월세 시 전세 scale 라 "평균 시세"로 쓰면 카드 요약과 불일치 → wolse 우선 분기.
+  if (c.wolseEstimate) {
+    metrics.push({
+      label: "월세",
+      value: formatWolse(c.wolseEstimate),
+      sub: c.avgArea != null ? `${c.avgArea}평` : undefined,
+    });
+  } else if (c.priceRange) {
     const avg = (c.priceRange.min + c.priceRange.max) / 2;
     metrics.push({
       label: "평균 시세",

--- a/onday-app/src/features/single/detail-mapper.ts
+++ b/onday-app/src/features/single/detail-mapper.ts
@@ -1,5 +1,6 @@
 import type { BadgeProps } from "@/components/ui/badge";
 import type { CandidateArea, SafetyGrade } from "@/lib/types";
+import { formatWolse } from "@/features/diagnosis/result-utils";
 
 import { getNightCrimeRate } from "./safety-stats";
 
@@ -44,7 +45,15 @@ export function buildSingleMetrics(
       sub: grade ? "10만명당" : "데이터 준비중",
     },
   ];
-  if (c.priceRange) {
+  // 월세 진단(wolseEstimate 채워짐)은 카드 요약과 동일하게 formatWolse(보증금/월) 표기.
+  //   priceRange 는 월세 시 전세 scale 라 "평균 시세"로 쓰면 카드 요약과 불일치 → wolse 우선 분기.
+  if (c.wolseEstimate) {
+    metrics.push({
+      label: "월세",
+      value: formatWolse(c.wolseEstimate),
+      sub: c.avgArea != null ? `${c.avgArea}평` : undefined,
+    });
+  } else if (c.priceRange) {
     const avg = (c.priceRange.min + c.priceRange.max) / 2;
     metrics.push({
       label: "평균 시세",


### PR DESCRIPTION
## 버그

거래유형 **월세**일 때, 같은 카드인데 **요약 ≠ 상세**:
- **카드 요약**: `formatWolse(wolseEstimate)` → "보증금 3.0억 / 월 168만 (추정)" ✅
- **상세(DetailSheet)**: `buildMetrics`/`buildSingleMetrics`가 dealType 무관하게 `priceRange`(월세 시 **전세 scale**)를 → "평균 시세 7.2억" ❌

부부·싱글 둘 다. 전세·매매는 양쪽 다 priceRange 기반이라 일치(정상). 찜은 단일 소스라 정상.

**월세 도입 때부터의 선재 버그** — detail 매퍼가 wolse 분기를 안 가짐. #170/#171이 만든 게 아니라 **4-A 실거래 전환으로 두 값의 괴리가 표면화**(전세 median 7.2억 vs 월세 보증금3억/월168).

## 수정 — 옵션 B (wolseEstimate 유무로 분기)

`detail-mapper.ts`(부부)·`single/detail-mapper.ts`(싱글) 두 곳에 wolse 우선 분기 추가:

```ts
if (c.wolseEstimate) {                         // 월세 진단에서만 채워짐
  metrics.push({ label: "월세", value: formatWolse(c.wolseEstimate), sub: …평 });
} else if (c.priceRange) {                      // 전세/매매 — 기존 그대로
  metrics.push({ label: "평균 시세", value: `${avg}억`, … });
}
```

**카드 요약과 동일한 `formatWolse` 함수 재사용** (새 포맷 안 만듦 — 일치가 목적).

## 검증 (tsx 직접 호출, 커밋 안 함)

- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- **★ 월세 일치**: 공덕동 카드 "보증금 4.0억 / 월 170만 (추정)" = **부부 상세** = **싱글 상세** ✅
- **전세 회귀 0**: 상세 "평균 시세 8.1억" 유지
- **매매 회귀 0**: 상세 "평균 시세 23.8억" 유지
- 폴백 동네 월세도 동일 경로(`wolseEstimate`→`formatWolse`)라 일치
- 찜(`favorites-menu`) 무변경(이미 단일 소스 정상)
- 변경 범위: 2 files, +20 −3

## 유지
카드 요약(result-content:591-594, single priceText, favorites)·4-A 가격 배선·#171 dealType·`wolseMedian`/`formatWolse` 로직 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)