### PR TITLE
feat(price): 결과 거래유형·예산 재필터 토글 5-1(부부) — real 통근 풀 캐시 재활용

### DIFF
--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -79,6 +79,7 @@ export default function DiagnosisPage() {
   const setLoading = useDiagnosisStore((s) => s.setLoading);
   const setError = useDiagnosisStore((s) => s.setError);
   const setResult = useDiagnosisStore((s) => s.setResult);
+  const setCommutePool = useDiagnosisStore((s) => s.setCommutePool);
   const pushToast = useUIStore((s) => s.pushToast);
   const createDiagnosis = useCreateDiagnosis();
 
@@ -193,6 +194,9 @@ export default function DiagnosisPage() {
         filters,
       });
       setResult(data.diagnosisId, data.candidates);
+      // ★ 5-1: real 진단의 통근 풀(12개) 캐시 → 결과에서 거래유형/예산 토글 재필터에 재활용.
+      //   mock(POST 응답엔 pool 없음)·재오픈 시 빈 배열 → 토글은 runMockDiagnosis 재실행 fallback.
+      setCommutePool(data.pool ?? []);
       // MON-003 v1.4 부활 (Issue #127) — REQ-NF-008 funnel 시작점.
       trackDiagnosisStarted(data.diagnosisId);
       // ★ REFACTOR-UI-002-FEEDBACK-2 (#96) — 진단 시작 성공 시 localStorage 저장 (★ "이전 조건 불러오기" 버튼 호출처).

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -34,7 +34,14 @@ import {
 } from "@/lib/haversine";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
 import { latLngToPixel } from "@/lib/coordinate-transform";
