### PR TITLE
feat(insight): 동네 하루 미리보기 Phase 2 — 3시간대 데이터 추출 헬퍼

### DIFF
--- a/onday-app/src/lib/external/odsay-transit/mapper.ts
+++ b/onday-app/src/lib/external/odsay-transit/mapper.ts
@@ -37,7 +37,8 @@ export function mapOdsayResponseToCommuteInfo(
     throw new OdsayTransitError("ODsay: 대중교통 경로 없음");
   }
 
-  const { totalTime, subwayTransitCount, busTransitCount } = path.info;
+  const { totalTime, subwayTransitCount, busTransitCount, firstStartStation } =
+    path.info;
   const transfers = Math.max(0, subwayTransitCount + busTransitCount - 1);
   const stationPath = extractStationPath(path);
 
@@ -47,6 +48,8 @@ export function mapOdsayResponseToCommuteInfo(
     transfers,
     // A-3 — 거쳐가는 정거장 좌표 (2개 이상일 때만). 출발·도착 연결은 화면단에서 보강.
     ...(stationPath.length >= 2 ? { routePath: stationPath } : {}),
+    // 하루 미리보기 — 첫 탑승역 이름(있을 때만, 거짓값 금지). 기존 로직 무영향(필드 추가만).
+    ...(firstStartStation ? { departureStation: firstStartStation } : {}),
     // totalWalk / payment 는 현재 CommuteInfo 미보유 — 정보 손실 수용 (차후 모델 확장 시).
   } satisfies CommuteInfo;
 }

--- a/onday-app/src/lib/external/odsay-transit/types.ts
+++ b/onday-app/src/lib/external/odsay-transit/types.ts
@@ -19,6 +19,7 @@ export interface OdsayPathInfo {
   payment: number; // 총 요금
   busTransitCount: number; // 버스 환승 카운트
   subwayTransitCount: number; // 지하철 환승 카운트
+  firstStartStation?: string; // 첫 탑승역 이름 (하루 미리보기 출발역용, 없을 수 있음)
 }
 
 /** subPath[].passStopList.stations[] — 거쳐가는 정거장 좌표 (x=lng, y=lat). */

