### PR TITLE
fix(result): 출처 배지 13px 확실 적용 — text-[13px] arbitrary (twMerge 드롭 회피)

### DIFF
--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -196,7 +196,7 @@ function LayerSources({
   });
 
   return (
-    <p className="mt-1 text-body-sm text-ink-3" aria-label="데이터 출처">
+    <p className="mt-1 text-[13px] leading-[20px] text-ink-3" aria-label="데이터 출처">
       {parts.join(" · ")}
     </p>
   );
@@ -538,7 +538,7 @@ export function SingleResultView({ id }: SingleResultViewProps) {
             />
 
             {/* 시세 출처(provenance) — 레이어 무관 공통. 폴백 동네는 카드 "구 평균" 캡션 별도. */}
-            <p className="text-body-sm text-ink-3" aria-label="시세 데이터 출처">
+            <p className="text-[13px] leading-[20px] text-ink-3" aria-label="시세 데이터 출처">
               시세: 국토교통부 실거래가 · 60~85㎡ · 2025.12~2026.06
             </p>
 

--- a/onday-app/src/components/data/data-source-badge.tsx
+++ b/onday-app/src/components/data/data-source-badge.tsx
@@ -42,11 +42,12 @@ export function DataSourceBadge({
       className={cn(
         "inline-flex w-fit items-center gap-1.5",
         // on-dark(공유 hero): 기존 chip 스타일·크기(caption-xs 11px) 유지.
-        // on-light(결과 화면): 보조 정보 — 테두리·배경 제거 + ink-3 + 일반 굵기. 위계는 색/굵기로,
-        //   크기는 body-sm(13px)로(10px는 너무 작아 13px 조정). 싱글 출처 캡션과 동일 크기.
+        // on-light(결과 화면): 보조 정보 — 테두리·배경 제거 + ink-3 + 일반 굵기. 크기 13px.
+        //   ★ text-[13px](arbitrary) 사용 — 커스텀 토큰 text-body-sm 은 cn(tailwind-merge)이
+        //   text-ink-3(색)와 충돌로 오인해 드롭(→16px 회귀)함. arbitrary 는 font-size 로 인식돼 유지.
         tone === "on-dark"
           ? "rounded-sm bg-white/15 px-s-2 py-1 text-caption-xs font-bold text-white backdrop-blur-sm"
-          : "text-body-sm font-medium text-ink-3",
+          : "text-[13px] font-medium leading-[20px] text-ink-3",
         className,
       )}
     >


### PR DESCRIPTION
## 문제
#180에서 `text-body-sm`(13px 토큰)을 적용했으나 라이브가 **16px**로 렌더. 원인(조사 확정): 배지는 `cn()`(=tailwind-merge)을 거치는데, **tailwind-merge가 커스텀 토큰 `text-body-sm`을 `text-ink-3`(색)와 같은 `text-*` 그룹 충돌로 오인 → 마지막(색)만 남기고 size 드롭** → font-size 클래스 0개 → body 기본 16px 상속.

```
twMerge("text-body-sm font-medium text-ink-3") => "font-medium text-ink-3"   ← text-body-sm 드롭(버그)
twMerge("text-[13px] font-medium leading-[20px] text-ink-3") => 그대로 유지   ← 수정
```

## 수정 — (a) arbitrary 값
- **DataSourceBadge on-light**: `text-body-sm` → **`text-[13px] leading-[20px]`**. arbitrary 값은 twMerge가 font-size로 정확히 인식해 유지(#179 `text-[10px]`가 먹던 원리).
- **싱글 출처 캡션 2곳**(레이어 `:199`, 시세 `:541`): `text-body-sm` → `text-[13px] leading-[20px]`로 표기 통일(리터럴이라 원래도 13px이나 부부 배지와 동일 클래스로 정합).
- dot·색·위계·배치·간격 #178 그대로. **on-dark·`cn`/utils 무변경.**

## 검증
- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors(경고 10건 기존)
- **twMerge가 `text-[13px]` 유지** 확인(드롭 없음) → 실제 13px 렌더.
- 인코딩 정상. 변경 2파일. 부부/싱글 출처 둘 다 13px(동일 클래스).

## 후속 메모 (이번 범위 외 — 근본 수정)
근본 원인은 **`cn`(tailwind-merge)이 커스텀 fontSize 토큰(body-sm/caption/caption-xs 등)을 모르는 것** → `cn("text-{토큰} ... text-{색}")` 조합 시 size 드롭(on-dark 배지 등 앱 전반 잠복). `extendTailwindMerge`로 cn이 커스텀 토큰을 인식하게 하는 게 근본 해법이나, **공용 함수라 영향 점검 후 별도 PR** 권장.

## ⚠️ 검증 한계
시각/반응형은 twMerge 출력 + tsc 검증(브라우저 실행 제약). 머지 후 라이브에서 출처 배지가 13px로 보이는지 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)