### PR TITLE
feat(naver): 죽은 매물 링크 → new.land 좌표 기반 교체 + 거래유형 정교화

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -641,12 +641,10 @@ export function ResultContent({
               ? `매물 ${selectedCandidate.listingsCount}건 보기`
               : "매물 보기",
             onClick: () => {
-              const url = buildNaverRealEstateUrl(
-                `${selectedCandidate.gu} ${selectedCandidate.dong}`,
-                selectedCandidate.priceRange
-                  ? { priceMax: selectedCandidate.priceRange.max }
-                  : {},
-              );
+              // 좌표 기반 new.land + 거래유형(토글 후 filters.dealType, 기본 전세). 매물종류=APT.
+              const url = buildNaverRealEstateUrl(selectedCandidate.coordinate, {
+                dealType: filters.dealType ?? "jeonse",
+              });
               window.open(url, "_blank", "noopener,noreferrer");
             },
           }}

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -803,12 +803,10 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                     ? `매물 ${selectedCandidate.listingsCount}건 보기`
                     : "매물 보기",
                   onClick: () => {
+                    // 좌표 기반 new.land + 거래유형(월세=B2 포함, 기본 전세). 매물종류=APT.
                     const url = buildNaverRealEstateUrl(
-                      `${selectedCandidate.gu} ${selectedCandidate.dong}`,
-                      // 월세는 priceRange(전세 scale)를 가격 상한으로 쓰면 오값 → 생략(사용자가 네이버에서 월세 필터).
-                      dealType === "wolse" || !selectedCandidate.priceRange
-                        ? {}
-                        : { priceMax: selectedCandidate.priceRange.max },
+                      selectedCandidate.coordinate,
+                      { dealType: dealType ?? "jeonse" },
                     );
                     window.open(url, "_blank", "noopener,noreferrer");
                   },

--- a/onday-app/src/components/deadline/listing-card.tsx
+++ b/onday-app/src/components/deadline/listing-card.tsx
@@ -17,7 +17,11 @@ interface ListingCardProps {
 }
 
 export function ListingCard({ listing }: ListingCardProps) {
-  const url = buildNaverRealEstateUrl(listing.areaName, { roomType: "apartment" });
+  // 좌표 기반 new.land + 거래유형(매매/전세 → A1/B1) + 아파트.
+  const url = buildNaverRealEstateUrl(listing.coordinate, {
+    dealType: listing.dealType === "매매" ? "maemae" : "jeonse",
+    roomType: "apartment",
+  });
   // 좌표 최근접 초등학교 (PR1 사전계산). 없으면 학교 줄 미렌더 (빈 값/에러 표시 금지).
   const school = getNearestSchool(listing.neighborhoodId);
 

--- a/onday-app/src/components/favorites/favorites-menu.tsx
+++ b/onday-app/src/components/favorites/favorites-menu.tsx
@@ -163,21 +163,20 @@ export function FavoritesMenu() {
                     </p>
                   </div>
 
-                  <a
-                    href={buildNaverRealEstateUrl(
-                      `${it.gu} ${it.dong}`,
-                      // 월세는 priceRange(전세 scale)를 가격 상한으로 쓰면 오값 → 생략.
-                      it.dealType === "wolse" || !it.priceRange
-                        ? {}
-                        : { priceMax: it.priceRange.max },
-                    )}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`${it.gu} ${it.dong} 매물 보기`}
-                    className="inline-flex size-9 shrink-0 items-center justify-center rounded-sm text-ink-3 hover:text-ink"
-                  >
-                    <ExternalLink aria-hidden className="size-4" />
-                  </a>
+                  {/* 좌표 기반 new.land + 거래유형(기본 전세). 레거시 스냅샷(좌표 미보유)은 링크 생략. */}
+                  {it.coordinate && (
+                    <a
+                      href={buildNaverRealEstateUrl(it.coordinate, {
+                        dealType: it.dealType ?? "jeonse",
+                      })}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`${it.gu} ${it.dong} 매물 보기`}
+                      className="inline-flex size-9 shrink-0 items-center justify-center rounded-sm text-ink-3 hover:text-ink"
+                    >
+                      <ExternalLink aria-hidden className="size-4" />
+                    </a>
+                  )}
                   <button
                     type="button"
                     onClick={() => remove(it.id)}

--- a/onday-app/src/lib/deadline/naver-url-builder.ts
+++ b/onday-app/src/lib/deadline/naver-url-builder.ts
@@ -1,21 +1,47 @@
-import type { ListingFilters } from "@/lib/types/deadline";
+import type { Coordinate, DealType } from "@/lib/types";
+import type { RoomType } from "@/lib/types/deadline";
 
