### PR TITLE
feat(price): 시세 4-B — what-if 천장/스텝 dealType-aware + 자동완성 "매가" 오라벨 정정

### DIFF
--- a/onday-app/src/features/diagnosis/use-address-suggest.ts
+++ b/onday-app/src/features/diagnosis/use-address-suggest.ts
@@ -19,6 +19,7 @@ import type { GeocodedAddress } from "@/lib/diagnosis";
 import type { AddressSuggestion } from "@/components/form/suggest-list";
 import { useDebounce } from "@/lib/use-debounce";
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
+import { comparableMedian } from "@/lib/diagnosis/price-index";
 
 const SUGGESTION_LIMIT = 5;
 const DEBOUNCE_MS = 300;
@@ -27,10 +28,14 @@ const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 
 /** ★ Neighborhood → AddressSuggestion 변환 (★ REFACTOR-UI-002-FEEDBACK 헬퍼 추출, 중복 제거) */
 function neighborhoodToSuggestion(n: (typeof MOCK_NEIGHBORHOODS)[number]): AddressSuggestion {
+  // 4-B: 기존 "매가 X억"은 avgPrice(전세 추정)를 매매가로 오라벨 → price-index 실거래 매매 median 으로 정정.
+  //   결측(id 없음)이면 가격 라벨 생략(거짓값 금지).
+  const maemae = comparableMedian(n.id, "maemae");
+  const pricePart = maemae != null ? `매가 ${(maemae / 10000).toFixed(1)}억 · ` : "";
   return {
     id: n.id,
     title: `${n.gu} ${n.dong}`,
-    sub: `매가 ${(n.avgPrice / 10000).toFixed(1)}억 · 안전등급 ${n.safetyGrade}`,
+    sub: `${pricePart}안전등급 ${n.safetyGrade}`,
     kind: "지역" as const,
     coordinate: n.coordinate,
   };

--- a/onday-app/src/lib/diagnosis/generate-suggestions.ts
+++ b/onday-app/src/lib/diagnosis/generate-suggestions.ts
@@ -14,9 +14,14 @@ const COMMUTE_STEP_MAJOR = 30;
 const COMMUTE_MAX_BASIC = 60;
 const COMMUTE_MAX_EXTENDED = 90;
 
-// 5천만원 단위 (만원 베이스 — DiagnosisFilters.budget 은 만원 단위)
-const BUDGET_STEP_MAN = 5_000;
-const BUDGET_MAX_CEIL_MAN = 150_000; // 15억원
+// 거래유형별 예산 완화 천장/스텝 — price-index 실거래 median 분포 기준(만원 베이스).
+//   매매 median 최대 32.7억 → 35억 천장·1억 스텝. 전세 median 최대 12억 → 15억 천장·5천만 스텝.
+//   (4-A 이전 전세 추정 스케일 고정값 15억/5천만이 매매(최대 32.7억)에 안 맞던 것 정합.)
+const BUDGET_CEIL_MAN = { jeonse: 150_000, maemae: 350_000 } as const; // 15억 / 35억
+const BUDGET_STEP_MAN = { jeonse: 5_000, maemae: 10_000 } as const; // 5천만 / 1억
+//   월세는 budget.max = 월세 상한(만원). 월세금 median 최대 290만 → 500만 천장·50만 스텝.
+const WOLSE_MONTHLY_CEIL_MAN = 500;
+const WOLSE_MONTHLY_STEP_MAN = 50;
 
 /**
  * 현재 filters 기반으로 완화 제안 배열 반환.
@@ -45,14 +50,30 @@ export function generateRelaxationSuggestions(
     });
   }
 
-  // 2. budget 완화 (★ Q3 결정 — 본 ISSUE Phase A 사전 박힘 발견 2번째 = 백엔드 자체 누락)
-  if (filters.budget && filters.budget.max < BUDGET_MAX_CEIL_MAN) {
-    const newMax = filters.budget.max + BUDGET_STEP_MAN;
-    const newMaxOk = newMax / 10_000; // 만원 → 억원 변환 (10,000만원 = 1억원)
-    suggestions.push({
-      label: `예산 최대를 ${newMaxOk.toFixed(1)}억원으로 늘려보세요`,
-      apply: { budget: { ...filters.budget, max: newMax } }, // dealType 보존
-    });
+  // 2. budget 완화 — 거래유형별 스케일(매매 35억/1억 · 전세 15억/5천만 · 월세 월500만/50만).
+  //    dealType 은 filters 최상위(#171 분리). apply 는 budget(금액)만 바꿔 filters.dealType 보존.
+  if (filters.budget) {
+    const dealType = filters.dealType ?? "jeonse";
+    if (dealType === "wolse") {
+      // budget.max = 월세 상한(만원). 억 라벨 부적합 → "월 X만원" 라벨.
+      if (filters.budget.max < WOLSE_MONTHLY_CEIL_MAN) {
+        const newMax = filters.budget.max + WOLSE_MONTHLY_STEP_MAN;
+        suggestions.push({
+          label: `월세 상한을 ${newMax}만원으로 늘려보세요`,
+          apply: { budget: { ...filters.budget, max: newMax } },
+        });
+      }
+    } else {
+      const ceil = BUDGET_CEIL_MAN[dealType];
+      const step = BUDGET_STEP_MAN[dealType];
+      if (filters.budget.max < ceil) {
+        const newMax = filters.budget.max + step;
+        suggestions.push({
+          label: `예산 최대를 ${(newMax / 10_000).toFixed(1)}억원으로 늘려보세요`,
+          apply: { budget: { ...filters.budget, max: newMax } },
+        });
+      }
+    }
   }
 
   return suggestions;


### PR DESCRIPTION
## 무엇을 / 왜

4-A 이후 남은 **가격 파생 정합 2건**. 새 매매 스케일(median 최대 32.7억)에 안 맞던 what-if 천장/스텝과, 전세값을 "매가"로 오라벨하던 자동완성 정정.

## 변경

### 1. `generate-suggestions.ts` — 예산 완화 dealType-aware
price-index 실거래 median 분포 기준:

| dealType | 천장 | 스텝 | 근거 |
|---|---|---|---|
| 매매 | **35억**(350000) | **1억**(10000) | 매매 median 최대 32.7억 |
| 전세/미지정 | 15억(150000) | 5천만(5000) | 전세 median 최대 12억 (기존 유지) |
| 월세 | **월 500만**(만원) | 월 50만 | 월세금 median 최대 290만. `budget.max`=월세 상한(만원) → "월세 상한을 X만원으로" 라벨 |

- 옛 고정 천장 **15억이 매매 완화를 막던 것 해소**(예: 20억 예산 → 21억 제안 정상).
- 옛 코드는 **월세 만원을 억으로 환산해 "0.5억원" 헛라벨** → 정정.
- dealType은 filters 최상위(#171). `apply`는 budget(금액)만 바꿔 `filters.dealType` 보존.

### 2. `use-address-suggest.ts` — "매가" 오라벨 정정
`매가 ${avgPrice/10000}억`이 **avgPrice(전세 추정 보증금)를 매매가로 오라벨**하던 것을, **price-index 실거래 매매 median**으로 교체. 결측 시 가격 라벨 생략(거짓값 금지).

| 동네 | 옛 라벨(=전세 추정) | 새 라벨(실거래 매매) |
|---|---|---|
| 역삼동 | 매가 11.5억 ❌ | **매가 23.8억** ✅ |
| 광교동 | 매가 11.8억 ❌ | **매가 12.8억** ✅ |
| 종로3가 | 매가 4.5억 ❌ | **매가 11.2억** ✅ |

## 검증 (tsx 직접 호출, 커밋 안 함)

- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- **what-if**: 매매 10억→"11.0억" / 매매 **20억→"21.0억"**(옛 15억 천장 돌파) / 매매 35억→제안없음 / 전세 8억→"8.5억"(회귀0) / 전세 15억→없음 / 미지정 8억→"8.5억" / **월세 200만→"월세 상한을 250만원으로"** / 월세 500만→없음.
- **자동완성**: "매가" = 실거래 매매 median으로 정직 표기.
- 회귀: 전세/월세 what-if·기존 진단 흐름 무변경. price-index 접근에 null-guard.
- 변경 범위: 2 files.

## 유지
4-A 가격 배선·예산 필터·priceRange 무변경. price.ts DEPRECATED 함수 그대로.

## 후속 (5단계)
"(추정)" 라벨 제거 · 폴백 "구 평균" 라벨 · 거래유형 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)