### PR TITLE
feat(insight): 동네 하루 미리보기 Phase 1 — Gemini 인프라 (Vercel AI SDK)

### DIFF
--- a/onday-app/.env.example
+++ b/onday-app/.env.example
@@ -25,9 +25,12 @@ NEXT_PUBLIC_ODSAY_API_KEY=
 # (구) Server key — /api/commute 프록시 폐지로 미사용. 레거시 참고용.
 # ODSAY_API_KEY=
 
-# AI
+# === AI (동네 하루 미리보기 — SRS CON-13/14: Vercel AI SDK + Gemini) ===
+# 동네별 AI 인사이트 생성(/api/insight). ★ 서버 전용 — NEXT_PUBLIC 아님(키 노출 금지).
 AI_PROVIDER=google
 GOOGLE_GENERATIVE_AI_API_KEY=
+# CON-14 — env 만으로 모델 교체. 미설정 시 비용 효율 gemini-2.0-flash 기본.
+# GEMINI_MODEL=gemini-2.0-flash
 
 # App
 # NEXT_PUBLIC_USE_MOCK=true → 진단/주소/auth 전부 mock (기본).

--- a/onday-app/package-lock.json
+++ b/onday-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@ai-sdk/google": "^3.0.80",
         "@base-ui/react": "^1.4.1",
         "@prisma/adapter-pg": "^7.8.0",
         "@sentry/nextjs": "^10.53.1",
@@ -16,6 +17,7 @@
         "@supabase/supabase-js": "^2.105.4",
         "@tanstack/react-query": "^5.100.6",
         "@vercel/speed-insights": "^2.0.0",
+        "ai": "^6.0.197",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -55,6 +57,68 @@
         "typescript": "^5",
         "vitest": "^4.1.6",
         "xlsx": "^0.18.5"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.125",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.125.tgz",
+      "integrity": "sha512-tocl7cUDoTpmhZqeW8XVKMMznZQwwQAEunF0VyNKmf64qt8NbMIAEiet/vRMzh7Jr9WcFeb6EZjmhLTP4Qx2Og==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.80.tgz",
+      "integrity": "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4778,7 +4842,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -5757,6 +5820,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vercel/speed-insights": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
@@ -6173,6 +6245,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.197",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.197.tgz",
+      "integrity": "sha512-U3KsjkqwQXGHC0u0VeUDqUaNaBS/uQc7v4Vj92Cjv5lPx5DIyRBQYk4Hipy5vwD9AQKIG8uRvdaN9R+pAvrtcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.125",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -10325,6 +10415,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",