-// QRY-DL-001 / CMD-DL-002 — 네이버 부동산 검색 아웃링크 URL 조합 (단일 수정점).
-// 자체 매물 DB 없이 조건을 URL 파라미터로 위임 (REQ-FUNC-016).
-// 네이버 부동산 검색 URL 스펙은 비공식이라 본 함수를 단일 변경점으로 둔다 (스펙 변경 시 여기만 수정).
-const NAVER_LAND_BASE = "https://land.naver.com/";
+// QRY-DL-001 / CMD-DL-002 — 네이버 부동산 아웃링크 URL 조합 (단일 수정점, REQ-FUNC-016).
+// ★ 구 land.naver.com/?query= 는 동작 안 함(403→포털 홈, 파라미터 무시) → 좌표 기반 new.land 로 교체.
+//   형식: new.land.naver.com/complexes?ms={lat},{lng},{zoom}&a={매물종류}&b={거래유형}&e=RETAIL
+//   - ms = 지도중심 좌표+줌 (법정동코드 불필요 → 폴백 동네 포함 전 동네 커버)
+//   - a  = 매물종류 (APT/OPST/VL), 미지정 = APT
+//   - b  = 거래유형 (매매=A1 / 전세=B1 / 월세=B2), 미지정 시 생략
+//   - e  = RETAIL (네이버 고정 카테고리)
+//   가격·면적은 new.land URL 스킴에 없음(내부 API 전용) → 싣지 않는다(거짓 param 금지).
+const NAVER_LAND_BASE = "https://new.land.naver.com/complexes";
+const NAVER_MAP_ZOOM = 16;
+
+// 거래유형 → 네이버 b= 코드.
+const NAVER_TRADE_CODE: Record<DealType, string> = {
+  maemae: "A1",
+  jeonse: "B1",
+  wolse: "B2",
+};
+
+// 매물종류 → 네이버 a= 코드. all/미지정 = APT (우리 시세·면적이 아파트 60~85㎡ 실거래 기준).
+const NAVER_ARTICLE_CODE: Record<RoomType, string> = {
+  apartment: "APT",
+  officetel: "OPST",
+  villa: "VL",
+  all: "APT",
+};
+
+export interface NaverRealEstateOptions {
+  dealType?: DealType; // 거래유형 → b= (미지정 시 b 생략)
+  roomType?: RoomType; // 매물종류 → a= (기본 APT)
+}
 
 export function buildNaverRealEstateUrl(
-  area: string,
-  filters: ListingFilters = {},
+  coordinate: Coordinate,
+  options: NaverRealEstateOptions = {},
 ): string {
-  const params = new URLSearchParams({ query: area });
-  if (filters.priceMin != null) params.set("priceMin", String(filters.priceMin));
-  if (filters.priceMax != null) params.set("priceMax", String(filters.priceMax));
-  if (filters.roomType && filters.roomType !== "all") {
-    params.set("type", filters.roomType);
-  }
-  return `${NAVER_LAND_BASE}?${params.toString()}`;
+  const { lat, lng } = coordinate;
+  const article = NAVER_ARTICLE_CODE[options.roomType ?? "apartment"];
+  const trade = options.dealType ? NAVER_TRADE_CODE[options.dealType] : null;
+  // 좌표(숫자)·코드(ASCII) 모두 인코딩 불필요 → 수동 조립으로 ms 콤마를 리터럴 유지(네이버 정규 형식).
+  const tradeParam = trade ? `&b=${trade}` : "";
+  return `${NAVER_LAND_BASE}?ms=${lat},${lng},${NAVER_MAP_ZOOM}&a=${article}${tradeParam}&e=RETAIL`;
 }
 
 // 학군 PR2 — 인근 초등학교명 → 네이버 통합검색 아웃링크.

