### PR TITLE
fix(result): 출처 배지 글씨 13px로 조정 + 부부/싱글 출처 톤 통일

### DIFF
--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -196,7 +196,7 @@ function LayerSources({
   });
 
   return (
-    <p className="mt-1 text-caption text-ink-3" aria-label="데이터 출처">
+    <p className="mt-1 text-body-sm text-ink-3" aria-label="데이터 출처">
       {parts.join(" · ")}
     </p>
   );
@@ -538,7 +538,7 @@ export function SingleResultView({ id }: SingleResultViewProps) {
             />
 
             {/* 시세 출처(provenance) — 레이어 무관 공통. 폴백 동네는 카드 "구 평균" 캡션 별도. */}
-            <p className="text-caption text-ink-3" aria-label="시세 데이터 출처">
+            <p className="text-body-sm text-ink-3" aria-label="시세 데이터 출처">
               시세: 국토교통부 실거래가 · 60~85㎡ · 2025.12~2026.06
             </p>
 

--- a/onday-app/src/components/data/data-source-badge.tsx
+++ b/onday-app/src/components/data/data-source-badge.tsx
@@ -42,11 +42,11 @@ export function DataSourceBadge({
       className={cn(
         "inline-flex w-fit items-center gap-1.5",
         // on-dark(공유 hero): 기존 chip 스타일·크기(caption-xs 11px) 유지.
-        // on-light(결과 화면): 보조 정보라 조용히 — 테두리·배경 제거 + ink-3 + 일반 굵기 +
-        //   글씨 한 단계 더 작게(10px) 위계 더 낮춤. (caption-xs 아래 토큰 없어 scoped 10px.)
+        // on-light(결과 화면): 보조 정보 — 테두리·배경 제거 + ink-3 + 일반 굵기. 위계는 색/굵기로,
+        //   크기는 body-sm(13px)로(10px는 너무 작아 13px 조정). 싱글 출처 캡션과 동일 크기.
         tone === "on-dark"
           ? "rounded-sm bg-white/15 px-s-2 py-1 text-caption-xs font-bold text-white backdrop-blur-sm"
-          : "text-[10px] font-medium leading-[14px] text-ink-3",
+          : "text-body-sm font-medium text-ink-3",
         className,
       )}
     >


### PR DESCRIPTION
## 요청
#179의 10px가 너무 작아 **13px로 조정**. (#179 머지됨 → main 분기, 새 PR)

## 수정
- **DataSourceBadge on-light**: `text-[10px]` → **`text-body-sm`**(13px/20px 기존 토큰). dot·색·위계·배치·간격 #178/#179 그대로.
- **싱글 출처 캡션 2곳** (레이어 출처 `:199`, 시세 출처 `:541`): `text-caption`(12px) → **`text-body-sm`**(13px) → **부부/싱글 출처 표기 크기 일관**.
- **on-dark(공유 hero) 무변경**(caption-xs 11px). 위계는 `ink-3`·`font-medium`로 유지(크기만 13px).

## 검증
- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- 인코딩 정상. 변경 2파일.
- 출처 내용·색·위계·배치 유지 — **글씨 크기만**.

## 유지
필터 바 기능·월세 토글·홈버튼·통근 캐시 무변경.

## ⚠️ 검증 한계
시각/반응형은 토큰 검증으로 확인(브라우저 실행 제약). 머지 후 모바일 폭에서 13px가 적당히 읽히고 부부/싱글 출처 톤이 일관된지 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)