--- a/onday-app/src/lib/insight/extract-day-data.ts
+++ b/onday-app/src/lib/insight/extract-day-data.ts
@@ -1,0 +1,75 @@
+import type {
+  CandidateArea,
+  CommuteInfo,
+  DiagnosisMode,
+  SafetyGrade,
+} from "@/lib/types";
+
+// 동네 하루 미리보기 (Phase 2) — CandidateArea 에서 3시간대(출근/여가/야간) 스토리 재료 추출.
+// ★ 외부 API 없음, 기존 데이터 구조화만. 없는 필드는 null/생략 — 거짓값 금지(채우지 않음).
+//   프롬프트(Phase 3)·UI(Phase 4)는 본 구조만 소비. 통근/캐싱/점수 로직과 무관.
+
+/** 한 구간(출근/여가) 통근 재료 — 있는 값만 채움. */
+export interface DayCommuteSlot {
+  time: number; // 분
+  transfers?: number; // 환승 횟수 (있을 때만)
+  departureStation?: string; // 첫 탑승역 이름 (ODsay 실데이터 있을 때만)
+}
+
+/** 야간 시간대 재료 — 없는 값은 생략. */
+export interface DayNight {
+  grade?: SafetyGrade; // 야간 치안 등급 A~D (no_data·부재 시 생략)
+  convenience?: number; // 편의점 밀집도
+  cafes?: number; // 카페 밀집도
+}
+
+/** 동네 하루 미리보기 데이터 — 3시간대(출근/여가/야간). */
+export interface DayPreviewData {
+  dong: string;
+  gu: string;
+  mode: DiagnosisMode;
+  // 출근 🚌 — 본인(a) 필수, 배우자(b)는 부부 모드(commuteB)일 때만.
+  morning: { a: DayCommuteSlot; b?: DayCommuteSlot };
+  // 여가 🍽️ — 싱글 여가거점(leisureA) 있을 때만. 부부·미입력 = null.
+  leisure: DayCommuteSlot | null;
+  // 야간 🌙 — 치안 등급 + 편의 밀집도.
+  night: DayNight;
+}
+
+/** CommuteInfo → DayCommuteSlot (있는 필드만). */
+function toSlot(c: CommuteInfo): DayCommuteSlot {
+  return {
+    time: c.time,
+    ...(c.transfers != null ? { transfers: c.transfers } : {}),
+    ...(c.departureStation ? { departureStation: c.departureStation } : {}),
+  };
+}
+
+/**
+ * 후보 동네 → 하루 미리보기 데이터. 없는 데이터는 null/생략(거짓값 금지).
+ * @param mode 진단 모드(부부/싱글) — 프롬프트 framing 용. 여가 유무는 데이터(leisureA)로 판단.
+ */
+export function extractDayData(
+  c: CandidateArea,
+  mode: DiagnosisMode,
+): DayPreviewData {
+  const night: DayNight = {
+    ...(c.safetyGrade ? { grade: c.safetyGrade } : {}),
+    ...(c.facilities?.convenience != null
+      ? { convenience: c.facilities.convenience }
+      : {}),
+    ...(c.facilities?.cafes != null ? { cafes: c.facilities.cafes } : {}),
+  };
+
+  return {
+    dong: c.dong,
+    gu: c.gu,
+    mode,
+    morning: {
+      a: toSlot(c.commuteA),
+      ...(c.commuteB ? { b: toSlot(c.commuteB) } : {}),
+    },
+    leisure: c.leisureA ? toSlot(c.leisureA) : null,
+    night,
+  };
+}

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -19,6 +19,8 @@ export interface CommuteInfo {
   // A-2 (#졸업 지도) — 실 이동 경로 좌표열. 자동차=Kakao 도로 vertexes.
   //   없으면(mock·실패·transit) 화면에서 직선 추정으로 fallback.
   routePath?: Coordinate[];
+  // 하루 미리보기 — 첫 탑승역 이름(ODsay firstStartStation). transit 실데이터만, 없으면 생략.
+  departureStation?: string;
 }
 
 export interface CandidateArea {


### PR DESCRIPTION
## 목표
"동네 하루 미리보기" AI 스토리에 쓸 **3시간대(출근/여가/야간) 데이터 추출 헬퍼**. **외부 API 없음, 기존 데이터 구조화만.** 프롬프트(Phase 3)·UI(Phase 4)는 후속. (4단계 중 2단계)

## 변경
- **`lib/insight/extract-day-data.ts`** (신규): `extractDayData(c: CandidateArea, mode)` → `DayPreviewData`
  - **출근 🚌** = `morning.a`(본인 commuteA) + `morning.b`(부부 `commuteB` 있을 때만)
  - **여가 🍽️** = `leisureA` 있으면 slot, 없으면 `null`(부부·미입력)
  - **야간 🌙** = `safetyGrade`(있을 때) + `facilities.convenience`/`cafes`
  - 각 slot = `time` + `transfers?`(있을 때) + `departureStation?`(있을 때)
- **ODsay mapper 출발역 이름 캡처** (선택 작업): `CommuteInfo.departureStation` + `OdsayPathInfo.firstStartStation` 추가, mapper가 응답에 있으면 캡처.
  - ★ **순수 additive** — `routePath`/`transfers`/`time`/캐싱/점수 로직 **무변경**(있으면 쓰고 없으면 생략).

## ★ 거짓값 금지 원칙
없는 데이터는 `null`/생략, 절대 채우지 않음 — 부부 여가 `null`, 출발역/등급 없으면 omit.

## 검증 (로컬)
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ 0 errors.
- **`extractDayData` 구조화** (실행 확인):

| 모드 | leisure | morning | night |
|---|---|---|---|
| 부부 | **`null`** ✅ | a+b (둘 다 출발역·환승) | grade+convenience+cafes |
| 싱글 | slot 포함 ✅ | a만 (출발역 없으면 **omit**) | grade **생략**(safetyGrade 부재 시) |

- **mapper 결정론 회귀 테스트**:
  - `firstStartStation` 있음 → `departureStation` 캡처 + `routePath`(3)·`transfers`(0)·`time`(43) **그대로(회귀 0)** ✅
  - `firstStartStation` 없음 → `departureStation` 생략(거짓값 0) + routePath/transfers 불변 ✅
- 실 ODsay 응답에 `firstStartStation` 존재 확인(`"지하철2호선강남역"`).

## 유지(무변경)
통근 계산·캐싱·`routePath`·점수 · Phase 1 `/api/insight`(데이터 주입은 Phase 3) · UI 없음(Phase 4).

## 후속
- **Phase 3**: `DayPreviewData` → Gemini 프롬프트(시간대별 스토리, 거짓 수치 금지) + `/api/insight` 에 실제 데이터 주입.
- **Phase 4**: DetailSheet "하루 미리보기" 섹션 UI(싱글 우선, 부부 여가 생략).

🤖 Generated with [Claude Code](https://claude.com/claude-code)