--- a/onday-app/src/stores/favorites.ts
+++ b/onday-app/src/stores/favorites.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from "zustand/middleware";
 
 import type {
   CandidateArea,
+  Coordinate,
   DealType,
   DiagnosisMode,
   SafetyGrade,
@@ -17,6 +18,8 @@ export interface FavoriteItem {
   id: string;
   gu: string;
   dong: string;
+  // 네이버 부동산 좌표 기반 아웃링크용 — 레거시 스냅샷은 미보유(optional) → 링크만 생략.
+  coordinate?: Coordinate;
   score: number;
   /** 싱글=야간안전 등급(resolveGrade). 부부는 없을 수 있음 → 목록은 점수로 fallback. */
   safetyGrade?: SafetyGrade;
@@ -44,6 +47,7 @@ export function toFavoriteSnapshot(
     id: c.id,
     gu: c.gu,
     dong: c.dong,
+    coordinate: c.coordinate,
     score: c.score,
     // grade===null = no_data(준비중) → mock 폴백 금지(#59), 배지 없이 점수 표시.
     //   grade 미전달(undefined, 부부)만 후보 mock 등급으로 폴백(레거시 유지).


### PR DESCRIPTION
## 목표
결과/찜/데드라인의 네이버 부동산 아웃링크가 **작동하지 않던 죽은 URL**(`land.naver.com/?query=` → 403 → 포털 홈, 파라미터 전부 무시)이었음. 좌표 기반 `new.land.naver.com/complexes` 로 교체하고 거래유형·매물종류를 URL에 실어 정교화.

## ★ STEP 0 — URL 스펙 실측 결과 (정직 보고)
⚠️ **이 샌드박스엔 JS 실행 브라우저가 없어 "실제 클릭 렌더" 테스트는 못 했습니다.** 대신 웹 리서치(네이버 정규 share URL)로 파라미터를 확정했습니다.

| 파라미터 | 확정도 | 근거 |
|---|---|---|
| `ms={lat},{lng},{zoom}` (지도중심) | ✅ 확정 | 정규 share URL |
| `a=APT/OPST/VL` (매물종류) | ✅ 확정 | 정규 share URL |
| `b=A1/B1/B2` (**거래유형** 매매/전세/월세) | ✅ 확정 | 1차 소스 `…/complexes/8928?ms=…&a=APT&b=A1&e=RETAIL` |
| `e=RETAIL` (고정 카테고리) | ✅ 확정 | 정규 share URL |
| **가격/면적** param | ❌ **URL 스킴에 없음** (내부 API 전용) → **생략** | 거짓 param 금지 원칙 |

- ★ 스펙 정정: 거래유형은 spec의 `e=` 가 아니라 **`b=`** 입니다 (`e=RETAIL`은 고정값).
- 라우팅 리스크: 1차 소스 예시는 `/complexes/{id}` (특정 단지)였는데 우리는 단지 ID가 없어 `/complexes?ms=…`(지도 브라우즈) 사용. `new.land.naver.com/` 가 `/complexes` 로 301하므로 `/complexes` 는 유효 라우트이고, curl이 `/404`로 튕기는 건 **anti-bot(쿠키·JS 없음)** 으로 판단. **단, 실 브라우저 렌더 확인은 아래 검증 필요.**

## 생성 URL 예시
```
부부 전세:  https://new.land.naver.com/complexes?ms=37.4979,127.0276,16&a=APT&b=B1&e=RETAIL
부부 매매:  …&b=A1&e=RETAIL
싱글 월세:  …&b=B2&e=RETAIL
데드라인:   …&a=APT&b=A1&e=RETAIL
```

## 변경
- **`naver-url-builder.ts`** (단일 변경점): `area(텍스트)` → `coordinate{lat,lng}` + `{dealType, roomType}`. 거래유형→`b=`, 매물종류→`a=`, `ms=`좌표+줌16. 가격 생략.
- **호출처 4곳**: `result-content`(부부) · `single-result-view`(싱글) · `favorites-menu`(찜) · `deadline/listing-card`(급매).
  - ★ 찜 스냅샷(`FavoriteItem`)에 `coordinate` 미보유였음 → `toFavoriteSnapshot`에 `c.coordinate` 추가(optional). 레거시 스냅샷(좌표 없음)은 링크만 생략(깨진 링크 방지).
  - ★ Phase 0 조사에선 호출처 3곳이라 했으나 **tsc가 4번째(찜)를 잡아냄** → 함께 수정.

## 검증
- `npx tsc --noEmit` ✅ (4번째 호출처도 컴파일 통과)
- `npm run lint` ✅ 0 errors (10 warnings = 기존·무관)
- 폴백 동네 포함 전 동네 좌표 보유 → 항상 정확한 위치. 예산 미입력시 가격 param 없음(원래 안 실음). 거래유형 토글→`b=` 자동 반영.

## ⚠️ 머지 전 필수 — 사용자 브라우저 클릭 검증
샌드박스 한계로 **실제 지도 렌더는 미검증**입니다. dev 서버에서 부부/싱글/데드라인 각 "매물 보기" 클릭 →
1. 그 동네 좌표로 지도 센터링되는지
2. 거래유형 필터(전세/매매/월세)가 적용되는지 (전세→매매 토글 시 `b=` 바뀌는지)
3. `/complexes?ms=…` 가 404 없이 지도 앱으로 뜨는지

만약 `/complexes?ms=`(단지 ID 없는 브라우즈)가 실 브라우저에서도 404면, 빌더 1파일만 조정하면 됩니다(예: `m.land.naver.com` 모바일 딥링크 검토).

## 무변경
통근/시세/안전/캐싱/토글 · `buildSchoolSearchUrl`(학교 검색).

🤖 Generated with [Claude Code](https://claude.com/claude-code)