### PR TITLE
feat(single): 결과 출근시간 변경 이식 — recomputeWhatIf 공통화(부부/싱글 일관)

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -27,11 +27,7 @@ import {
   sortCandidates,
   toChipMode,
 } from "@/features/diagnosis/result-utils";
-import {
-  estimateCommuteMinutes,
-  haversineDistance,
-  rushHourFactor,
-} from "@/lib/haversine";
+import { recomputeWhatIf } from "@/lib/diagnosis/whatif";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
 import { latLngToPixel } from "@/lib/coordinate-transform";
 import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
@@ -63,75 +59,7 @@ interface ResultContentProps {
   onShare: () => void | Promise<void>;
 }
 
-// what-if(시간/통근/예산) 재계산 — ★ 후보 재선정 대신 고정 baseline 세트를 in-place 갱신.
-//   기존 runMockDiagnosis 는 풀에서 top-N 을 다시 뽑아(mock 점수) 세트가 바뀌고 → 새 후보엔
-//   routePath/자동차 없음(버그1) + 자동차 시간 미반영(버그2). 본 함수는 세트·순위·routePath 고정,
-//   통근 '분'만 재계산해 두 버그 동시 해소.
-//   · 대중교통: estimateCommuteMinutes(거리, 출발시각) — 러시아워 계수 반영
-//   · 자동차: 실 Kakao 기준시간 × rushHourFactor (거리추정은 도로보다 짧아 부정확 → 기준값 보존)
-//   · routePath(정거장/도로선)·순위(점수)·여가는 baseline 그대로 유지, 필터만 재적용.
-function recomputeWhatIf(
-  baseline: CandidateArea[],
-  filters: DiagnosisFilters,
-  coordA: { lat: number; lng: number },
-  coordB: { lat: number; lng: number } | null | undefined,
-): CandidateArea[] {
-  const depTime = filters.commuteSchedule?.departureTime;
-  const carFactor = rushHourFactor(depTime);
-  return baseline
-    .map((c) => {
-      const distA = haversineDistance(coordA, c.coordinate);
-      const next: CandidateArea = {
-        ...c,
-        commuteA: { ...c.commuteA, time: estimateCommuteMinutes(distA, depTime) },
-      };
-      if (coordB && c.commuteB) {
-        const distB = haversineDistance(coordB, c.coordinate);
-        next.commuteB = {
-          ...c.commuteB,
-          time: estimateCommuteMinutes(distB, depTime),
-        };
-      }
-      if (c.commuteACar) {
-        next.commuteACar = {
-          ...c.commuteACar,
-          time: Math.round(c.commuteACar.time * carFactor),
-        };
-      }
-      if (c.commuteBCar) {
-        next.commuteBCar = {
-          ...c.commuteBCar,
-          time: Math.round(c.commuteBCar.time * carFactor),
-        };
-      }
-      return next;
-    })
-    .filter((c) => {
-      if (filters.maxCommuteTime) {
-        const maxC = Math.max(c.commuteA.time, c.commuteB?.time ?? 0);
-        if (maxC > filters.maxCommuteTime) return false;
-      }
-      if (filters.budget) {
-        if (filters.dealType === "wolse") {
-          // 월세 — 추정 보증금/월세로 재필터 (priceRange 는 전세 scale 라 부적합).
-          const w = c.wolseEstimate;
-          if (w) {
-            if (w.monthly > filters.budget.max) return false;
-            if (
-              filters.budget.depositMax != null &&
-              w.deposit > filters.budget.depositMax
-            ) {
-              return false;
-            }
-          }
-        } else if (c.priceRange) {
-          const avg = (c.priceRange.min + c.priceRange.max) / 2;
-          if (avg < filters.budget.min || avg > filters.budget.max) return false;
-        }
-      }
-      return true;
-    });
-}
+// what-if 재계산(출근시간 변경 시 통근 '분' 재추정)은 lib/diagnosis/whatif.ts 로 공통화(부부·싱글 공용).
 
 export function ResultContent({
   candidates,

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -38,7 +38,9 @@ import {
 import { FilterPanel } from "@/components/form/filter-panel";
 import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
 import { refilterPool } from "@/lib/diagnosis/refilter";
+import { recomputeWhatIf } from "@/lib/diagnosis/whatif";
 import { BudgetChipOptions } from "@/app/diagnosis/result/[id]/budget-chip-options";
+import { TimeChipOptions } from "@/app/diagnosis/result/[id]/time-chip-options";
 import { buildCommuteRows, buildLines } from "@/features/diagnosis/detail-mapper";
 import { latLngToPixel } from "@/lib/coordinate-transform";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
@@ -255,6 +257,16 @@ export function SingleResultView({ id }: SingleResultViewProps) {
 
   const [layer, setLayer] = React.useState<SingleLayer>("safety");
   const [showBudgetOptions, setShowBudgetOptions] = React.useState(false);
+  const [showTimeOptions, setShowTimeOptions] = React.useState(false);
+  const currentDepartureTime = filters.commuteSchedule?.departureTime ?? "08:00";
+
+  // ★ 출근시간 what-if 용 baseline — 첫 결과 1회 캡처(부부 result-content 동일). 통근 '분' 재추정 기준.
+  const baselineRef = React.useRef<CandidateArea[] | null>(null);
+  React.useEffect(() => {
+    if (baselineRef.current === null && candidates.length > 0) {
+      baselineRef.current = candidates;
+    }
+  }, [candidates]);
 
   // ★ PR B 거래유형/예산 토글 재필터(부부 result-content applyDealBudget 이식, mode="single").
   //   real: 통근 캐시 풀 재필터(통근 열화·API 0). mock/재오픈: runMockDiagnosis 재실행(전체 44, Haversine).
@@ -290,6 +302,33 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   // 예산 what-if — 금액만 조정(dealType 보존). 예산 넓히면 풀에서 새 동네 등장.
   const handleBudgetWhatIf = (min: number, max: number, depositMax?: number) => {
     void applyDealBudget({ ...filters, budget: { min, max, depositMax } });
+  };
+
+  // ★ 출근시간 변경 — 통근 '분' 재추정(recomputeWhatIf, baseline 기준). 거래유형/예산 토글(통근 캐시
+  //   재활용)과 다른 경로(출발시각이 바뀌면 통근 재계산 필요). 싱글=직장 1개라 coordB=null.
+  const handleTimeWhatIf = (time: string) => {
+    if (!coordinateA) {
+      pushToast({
+        variant: "default",
+        message: "페이지 새로고침 후 다시 시도해주세요",
+      });
+      return;
+    }
+    const newFilters: DiagnosisFilters = {
+      ...filters,
+      commuteSchedule: {
+        days: filters.commuteSchedule?.days ?? [],
+        departureTime: time,
+      },
+    };
+    setFilters(newFilters);
+    const next = recomputeWhatIf(
+      baselineRef.current ?? candidates,
+      newFilters,
+      coordinateA,
+      null,
+    );
+    setResult(id, next);
   };
 
   const sorted = React.useMemo(
@@ -596,8 +635,14 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                 </div>
               </div>
 
+              {/* 출근시간(변경 가능) + 예산 칩 — 부부 결과와 동일. 클릭 시 아래 인라인 편집. */}
               <FilterPanel
                 filters={[
+                  {
+                    label: "출근시간",
+                    value: currentDepartureTime,
+                    onClick: () => setShowTimeOptions((prev) => !prev),
+                  },
                   {
                     label: "예산",
                     value: formatBudgetFilter(filters.budget, filters.dealType),
@@ -606,10 +651,13 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                 ]}
               />
 
-              {filters.commuteSchedule?.departureTime && (
-                <p className="text-caption text-ink-3">
-                  출근 {filters.commuteSchedule.departureTime} 기준
-                </p>
+              {/* 출근시간 변경 — recomputeWhatIf 로 통근 재추정. key=재마운트(React 19). */}
+              {showTimeOptions && (
+                <TimeChipOptions
+                  key={currentDepartureTime}
+                  baseTime={currentDepartureTime}
+                  onConfirm={handleTimeWhatIf}
+                />
               )}
 
               {showBudgetOptions && (

--- a/onday-app/src/lib/diagnosis/whatif.ts
+++ b/onday-app/src/lib/diagnosis/whatif.ts
@@ -1,0 +1,77 @@
+// 출근시간(출발시각) what-if 재계산 — ★ 후보 재선정 대신 고정 baseline 세트를 in-place 갱신.
+//   거래유형/예산 토글(refilterPool, 통근 캐시 재활용)과 다른 경로 — 출발시각이 바뀌면 통근'분'이
+//   달라지므로 baseline 의 통근을 재추정한다(routePath·순위·여가는 보존, 통근 분만 재계산).
+//   · 대중교통: estimateCommuteMinutes(거리, 출발시각) — 러시아워 계수 반영
+//   · 자동차: 실 Kakao 기준시간 × rushHourFactor (거리추정은 도로보다 짧아 부정확 → 기준값 보존)
+//   부부(result-content)·싱글(single-result-view) 공용. 예산/통근 필터는 baseline 의 baked
+//   priceRange/wolseEstimate 기준(진단 시점 dealType) — what-if 의미론 유지.
+
+import {
+  estimateCommuteMinutes,
+  haversineDistance,
+  rushHourFactor,
+} from "@/lib/haversine";
+import type { CandidateArea, DiagnosisFilters } from "@/lib/types";
+
+export function recomputeWhatIf(
+  baseline: CandidateArea[],
+  filters: DiagnosisFilters,
+  coordA: { lat: number; lng: number },
+  coordB: { lat: number; lng: number } | null | undefined,
+): CandidateArea[] {
+  const depTime = filters.commuteSchedule?.departureTime;
+  const carFactor = rushHourFactor(depTime);
+  return baseline
+    .map((c) => {
+      const distA = haversineDistance(coordA, c.coordinate);
+      const next: CandidateArea = {
+        ...c,
+        commuteA: { ...c.commuteA, time: estimateCommuteMinutes(distA, depTime) },
+      };
+      if (coordB && c.commuteB) {
+        const distB = haversineDistance(coordB, c.coordinate);
+        next.commuteB = {
+          ...c.commuteB,
+          time: estimateCommuteMinutes(distB, depTime),
+        };
+      }
+      if (c.commuteACar) {
+        next.commuteACar = {
+          ...c.commuteACar,
+          time: Math.round(c.commuteACar.time * carFactor),
+        };
+      }
+      if (c.commuteBCar) {
+        next.commuteBCar = {
+          ...c.commuteBCar,
+          time: Math.round(c.commuteBCar.time * carFactor),
+        };
+      }
+      return next;
+    })
+    .filter((c) => {
+      if (filters.maxCommuteTime) {
+        const maxC = Math.max(c.commuteA.time, c.commuteB?.time ?? 0);
+        if (maxC > filters.maxCommuteTime) return false;
+      }
+      if (filters.budget) {
+        if (filters.dealType === "wolse") {
+          // 월세 — 보증금/월세로 재필터 (priceRange 는 전세 scale 라 부적합).
+          const w = c.wolseEstimate;
+          if (w) {
+            if (w.monthly > filters.budget.max) return false;
+            if (
+              filters.budget.depositMax != null &&
+              w.deposit > filters.budget.depositMax
+            ) {
+              return false;
+            }
+          }
+        } else if (c.priceRange) {
+          const avg = (c.priceRange.min + c.priceRange.max) / 2;
+          if (avg < filters.budget.min || avg > filters.budget.max) return false;
+        }
+      }
+      return true;
+    });
+}


### PR DESCRIPTION
PR B에서 거래유형/예산 토글은 옮겼으나 **출근시간 in-result 변경**은 범위 외였음 → 부부와 완전 동일하게 이식. **출근시간 + 거래유형 + 예산 셋 다 결과 페이지에서 변경 가능(부부/싱글 일관).**

## 변경
| 파일 | 내용 |
|---|---|
| `lib/diagnosis/whatif.ts` (신규) | `recomputeWhatIf` **공통화** — 부부 `result-content` 로컬 함수를 verbatim 추출(동작 동일). 출발시각 변경 시 baseline 통근 '분' 재추정(routePath·순위·여가 보존). |
| `result-content.tsx` (부부) | 로컬 `recomputeWhatIf` 제거 → whatif.ts import. 미사용 `@/lib/haversine` import 정리. **부부 시간/통근 what-if 동작 무변경**(동일 함수). |
| `single-result-view.tsx` | 출근시간 "표시" → **"변경 가능" 칩**. `baselineRef` 캡처 + `handleTimeWhatIf`(recomputeWhatIf, 싱글=직장 1개 → coordB=null) + `TimeChipOptions` 인라인. |

## 두 경로 구분 유지
- **거래유형/예산 토글** = 통근 캐시 재활용(`refilterPool`, 통근 불변) — PR B, 무변경.
- **출근시간 변경** = 통근 재계산(`recomputeWhatIf`, baseline) — 출발시각 바뀌면 통근시간 달라지므로 별도 경로.

## 검증 (tsx 직접 호출, 커밋 안 함)
- `npx tsc --noEmit` ✅ exit 0 · `npm run lint` ✅ 0 errors
- **싱글 출근시간 변경**: baseline 통근 재추정(30→34분) ✅, **commuteB 없이 안전**(commuteB undefined 유지) ✅, maxCommute 필터 정상 ✅
- **부부 회귀 0**: `recomputeWhatIf` 동일 함수로 import만 전환(2곳 사용 유지), haversine 미사용 제거.
- 기본 출근시간(08:00) 미선택 동작 유지.

## ⚠️ 검증 한계
디자인/네트워크(real)는 토큰+로직 검증(브라우저 제약). 머지 후 싱글에서 (1)출근시간 변경→결과 갱신 (2)거래유형/예산과 함께 동작 (3)부부와 일관을 시각 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)