--- a/onday-app/package.json
+++ b/onday-app/package.json
@@ -21,6 +21,7 @@
     "build:price": "npx tsx scripts/build-price-index.ts"
   },
   "dependencies": {
+    "@ai-sdk/google": "^3.0.80",
     "@base-ui/react": "^1.4.1",
     "@prisma/adapter-pg": "^7.8.0",
     "@sentry/nextjs": "^10.53.1",
@@ -28,6 +29,7 @@
     "@supabase/supabase-js": "^2.105.4",
     "@tanstack/react-query": "^5.100.6",
     "@vercel/speed-insights": "^2.0.0",
+    "ai": "^6.0.197",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/onday-app/src/app/api/insight/route.ts
+++ b/onday-app/src/app/api/insight/route.ts
@@ -11,7 +11,8 @@ export const maxDuration = 10;
 
 const API_KEY = process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "";
 // CON-14 — 모델은 env 만으로 교체 가능. 미설정 시 비용 효율 Flash 기본.
-const MODEL_ID = process.env.GEMINI_MODEL ?? "gemini-2.0-flash";
+// ★ gemini-2.0-flash 는 free tier 쿼터 0(limit:0)인 키가 있어 2.5-flash 기본(무료 동작 확인).
+const MODEL_ID = process.env.GEMINI_MODEL ?? "gemini-2.5-flash";
 
 // POST /api/insight  { dong: string }  → { insight: string }
 export async function POST(request: Request) {
@@ -40,6 +41,8 @@ export async function POST(request: Request) {
       model: google(MODEL_ID),
       // ★ Phase 1 최소 프롬프트 — 실제 동선 데이터는 Phase 2~3 에서 주입. 거짓 수치 방지 가드만.
       prompt: `"${dong}" 동네에 사는 하루를 한 문장으로 친근하게 묘사해줘. 추측성 구체 수치나 사실은 넣지 말고 분위기만.`,
+      // ★ thinking 비활성 — 한 문장 인사이트엔 추론 불필요, 지연만 늘어 Vercel 10초 한도 위협.
+      providerOptions: { google: { thinkingConfig: { thinkingBudget: 0 } } },
     });
     return NextResponse.json({ insight: text });
   } catch (error) {

--- a/onday-app/src/app/api/insight/route.ts
+++ b/onday-app/src/app/api/insight/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { generateText } from "ai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+
+// 동네 하루 미리보기 — Gemini 인사이트 (SRS CON-13/14: Vercel AI SDK + Gemini, env 모델 교체).
+// ★ Phase 1 = 인프라 + 최소 동작 확인만. 실제 동선 데이터(통근/여가/야간) 주입·프롬프트·UI 는 후속 Phase.
+// ★ 서버 전용 키 — GOOGLE_GENERATIVE_AI_API_KEY (NEXT_PUBLIC 아님: 키 브라우저 노출 금지).
+export const dynamic = "force-dynamic";
+// CLAUDE.md §3 — Vercel 무료 함수 10초 한도. 짧은 프롬프트 단발 호출로 회피(스트리밍은 Phase 3 UI 검토).
+export const maxDuration = 10;
+
+const API_KEY = process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "";
+// CON-14 — 모델은 env 만으로 교체 가능. 미설정 시 비용 효율 Flash 기본.
+const MODEL_ID = process.env.GEMINI_MODEL ?? "gemini-2.0-flash";
+
+// POST /api/insight  { dong: string }  → { insight: string }
+export async function POST(request: Request) {
+  // 키 없음 → graceful 503 (크래시 X — ODsay fallback 정신과 동일, 호출처가 안내/생략 처리).
+  if (!API_KEY) {
+    return NextResponse.json(
+      { error: "AI 키가 설정되지 않았습니다 (GOOGLE_GENERATIVE_AI_API_KEY)" },
+      { status: 503 },
+    );
+  }
+
+  let dong = "";
+  try {
+    const body = await request.json();
+    dong = typeof body?.dong === "string" ? body.dong.trim() : "";
+  } catch {
+    return NextResponse.json({ error: "잘못된 요청입니다" }, { status: 400 });
+  }
+  if (!dong) {
+    return NextResponse.json({ error: "dong 이 필요합니다" }, { status: 400 });
+  }
+
+  try {
+    const google = createGoogleGenerativeAI({ apiKey: API_KEY });
+    const { text } = await generateText({
+      model: google(MODEL_ID),
+      // ★ Phase 1 최소 프롬프트 — 실제 동선 데이터는 Phase 2~3 에서 주입. 거짓 수치 방지 가드만.
+      prompt: `"${dong}" 동네에 사는 하루를 한 문장으로 친근하게 묘사해줘. 추측성 구체 수치나 사실은 넣지 말고 분위기만.`,
+    });
+    return NextResponse.json({ insight: text });
+  } catch (error) {
+    // Gemini 실패/타임아웃/쿼터 → graceful 502 (크래시 X).
+    console.error("[API] POST /api/insight error:", error);
+    return NextResponse.json(
+      { error: "인사이트 생성에 실패했습니다" },
+      { status: 502 },
+    );
+  }
+}


### PR DESCRIPTION
## 목표
"동네 하루 미리보기" AI 스토리 기능의 **Gemini 연동 토대**. SRS **CON-13/14**(Vercel AI SDK + Google Gemini, env 모델 교체) 준수. **4단계 중 1단계(인프라만)** — 데이터 추출·프롬프트·UI 는 후속 Phase 2~4.

## 변경
- **패키지**: `ai@6.0.197` + `@ai-sdk/google@3.0.80` 신규 설치 (기존 AI 패키지 전무 → 0부터).
- **`/api/insight` (POST) Route Handler 신설**: `{ dong }` → `{ insight }`. Gemini Flash 단발 호출.
- **모델 env 교체** (CON-14): `GEMINI_MODEL` (미설정 시 `gemini-2.0-flash`).
- **★ 서버 전용 키**: `GOOGLE_GENERATIVE_AI_API_KEY` — `NEXT_PUBLIC` **아님**(키 브라우저 노출 금지).
- **★ graceful 에러 핸들링** (크래시 X — ODsay fallback 정신): 키없음 `503` / 잘못된 요청·`dong` 누락 `400` / Gemini 실패·타임아웃·쿼터 `502`.
- `maxDuration=10` (CLAUDE.md §3 — Vercel 무료 10초, 짧은 프롬프트 단발로 회피).
- `.env.example` AI 섹션 정합(`GEMINI_MODEL` 주석 + 서버 전용 명시).

## 검증 (로컬)
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ 0 errors (10 warnings = 기존·무관).
- 패키지 설치·빌드 통과 ✅.
- **graceful 동작 전수 확인 (크래시 0)**:

| 케이스 | 결과 |
|---|---|
| 키 없음 | `503` graceful ✅ |
| 유효 dong + 무효 키(Gemini 도달 후 실패) | **`502` graceful** ✅ (호출 경로 정상 배선 입증) |
| 잘못된 JSON 본문 | `400` ✅ |
| `dong` 누락 | `400` ✅ |

- 실제 Gemini 응답(해피패스)은 **실 키 필요** → 사용자가 `GOOGLE_GENERATIVE_AI_API_KEY` 주입 후 확인. (무효 키가 Gemini API까지 도달해 502로 떨어진 것으로 배선은 검증됨.)
- 모델 env 교체 구조 ✅ (`GEMINI_MODEL`).
- 서버 전용 키 ✅ (`NEXT_PUBLIC` 미사용).

## 후속 (이번 범위 밖)
- **Phase 2**: `CandidateArea`에서 3시간대(출근 통근·여가 거점·야간 안전+편의) 데이터 추출 헬퍼. (선택) ODsay mapper 확장 — 현재 버려지는 출발역 이름 캡처.
- **Phase 3**: 실제 동선 데이터 주입 프롬프트(시간대별 스토리). 거짓 수치 금지.
- **Phase 4**: DetailSheet "하루 미리보기" 섹션 UI(싱글 우선, 부부는 여가 생략).

## 무변경
통근/시세/안전/네이버링크/캐싱 · UI · 데이터 추출(후속 Phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)