### PR TITLE
feat(result): PR A(부부) — 월세 토글 버그수정 + 통합 필터 바 + 홈 버튼

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -248,10 +248,12 @@ export function ResultContent({
     if (diagnosisId) setResult(diagnosisId, next);
   };
 
-  // 거래유형 토글 — filters.dealType 갱신 후 재필터. 예산은 그대로.
+  // 거래유형 토글 — filters.dealType 갱신 후 재필터.
+  //   ★ 버그수정: 거래유형마다 예산 단위/의미가 달라(전세/매매=억, 월세=월세만원+보증금) 이월 무효 →
+  //   budget 리셋. (월세 토글 시 억 예산 이월로 전 후보 탈락→빈결과→롤백 버그 해소.)
   const handleDealTypeChange = (dealType: DealType) => {
     if (dealType === (filters.dealType ?? "jeonse")) return;
-    void applyDealBudget({ ...filters, dealType });
+    void applyDealBudget({ ...filters, dealType, budget: undefined });
   };
 
   // 예산 what-if — 금액만 조정(dealType 보존). ★ 5-1: 재필터로 전환(예산 넓히면 풀에서 새 동네 등장).
@@ -474,95 +476,95 @@ export function ResultContent({
   return (
     <div className="space-y-s-4">
       <PreferenceBanner priorityKey={priorityKey} />
-      <FilterPanel
-        // Issue #106 ㊘ — TimeTabs 미박힘 (★ "사용자 입력 → 결과" 자연 흐름 도달).
-        //   ㊔ 사용자 입력 X 필터는 chip 숨김 (★ "제한 없음"/"전체" 표시 X).
-        //   ㊒ 출근시간 chip = 사용자 입력값 박힘 (★ 진단 → 결과 데이터 흐름 정합).
-        filters={[
-          {
-            label: "출근시간",
-            value: filters.commuteSchedule?.departureTime ?? "08:00",
-            // Issue #111 — what-if 옵션 inline 박힘 토글 (★ #106 ㊒ notifyComingSoon 정정).
-            onClick: () => setShowTimeOptions((prev) => !prev),
-          },
-          filters.maxCommuteTime != null && {
-            label: "통근시간",
-            value: formatCommuteFilter(filters.maxCommuteTime),
-            // Issue #112 — what-if 옵션 inline 박힘 토글 (★ #111 답습).
-            onClick: () => setShowCommuteOptions((prev) => !prev),
-          },
-          {
-            // ★ 5-1: 예산 칩 항상 노출 — 결과에서 예산 설정/변경 가능(미설정 시 "전체"). 변경 시 재필터.
-            label: "예산",
-            value: formatBudgetFilter(filters.budget, filters.dealType),
-            onClick: () => setShowBudgetOptions((prev) => !prev),
-          },
-        ].filter(Boolean) as { label: string; value: string; onClick: () => void }[]}
-      />
 
-      {/* ★ 5-1 거래유형 토글 — 전세/매매/월세. 변경 시 추천 세트 재필터(real 통근 캐시 / mock 재실행). */}
-      <div
-        className="flex items-center gap-s-2"
-        role="group"
-        aria-label="거래유형 선택"
+      {/* ★ PR A — 통합 필터 바: 거래유형 세그먼트 + 출근시간/예산 칩 + 인라인 편집을 한 카드로 정돈. */}
+      <section
+        aria-label="검색 조건"
+        className="space-y-s-3 rounded-lg border border-card-border bg-surface p-s-3"
       >
-        <span className="text-caption font-bold text-ink-2">거래유형</span>
-        {(
-          [
-            ["jeonse", "전세"],
-            ["maemae", "매매"],
-            ["wolse", "월세"],
-          ] as const
-        ).map(([key, label]) => {
-          const active = (filters.dealType ?? "jeonse") === key;
-          return (
-            <button
-              key={key}
-              type="button"
-              onClick={() => handleDealTypeChange(key)}
-              aria-pressed={active}
-              className={cn(
-                "rounded-sm px-s-3 py-s-1 text-body-sm font-bold transition-colors",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                active
-                  ? "bg-primary text-primary-foreground"
-                  : "border border-card-border bg-surface text-ink-2 hover:text-ink",
-              )}
-            >
-              {label}
-            </button>
-          );
-        })}
-      </div>
+        {/* 거래유형 세그먼트 (전세/매매/월세) — 변경 시 추천 세트 재필터 + 예산 리셋. */}
+        <div role="group" aria-label="거래유형 선택" className="flex items-center gap-s-2">
+          <span className="w-12 shrink-0 text-caption font-bold text-ink-3">
+            거래유형
+          </span>
+          <div className="flex flex-1 gap-s-1">
+            {(
+              [
+                ["jeonse", "전세"],
+                ["maemae", "매매"],
+                ["wolse", "월세"],
+              ] as const
+            ).map(([key, label]) => {
+              const active = (filters.dealType ?? "jeonse") === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => handleDealTypeChange(key)}
+                  aria-pressed={active}
+                  className={cn(
+                    "flex-1 rounded-sm border px-s-3 py-s-1 text-body-sm font-bold transition-all",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-1",
+                    active
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-card-border bg-surface text-ink-2 hover:brightness-95",
+                  )}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
 
-      {/* Issue #111 β + #118 — what-if 시뮬레이션 입력 (★ <input type="time"> + "변경" 버튼 명시적 확인 + 시나리오 B handler fallback). */}
-      {/* key={currentDepartureTime} — baseTime 변경 시 컴포넌트 재마운트 (★ React 19 set-state-in-effect 규칙 답습). */}
-      {showTimeOptions && (
-        <TimeChipOptions
-          key={currentDepartureTime}
-          baseTime={currentDepartureTime}
-          onConfirm={handleTimeWhatIf}
+        {/* 출근시간 · (통근시간) · 예산 칩 — 클릭 시 아래 인라인 편집 토글. */}
+        <FilterPanel
+          filters={[
+            {
+              label: "출근시간",
+              value: filters.commuteSchedule?.departureTime ?? "08:00",
+              onClick: () => setShowTimeOptions((prev) => !prev),
+            },
+            filters.maxCommuteTime != null && {
+              label: "통근시간",
+              value: formatCommuteFilter(filters.maxCommuteTime),
+              onClick: () => setShowCommuteOptions((prev) => !prev),
+            },
+            {
+              // ★ 5-1: 예산 칩 항상 노출 — 결과에서 거래유형별 예산 설정/변경(미설정 "전체"). 변경 시 재필터.
+              label: "예산",
+              value: formatBudgetFilter(filters.budget, filters.dealType),
+              onClick: () => setShowBudgetOptions((prev) => !prev),
+            },
+          ].filter(Boolean) as { label: string; value: string; onClick: () => void }[]}
         />
-      )}
 
-      {/* Issue #112 — maxCommuteTime + budget what-if 입력 (★ #111+#118 답습). */}
-      {showCommuteOptions && filters.maxCommuteTime != null && (
-        <CommuteChipOptions
-          key={filters.maxCommuteTime}
-          baseValue={filters.maxCommuteTime}
-          onConfirm={handleCommuteWhatIf}
-        />
-      )}
-      {showBudgetOptions && (
-        <BudgetChipOptions
-          key={`${filters.budget?.min ?? 0}-${filters.budget?.max ?? 0}-${filters.budget?.depositMax ?? ""}`}
-          baseMin={filters.budget?.min ?? 0}
-          baseMax={filters.budget?.max ?? 0}
-          baseDepositMax={filters.budget?.depositMax}
-          dealType={filters.dealType}
-          onConfirm={handleBudgetWhatIf}
-        />
-      )}
+        {/* 인라인 편집 — 칩 클릭 시 해당 입력만 펼침. key=재마운트(React 19 규칙). */}
+        {showTimeOptions && (
+          <TimeChipOptions
+            key={currentDepartureTime}
+            baseTime={currentDepartureTime}
+            onConfirm={handleTimeWhatIf}
+          />
+        )}
+        {showCommuteOptions && filters.maxCommuteTime != null && (
+          <CommuteChipOptions
+            key={filters.maxCommuteTime}
+            baseValue={filters.maxCommuteTime}
+            onConfirm={handleCommuteWhatIf}
+          />
+        )}
+        {showBudgetOptions && (
+          <BudgetChipOptions
+            key={`${filters.dealType ?? "jeonse"}-${filters.budget?.min ?? 0}-${filters.budget?.max ?? 0}-${filters.budget?.depositMax ?? ""}`}
+            baseMin={filters.budget?.min ?? 0}
+            baseMax={filters.budget?.max ?? 0}
+            baseDepositMax={filters.budget?.depositMax}
+            dealType={filters.dealType}
+            onConfirm={handleBudgetWhatIf}
+          />
+        )}
+      </section>
 
       {/* Issue #45 (UI-007 v1.4) — REQ-FUNC-012 출처 배지 박힘 영역.
           share-report-view 인라인 3개 답습 = 공유 vs 개인 시각 일관성 100% 사수.

--- a/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import {
   AlertCircle,
   ChevronLeft,
+  Home,
   Loader2,
   Share2,
 } from "lucide-react";
@@ -16,6 +17,7 @@ import { FavoritesMenu } from "@/components/favorites/favorites-menu";
 import { EmptyState } from "@/components/diagnosis/empty-state";
 import { AppHeader } from "@/components/layout/app-header";
 import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
 import { liftLegacyDealType } from "@/features/diagnosis/result-utils";
@@ -48,7 +50,9 @@ export function ResultView({ id }: ResultViewProps) {
   const leisureCoordB = useDiagnosisStore((s) => s.leisureCoordB);
   const pushToast = useUIStore((s) => s.pushToast);
 
-  const inSync = storeId === id && storeCandidates.length > 0;
+  // ★ 버그수정: length>0 제거 — 토글/필터로 결과가 0개가 돼도 "미로드"로 오판해 DB 원본을
+  //   재로드(dealType 롤백)하던 것 방지. 정당한 0개 결과는 EmptyState(완화 제안)로 처리.
+  const inSync = storeId === id;
   const query = useDiagnosis(inSync ? null : id);
 
   React.useEffect(() => {
@@ -149,6 +153,8 @@ export function ResultView({ id }: ResultViewProps) {
         title={headerTitle}
         trailing={
           <>
+            {/* PR A — 홈(진단 시작 입력) 이동 버튼. 기존 헤더 아이콘과 동일 IconButton 스타일. */}
+            <IconButton icon={<Home />} ariaLabel="진단 시작 화면으로" href="/diagnosis" />
             <FavoritesMenu />
             <DeadlineBell />
             <Button


### PR DESCRIPTION
부부 결과 화면: 월세 토글 버그 수정 + 흩어진 필터를 통합 필터 바로 정돈 + 헤더 홈 버튼. (싱글은 PR B 후속)

## STEP 0 — 디자인 토큰 (코딩 전 파악)
- 색(HSL 변수): `primary`(블루)·`danger`·`ink/2/3`·`surface/surface-soft`·`card-border`·`success/info/warning`
- 폰트 Pretendard · 간격 `s-1`~`s-10`(4~64px) · 타입 title16/body-sm13/caption12
- 세그먼트 패턴(입력폼): `rounded-sm border px-s-3 py-s-1 text-body-sm font-bold` + active `border-primary bg-primary text-primary-foreground`
- 헤더: `AppHeader` `trailing` 슬롯 + `IconButton`
→ 위 토큰/패턴 그대로 사용해 "얹어진 느낌" 없이 일관.

## STEP 1 — 월세 토글 버그 수정
원인(조사 확정): ①거래유형 토글 시 직전 억-스케일 budget 이월 → 월세 필터가 월세범위(만원)로 오해석 → 전 후보 탈락→빈결과. ②빈 결과 → `inSync`(length>0)가 false → DB 원본 재로드 → dealType 롤백.

- **거래유형 변경 시 budget 리셋** (`handleDealTypeChange` → `budget: undefined`). 단위/의미가 달라 이월 무효.
- **빈 결과 롤백 차단** (`result-view` `inSync = storeId===id`). 0개 결과도 EmptyState(완화 제안)로, 원본 롤백 X.
- **예산 칩 ↔ 데이터 동기화**: `BudgetChipOptions` key에 dealType 추가 → 월세 전환 시 보증금/월세 입력으로 재마운트.

## STEP 2 — 통합 필터 바
흩어진 [거래유형 세그먼트] + [출근시간/예산 칩] + [인라인 편집]을 **하나의 카드**(`border-card-border rounded-lg bg-surface p-s-3`)로 정돈. 거래유형은 `flex-1` 균등 세그먼트(입력폼 토큰 답습). 예산 칩 항상 노출(결과에서 거래유형별 예산 설정), 인라인 편집 패널을 같은 카드 안에 배치.

## STEP 3 — 홈 버튼
헤더 `trailing` 하트 옆 `Home` IconButton → `/diagnosis`(진단 시작) 이동. 기존 아이콘 스타일 일관.

## 검증 (tsx 직접 호출, 커밋 안 함)
- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- **월세 토글**: (구) budget 이월 → **0개(빈결과·롤백)** → (신) budget 리셋 → **8개(되돌아감 없음)** ✅. 월세 표시 "보증금 2.5억 · 월 178만" 정상.
- **월세 예산 2축 필터**(보증금 5억↓/월 200만↓) 동작 ✅
- 거래유형 리셋 후 전세/매매/월세 모두 비어있지 않음 ✅
- 빈 결과(예산 빡빡) → EmptyState(롤백 X) ✅

## 유지
`refilterPool` 월세 로직(정상)·통근 캐시·4-A 배선·5단계 표시·출발시각 what-if 무변경.

## ⚠️ 검증 한계
디자인/반응형은 **앱 토큰 사용 + tsc 검증**으로 확인(이 환경 브라우저 실행 제약). 머지 후 모바일 폭에서 (1)필터 바 정렬 (2)월세 토글 정상 (3)홈 버튼 이동을 시각 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)