### PR TITLE
fix(real): 통근 실시간 점선 수정 — ODsay 429 대응(동시성↓·retry/backoff·간격)

### DIFF
--- a/onday-app/src/features/diagnosis/run-real-diagnosis.ts
+++ b/onday-app/src/features/diagnosis/run-real-diagnosis.ts
@@ -73,9 +73,12 @@ async function fetchCarCommute(
 const PREFILTER_TOP_N = 12;
 const RESULT_TOP_N = 8;
 
-// ★ ODsay 초당 호출 제한(미공개) 회피 — 동네를 배치로 처리(동시 ODsay 호출 cap).
-//   Promise.all 전량 동시(~20+)는 429(Too Many Requests) 유발 → 배치 N개씩.
-const ODSAY_CONCURRENCY = 4;
+// ★ ODsay 동시 호출 제한 회피 — 동네를 배치로 처리(동시 ODsay 호출 cap).
+//   실측: 4 동시도 429(Too Many Requests) 다수 → 2 로 낮춤(2 동시 + 간격이 최저 429율).
+//   동네 fn 내부는 A→B 순차라 실 동시 ODsay = 최대 limit 개.
+const ODSAY_CONCURRENCY = 2;
+// 배치 사이 간격 — ODsay 순간 동시성 429 완화(실측: spacing 시 429 급감).
+const ODSAY_BATCH_DELAY_MS = 250;
 
 async function mapWithConcurrency<T, R>(
   items: T[],
@@ -86,6 +89,10 @@ async function mapWithConcurrency<T, R>(
   for (let i = 0; i < items.length; i += limit) {
     const batch = items.slice(i, i + limit);
     results.push(...(await Promise.all(batch.map(fn))));
+    // 마지막 배치 뒤에는 대기 불필요.
+    if (i + limit < items.length) {
+      await new Promise((r) => setTimeout(r, ODSAY_BATCH_DELAY_MS));
+    }
   }
   return results;
 }

--- a/onday-app/src/lib/external/odsay-transit/client.ts
+++ b/onday-app/src/lib/external/odsay-transit/client.ts
@@ -8,6 +8,15 @@ import type {
 import { DEFAULT_ODSAY_CONFIG, OdsayTransitError } from "./types";
 import { mapOdsayResponseToCommuteInfo } from "./mapper";
 
+// ODsay 429(Too Many Requests)는 HTTP 200 + 본문 error 로 온다. error 형태가
+// 객체({code,message}) 또는 배열([{code}]) 둘 다 관측됨 → 런타임에서 양쪽 방어.
+function isRateLimited(res: OdsayTransitResponse): boolean {
+  const err = res.error as unknown;
+  if (!err) return false;
+  const first = Array.isArray(err) ? err[0] : err;
+  return String((first as { code?: unknown } | undefined)?.code) === "429";
+}
+
 /**
  * ODsay 대중교통 길찾기 클라이언트 — 브라우저 직접 호출 (#33 QRY-DIAG-002 / #30 timeout).
  * ★ B2 아키텍처: runRealDiagnosis(클라)가 동네별로 1회씩 호출 (Vercel 함수/10초 무관).
@@ -46,7 +55,14 @@ export class OdsayTransitClient implements IOdsayTransitClient {
       } catch (err) {
         lastError = err;
         if (attempt < this.config.maxRetries) {
-          await new Promise((r) => setTimeout(r, this.config.retryDelayMs));
+          // ★ 429(rate limit)는 지수 backoff(혼잡 완화) — 600→1200→2400ms.
+          //   그 외 에러(타임아웃·네트워크·HTTP)는 기존 고정 지연 유지.
+          const isRateLimit =
+            err instanceof OdsayTransitError && err.code === "429";
+          const delay = isRateLimit
+            ? this.config.retryDelayMs * 2 ** attempt
+            : this.config.retryDelayMs;
+          await new Promise((r) => setTimeout(r, delay));
         }
       }
     }
@@ -72,9 +88,15 @@ export class OdsayTransitClient implements IOdsayTransitClient {
     try {
       const res = await fetch(url.toString(), { signal: controller.signal });
       if (!res.ok) {
-        throw new OdsayTransitError(`ODsay HTTP ${res.status}`);
+        throw new OdsayTransitError(`ODsay HTTP ${res.status}`, String(res.status));
       }
-      return (await res.json()) as OdsayTransitResponse;
+      const data = (await res.json()) as OdsayTransitResponse;
+      // ★ ODsay 429 는 HTTP 200 본문으로 옴({"error":{"code":"429"}}) → 여기서 throw 해야
+      //   fetchWithRetry 의 backoff 재시도에 진입한다. (error 형태: 객체 또는 배열 둘 다 방어.)
+      if (isRateLimited(data)) {
+        throw new OdsayTransitError("ODsay 429 Too Many Requests", "429");
+      }
+      return data;
     } finally {
       clearTimeout(timer);
     }

--- a/onday-app/src/lib/external/odsay-transit/types.ts
+++ b/onday-app/src/lib/external/odsay-transit/types.ts
@@ -54,8 +54,10 @@ export interface OdsayTransitClientConfig {
 export const DEFAULT_ODSAY_CONFIG: Omit<OdsayTransitClientConfig, "apiKey"> = {
   baseUrl: "https://api.odsay.com/v1/api",
   timeoutMs: 5000, // REQ-FUNC-007 정합 (단일 호출 — B2 라 함수당 1회)
-  maxRetries: 1,
-  retryDelayMs: 500,
+  // ★ 429(Too Many Requests) 대응 — ODsay 동시호출 한계가 낮아 재시도 필수.
+  //   429 는 지수 backoff(600→1200→2400ms)로, 그 외 에러는 retryDelayMs 고정(client.ts).
+  maxRetries: 3,
+  retryDelayMs: 600,
 };
 
 export interface IOdsayTransitClient {


### PR DESCRIPTION
> ⚠️ **Stacked PR** — base = `feat/odsay-browser-direct`(#184, ODsay 브라우저 직접 전환). #184 머지 후 base를 `main`으로 바꾸거나 #184 머지 뒤 리베이스 하세요. 단독 머지 금지.

## 문제
`USE_MOCK=false`(통근 실시간) 전환 후 지도 대중교통 경로가 **점선**으로 나옴 — 배우자(B) 주로, 가끔 A·B 둘 다. 자차(카카오)는 실선 정상.

## 근본 원인 (실측 확정)
- 점선 = `routePath` 부재(`result-content.tsx:281-302`). `routePath` 는 ODsay 실패 시 Haversine fallback(`estimateTransit`)이라 안 채워짐 → **점선 + 시간도 추정**.
- ODsay가 **동시 호출을 강하게 rate-limit** → `{"error":{"code":"429"}}`.
- ★ 그 429가 **HTTP 200 본문**으로 옴 → `client.ts` `if(!res.ok)`(HTTP 검사) 통과 → `fetchOnce` 가 정상 반환 → **`fetchWithRetry` 재시도 안 함**(throw는 mapper에서, retry 루프 바깥) → `maxRetries=1` 무용 → 즉시 fallback → 점선.
- B가 A보다 **나중에 호출**(동네 fn 내 `A→B` 순차)돼 throttle 창에 더 자주 걸림 → "B 주로, 가끔 둘 다".
- 실측: 24동시 → **19/24 429**, 4동시도 429. 간격 두면 성공. polyline 추출(mapper)·자차는 정상(원인 아님).

## 수정 (셋 다)
1. **동시성 ↓** — `ODSAY_CONCURRENCY` 4 → **2** (`run-real-diagnosis.ts`). 실측상 2가 최저 429율(2:5/24, 3:11/24, 4:다수).
2. **배치 간격** — `mapWithConcurrency` 배치 사이 **250ms** delay(마지막 배치 제외).
3. **★ 429 retry 살리기** (`client.ts`) — `fetchOnce` 응답 파싱 직후 `isRateLimited(data)`(error 객체/배열 둘 다 방어) 감지 시 `OdsayTransitError(code="429")` **throw** → `fetchWithRetry` 재시도 진입. 429는 **지수 backoff(600→1200→2400ms)**, `maxRetries` 1→3(`types.ts`). 그 외 에러는 기존 고정 지연 유지.

## 검증 (로컬, Web 키 실호출)
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ 0 errors (10 warnings = 기존·무관).
- **수정 전**: 24동시 19/24 429, 4동시도 429 → 점선 다수.
- **수정 후 시뮬**(conc2 + 250ms 간격 + retry/backoff, 실 ODsay 호출): **24/24 SOLID, fallback 0**.
- **★ retry 작동 입증**: ODsay throttle 중 시작 → `first429=2` → **retry 4회 fired → 2건이 retry로 SOLID 복구** → 24/24 solid, 0 fallback. (pre-fix면 그 2건 즉시 점선·추정.)
- **체감 시간**: 부부(24 ODsay) 통근 풀 빌드 ~8–9s (conc2 + 간격 비용). 로딩 UI 있음·토글은 캐시 재사용(재호출 0)이라 1회성. 더 빠르게가 필요하면 conc 2↔3 조율 가능(단 3은 429↑ → retry 지연으로 net 이득 작음).
- **정직성**: 끝까지 429면 Haversine fallback 유지(크래시 X). 그 경우 점선=추정시간이 맞고, fallback은 routePath 미설정 + 추정 시간 유지(거짓 실데이터 표기 없음).

## 유지(무변경)
polyline 추출(`mapper.ts`) · 자차(카카오) · 통근 캐싱(`refilterPool` 12풀) · 토글 · 시세 · 안전 · fallback 안전망 자체(발동 빈도만 감소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)