-import type { CandidateArea, CommuteInfo, DiagnosisFilters } from "@/lib/types";
+import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
+import { refilterPool } from "@/lib/diagnosis/refilter";
+import type {
+  CandidateArea,
+  CommuteInfo,
+  DealType,
+  DiagnosisFilters,
+} from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useFavoritesStore, toFavoriteSnapshot } from "@/stores/favorites";
@@ -144,6 +151,11 @@ export function ResultContent({
   const diagnosisId = useDiagnosisStore((s) => s.diagnosisId);
   const coordinateA = useDiagnosisStore((s) => s.coordinateA);
   const coordinateB = useDiagnosisStore((s) => s.coordinateB);
+  // ★ 5-1 거래유형/예산 토글 재필터 — real 통근 풀 캐시(있으면) / 없으면 runMockDiagnosis 재실행.
+  const commutePool = useDiagnosisStore((s) => s.commutePool);
+  const mode = useDiagnosisStore((s) => s.mode);
+  const leisureCoordA = useDiagnosisStore((s) => s.leisureCoordA);
+  const leisureCoordB = useDiagnosisStore((s) => s.leisureCoordB);
 
   const favorites = useFavoritesStore((s) => s.favorites);
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
@@ -210,11 +222,10 @@ export function ResultContent({
     if (diagnosisId) setResult(diagnosisId, next);
   };
 
-  const handleBudgetWhatIf = (
-    min: number,
-    max: number,
-    depositMax?: number,
-  ) => {
+  // ★ 5-1 거래유형/예산 토글 재필터 — 추천 세트가 바뀜(표시전환 아님).
+  //   real: 캐시 풀(통근 보존) 재필터(통근 열화·API 0). mock/재오픈: runMockDiagnosis 재실행(전체 44, Haversine).
+  //   (출발시각/통근상한 what-if 는 기존 recomputeWhatIf 경로 유지 — 이번 범위 밖.)
+  const applyDealBudget = async (newFilters: DiagnosisFilters) => {
     if (!coordinateA) {
       pushToast({
         variant: "default",
@@ -222,19 +233,34 @@ export function ResultContent({
       });
       return;
     }
-    // what-if 는 금액만 조정 — dealType(거래유형)은 filters.dealType 에 보존(...filters). budget 은 금액만.
-    const newFilters = {
-      ...filters,
-      budget: { min, max, depositMax },
-    };
     setFilters(newFilters);
-    const next = recomputeWhatIf(
-      baselineRef.current ?? candidates,
-      newFilters,
-      coordinateA,
-      coordinateB,
-    );
+    const next =
+      commutePool.length > 0
+        ? refilterPool(commutePool, newFilters)
+        : await runMockDiagnosis(
+            coordinateA,
+            coordinateB,
+            newFilters,
+            mode,
+            leisureCoordA,
+            leisureCoordB,
+          );
     if (diagnosisId) setResult(diagnosisId, next);
+  };
+
+  // 거래유형 토글 — filters.dealType 갱신 후 재필터. 예산은 그대로.
+  const handleDealTypeChange = (dealType: DealType) => {
+    if (dealType === (filters.dealType ?? "jeonse")) return;
+    void applyDealBudget({ ...filters, dealType });
+  };
+
+  // 예산 what-if — 금액만 조정(dealType 보존). ★ 5-1: 재필터로 전환(예산 넓히면 풀에서 새 동네 등장).
+  const handleBudgetWhatIf = (
+    min: number,
+    max: number,
+    depositMax?: number,
+  ) => {
+    void applyDealBudget({ ...filters, budget: { min, max, depositMax } });
   };
 
   const sorted = React.useMemo(
@@ -465,14 +491,49 @@ export function ResultContent({
             // Issue #112 — what-if 옵션 inline 박힘 토글 (★ #111 답습).
             onClick: () => setShowCommuteOptions((prev) => !prev),
           },
-          filters.budget != null && {
+          {
+            // ★ 5-1: 예산 칩 항상 노출 — 결과에서 예산 설정/변경 가능(미설정 시 "전체"). 변경 시 재필터.
             label: "예산",
             value: formatBudgetFilter(filters.budget, filters.dealType),
-            // Issue #112 — what-if 옵션 inline 박힘 토글 (★ #111 답습).
             onClick: () => setShowBudgetOptions((prev) => !prev),
           },
         ].filter(Boolean) as { label: string; value: string; onClick: () => void }[]}
       />
+
+      {/* ★ 5-1 거래유형 토글 — 전세/매매/월세. 변경 시 추천 세트 재필터(real 통근 캐시 / mock 재실행). */}
+      <div
+        className="flex items-center gap-s-2"
+        role="group"
+        aria-label="거래유형 선택"
+      >
+        <span className="text-caption font-bold text-ink-2">거래유형</span>
+        {(
+          [
+            ["jeonse", "전세"],
+            ["maemae", "매매"],
+            ["wolse", "월세"],
+          ] as const
+        ).map(([key, label]) => {
+          const active = (filters.dealType ?? "jeonse") === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => handleDealTypeChange(key)}
+              aria-pressed={active}
+              className={cn(
+                "rounded-sm px-s-3 py-s-1 text-body-sm font-bold transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                active
+                  ? "bg-primary text-primary-foreground"
+                  : "border border-card-border bg-surface text-ink-2 hover:text-ink",
+              )}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
 
       {/* Issue #111 β + #118 — what-if 시뮬레이션 입력 (★ <input type="time"> + "변경" 버튼 명시적 확인 + 시나리오 B handler fallback). */}
       {/* key={currentDepartureTime} — baseTime 변경 시 컴포넌트 재마운트 (★ React 19 set-state-in-effect 규칙 답습). */}
@@ -492,12 +553,12 @@ export function ResultContent({
           onConfirm={handleCommuteWhatIf}
         />
       )}
-      {showBudgetOptions && filters.budget != null && (
+      {showBudgetOptions && (
         <BudgetChipOptions
-          key={`${filters.budget.min}-${filters.budget.max}-${filters.budget.depositMax ?? ""}`}
-          baseMin={filters.budget.min}
-          baseMax={filters.budget.max}
-          baseDepositMax={filters.budget.depositMax}
+          key={`${filters.budget?.min ?? 0}-${filters.budget?.max ?? 0}-${filters.budget?.depositMax ?? ""}`}
+          baseMin={filters.budget?.min ?? 0}
+          baseMax={filters.budget?.max ?? 0}
+          baseDepositMax={filters.budget?.depositMax}
           dealType={filters.dealType}
           onConfirm={handleBudgetWhatIf}
         />

--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -13,7 +13,9 @@ import {
 } from "@/lib/haversine";
 import { scoreCandidate } from "@/lib/diagnosis/scoring";
 // 시세 4-A — 예산 필터·priceRange 가 실거래 median(price-index)을 사용. price.ts 추정 환산 제거.
-import { comparableMedian, wolseMedian, priceRangeFor } from "@/lib/diagnosis/price-index";
+import { wolseMedian, priceRangeFor } from "@/lib/diagnosis/price-index";
+// 시세 5-1 — 예산/통근 필터를 공용 술어로(토글 재필터와 동일 의미론).
+import { passesFilters } from "@/lib/diagnosis/refilter";
 import { MOCK_NEIGHBORHOODS } from "@/mocks/neighborhoods";
 import { KakaoCarClient } from "@/lib/external/kakao-car";
 
@@ -117,10 +119,15 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
 
   // 2) 동네별 통근시간 (병렬). ★ 방향 = 동네(집) → 직장 (출퇴근 의미론, #3 정정).
   //    동네 내부 경로는 순차(동시 호출 부하 완화).
-  const settled = await mapWithConcurrency(
+  // 거래유형 — filters.dealType 단일 소스(budget 과 독립). 미지정=전세.
+  const dealType = filters.dealType ?? "jeonse";
+
+  // 2) prefilter 12개 풀 빌드 — 통근(transit/자차) 전부 계산, 예산/통근 필터는 적용 안 함(아래 후처리).
+  //    ★ 5-1: 이 12개 풀을 클라가 캐시 → 거래유형/예산 토글 시 재필터(통근 열화·API 재호출 0).
+  const pool = await mapWithConcurrency(
     prefiltered,
     ODSAY_CONCURRENCY,
-    async ({ n }): Promise<CandidateArea | null> => {
+    async ({ n }): Promise<CandidateArea> => {
       const depTime = filters.commuteSchedule?.departureTime;
       // ODsay 실패 → 후보 drop 대신 haversine 추정(빈 결과 방지, Vercel 무료 대응).
       const commuteA =
@@ -146,35 +153,8 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
           (await fetchCommute(n.coordinate, leisureCoordB)) ??
           estimateTransit(n.coordinate, leisureCoordB, depTime);
 
-      // 필터 — 통근 상한
-      if (filters.maxCommuteTime) {
-        const maxCommute = Math.max(commuteA.time, commuteB?.time ?? 0);
-        if (maxCommute > filters.maxCommuteTime) return null;
-      }
-      // 필터 — 예산 범위
-      // 거래유형 — filters.dealType 단일 소스(budget 과 독립). 미지정=전세.
-      const dealType = filters.dealType ?? "jeonse";
-      if (filters.budget) {
-        if (dealType === "wolse") {
-          // 월세 — 보증금(상한) + 월세(범위) 2축. 실거래 median 기준. 결측이면 제외(임의 통과 금지).
-          const w = wolseMedian(n.id);
-          if (!w) return null;
-          const depositOk = w.deposit <= (filters.budget.depositMax ?? Infinity);
-          const monthlyOk =
-            w.monthly >= filters.budget.min && w.monthly <= filters.budget.max;
-          if (!depositOk || !monthlyOk) return null;
-        } else {
-          // 전세/매매 — 실거래 median. 미지정=전세. median 결측이면 제외(임의 통과 금지).
-          const price = comparableMedian(n.id, dealType);
-          if (price == null) return null;
-          if (price < filters.budget.min || price > filters.budget.max) {
-            return null;
-          }
-        }
-      }
-
-      // ★ W2B 자차(카카오) — 필터 통과한 후보의 직장 경로만. best-effort 병렬.
-      //   대중교통이 주(필수)이므로 여기서 실패해도 후보·점수 불변.
+      // ★ W2B 자차(카카오) — (가) 12개 전부 계산(토글 캐시 완비, 예산 통과분만→전부로 확장).
+      //   best-effort: 실패/키없음 → undefined(차량 행만 생략, 후보·점수 무영향).
       const [commuteACar, commuteBCar] = await Promise.all([
         fetchCarCommute(n.coordinate, coordinateA),
         coordinateB
@@ -217,12 +197,13 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
     },
   );
 
-  const candidates = settled
-    .filter((c): c is CandidateArea => c !== null)
+  // 3) 예산/통근 필터 적용 + 점수순 top N → 저장·표시용 후보.
+  const candidates = pool
+    .filter((c) => passesFilters(c, filters))
     .sort((a, b) => b.score - a.score)
     .slice(0, RESULT_TOP_N);
 
-  // 3) 저장 — production 분기는 클라가 계산한 candidates 를 받아 저장만 (B2).
+  // 4) 저장 — production 분기는 클라가 계산한 candidates 를 받아 저장만 (B2). 저장은 8개만.
   const res = await fetch("/api/diagnosis", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -232,5 +213,7 @@ export async function runRealDiagnosis(input: DiagnosisInput) {
     const err = await res.json();
     throw new Error(err.error ?? "진단 저장에 실패했습니다");
   }
-  return res.json();
+  // ★ 5-1: pool(12개, 통근 캐시)을 함께 반환 → 클라가 거래유형/예산 토글 재필터에 재활용.
+  const saved = await res.json();
+  return { ...saved, pool };
 }

--- a/onday-app/src/lib/diagnosis/refilter.ts
+++ b/onday-app/src/lib/diagnosis/refilter.ts
@@ -1,0 +1,54 @@
+// 시세 5-1 — 거래유형/예산 토글 재필터 공용 로직.
+//   real 진단의 prefilter 12개 풀(통근 캐시)에 거래유형/예산을 다시 적용해 추천 세트를 갱신한다.
+//   ★ 통근은 캐시값 그대로(재계산 X, API 재호출 X). 점수는 가격 무관(scoring) → 통근 캐시면 불변.
+//   ★ priceRange/wolseEstimate 는 새 거래유형 기준으로 price-index 에서 재계산.
+
+import type { CandidateArea, DiagnosisFilters } from "@/lib/types";
+import { comparableMedian, wolseMedian, priceRangeFor } from "./price-index";
+
+const RESULT_TOP_N = 8;
+
+// 통근 상한 + 예산(거래유형별) 필터 — mock-calculator / run-real 와 동일 의미론(price-index 기준).
+export function passesFilters(c: CandidateArea, filters: DiagnosisFilters): boolean {
+  if (filters.maxCommuteTime) {
+    const maxCommute = Math.max(c.commuteA.time, c.commuteB?.time ?? 0);
+    if (maxCommute > filters.maxCommuteTime) return false;
+  }
+  if (filters.budget) {
+    const dealType = filters.dealType ?? "jeonse";
+    if (dealType === "wolse") {
+      const w = wolseMedian(c.id);
+      if (!w) return false; // median 결측 → 제외(임의 통과 금지)
+      if (w.deposit > (filters.budget.depositMax ?? Infinity)) return false;
+      if (w.monthly < filters.budget.min || w.monthly > filters.budget.max) {
+        return false;
+      }
+    } else {
+      const price = comparableMedian(c.id, dealType);
+      if (price == null) return false;
+      if (price < filters.budget.min || price > filters.budget.max) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * 캐시 풀(통근 보존) → 거래유형/예산 재필터 + 거래유형별 시세 재계산 + 점수순 top N.
+ * ★ 후보 우주 = prefilter 12개(거리 기준, 가격 무관) → 토글로 등장 가능한 모든 동네 포함.
+ */
+export function refilterPool(
+  pool: CandidateArea[],
+  filters: DiagnosisFilters,
+): CandidateArea[] {
+  const dealType = filters.dealType ?? "jeonse";
+  return pool
+    .map((c) => ({
+      ...c,
+      priceRange: priceRangeFor(c.id, dealType),
+      wolseEstimate:
+        dealType === "wolse" ? (wolseMedian(c.id) ?? undefined) : undefined,
+    }))
+    .filter((c) => passesFilters(c, filters))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, RESULT_TOP_N);
+}

--- a/onday-app/src/stores/diagnosis-store.ts
+++ b/onday-app/src/stores/diagnosis-store.ts
@@ -19,6 +19,9 @@ interface DiagnosisState {
   // Result
   diagnosisId: string | null;
   candidates: CandidateArea[];
+  // ★ 거래유형/예산 토글 재필터용 통근 캐시 — real 진단의 prefilter 12개 풀(실 transit/자차 통근 보존,
+  //   예산필터 전). 토글 시 이 풀을 재필터해 통근 열화·API 재호출 0. mock·재오픈 시 빈 배열(재실행 fallback).
+  commutePool: CandidateArea[];
   isLoading: boolean;
   error: string | null;
 
@@ -31,6 +34,7 @@ interface DiagnosisState {
   setFilters: (filters: DiagnosisFilters) => void;
   setDeadlineDate: (date: string | null) => void;
   setResult: (id: string, candidates: CandidateArea[]) => void;
+  setCommutePool: (pool: CandidateArea[]) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   reset: () => void;
@@ -50,6 +54,7 @@ const initialState = {
   deadlineDate: null,
   diagnosisId: null,
   candidates: [],
+  commutePool: [],
   isLoading: false,
   error: null,
 };
@@ -75,6 +80,8 @@ export const useDiagnosisStore = create<DiagnosisState>((set) => ({
 
   setResult: (diagnosisId, candidates) =>
     set({ diagnosisId, candidates, isLoading: false, error: null }),
+
+  setCommutePool: (commutePool) => set({ commutePool }),
 
   setLoading: (isLoading) => set({ isLoading }),
   setError: (error) => set({ error, isLoading: false }),


### PR DESCRIPTION
## 무엇을 / 왜

부부 결과 화면에 **거래유형(전세/매매/월세) 세그먼트 + 예산 칩(항상 노출)** 추가. 토글 시 **추천 동네 세트가 재필터**됨(표시전환 아님). real 모드는 처음 진단의 **실 transit 통근값을 캐시 재활용 → 통근 열화·API 재호출 0**. mock/재오픈은 `runMockDiagnosis` 재실행 fallback.

**핵심 근거**: prefilter(44→12)가 **거리 기준(가격 무관)** → 토글해도 후보 우주(12)가 불변. 12개 풀을 캐시하면 어떤 토글 결과든 캐시로 커버(우주 밖 동네 등장 불가).

- 싱글은 **PR 5-2 후속**.

## 변경

| 파일 | 변경 |
|---|---|
| `run-real-diagnosis.ts` | prefilter 12개를 **예산/통근 필터 전 풀**로 빌드(★ 자차 12개 전부 계산 (가)), `passesFilters`(공용)로 후처리해 저장용 top8 산출, **`pool`(12, 통근 캐시) 함께 반환** |
| `lib/diagnosis/refilter.ts` (신규) | `passesFilters`(예산/통근 공용 술어) + `refilterPool`(통근 캐시 보존·거래유형별 priceRange/wolse 재계산·점수순 top8) |
| `diagnosis-store.ts` | `commutePool` + `setCommutePool` |
| `page.tsx` | 진단 성공 시 `setCommutePool(data.pool ?? [])` |
| `result-content.tsx` | 거래유형 세그먼트(항상) + 예산 칩 항상 노출. `applyDealBudget` — pool 있으면 `refilterPool`, 없으면 `runMockDiagnosis` 재실행. 예산 what-if도 이 경로(예산 넓히면 풀에서 새 동네). 출발시각/통근상한 what-if는 `recomputeWhatIf` 유지 |

## 검증 (tsx 직접 호출, 커밋 안 함)

- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- **`refilterPool`**:
  - **통근 캐시 보존**: 결과 commuteA=20분 = 풀 원본(재계산 X) ✅
  - **거래유형별 재가격**: 종로3가 전세 6.4억 → 매매 9.5억(price-index 재계산) ✅
  - **세트 변경**: 매매 5~9억 **1개** vs 5~35억 **8개**(좁힘<넓힘) ✅
  - **12 우주 내**: 풀 밖 동네 등장 **0건** ✅
  - **필터 일관**: 역삼 매매 23.8억 ∈ [10,30억] → passesFilters=true ✅
- mock 경로(`runMockDiagnosis` 재실행)는 4-A 검증과 동일(전체 44 재필터).

## 동작 요약
- **real(인세션)**: 토글 → 캐시 12풀 재필터 → **실 통근 그대로, ODsay/Kakao 0회**.
- **mock·재오픈**: 토글 → `runMockDiagnosis`(Haversine, 싸고 정확).
- 표시(카드/상세, 5단계)·정렬·트레이드오프는 `filters.dealType`/`priceRange` 자동 추종. 찜은 토글 제외(스냅샷 보존).

## 유지
4-A 가격 배선·예산 필터 의미론·#171 dealType·5단계 표시·출발시각 what-if(`recomputeWhatIf`) 무변경.

## ⚠️ 검증 한계
real 통근 캐시·자차 12개 계산은 **네트워크 경로**라 이 환경에서 직접 못 돌려 **코드 검증 + 순수 `refilterPool` 단위 검증**으로 확인했습니다. 머지 후 라이브에서 (1)토글 시 네트워크 0회 (2)자차 12개 호출 (3)예산 넓힘 시 새 동네 등장을 한 번 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)