### PR TITLE
fix(result): 출처 배지 글씨 한 단계 더 작게(on-light 11→10px)

### DIFF
--- a/onday-app/src/components/data/data-source-badge.tsx
+++ b/onday-app/src/components/data/data-source-badge.tsx
@@ -40,12 +40,13 @@ export function DataSourceBadge({
       role="img"
       aria-label={`${KIND_LABELS[kind]}: ${source} 갱신일 ${updatedAt}`}
       className={cn(
-        "inline-flex w-fit items-center gap-1.5 text-caption-xs",
-        // on-dark(공유 hero): 기존 chip 스타일 유지. on-light(결과 화면): 보조 정보라 조용히 —
-        //   테두리·배경 제거 + ink-3(흐린 회색) + 일반 굵기로 메인 콘텐츠보다 위계 낮춤.
+        "inline-flex w-fit items-center gap-1.5",
+        // on-dark(공유 hero): 기존 chip 스타일·크기(caption-xs 11px) 유지.
+        // on-light(결과 화면): 보조 정보라 조용히 — 테두리·배경 제거 + ink-3 + 일반 굵기 +
+        //   글씨 한 단계 더 작게(10px) 위계 더 낮춤. (caption-xs 아래 토큰 없어 scoped 10px.)
         tone === "on-dark"
-          ? "rounded-sm bg-white/15 px-s-2 py-1 font-bold text-white backdrop-blur-sm"
-          : "font-medium text-ink-3",
+          ? "rounded-sm bg-white/15 px-s-2 py-1 text-caption-xs font-bold text-white backdrop-blur-sm"
+          : "text-[10px] font-medium leading-[14px] text-ink-3",
         className,
       )}
     >


### PR DESCRIPTION
## 요청
#178로 흐려진 부부 결과 출처 배지의 글씨를 **한 단계 더 작게**(다른 건 #178 그대로).

## 수정
- **on-light**: `text-caption-xs`(11px) → **`text-[10px] leading-[14px]`**. caption-xs 아래 토큰이 없어 scoped arbitrary 10px(가독 유지 수준). dot `size-1` 유지. **색·위계·배치·간격은 #178 그대로**.
- **on-dark(공유 hero)·primary·muted 무변경**: `text-caption-xs`(11px)를 on-dark 분기로 이동만 했고 렌더 동일. on-light 사용처는 결과 화면 + dev 갤러리뿐이라 영향 격리.

## 검증
- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- 인코딩 정상. 변경 1파일.
- 출처 내용·색·배치 #178 유지 — **글씨 크기만**.

## 유지 / 참고
필터 바 기능·월세 토글·홈버튼·통근 캐시 무변경. 싱글 레이어-출처 캡션(`text-caption` 12px)은 별개 요소라 무변경(원하시면 별도로 10px 매칭 가능).

## ⚠️ 검증 한계
시각/반응형은 토큰 검증으로 확인(브라우저 실행 제약). 머지 후 모바일 폭에서 출처 글씨가 한 단계 작아지되 읽히는 수준인지 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)