### PR TITLE
feat(insight): 동네 하루 미리보기 Phase 3 — Gemini 시간대별 스토리 프롬프트

### DIFF
--- a/onday-app/src/app/api/insight/route.ts
+++ b/onday-app/src/app/api/insight/route.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from "next/server";
-import { generateText } from "ai";
+import { generateObject } from "ai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { DayPreviewData } from "@/lib/insight/extract-day-data";
+import {
+  auditGradeMismatch,
+  buildStoryPrompt,
+  sanitizeStory,
+  storySchema,
+} from "@/lib/insight/story";
 
-// 동네 하루 미리보기 — Gemini 인사이트 (SRS CON-13/14: Vercel AI SDK + Gemini, env 모델 교체).
-// ★ Phase 1 = 인프라 + 최소 동작 확인만. 실제 동선 데이터(통근/여가/야간) 주입·프롬프트·UI 는 후속 Phase.
+// 동네 하루 미리보기 — Gemini 시간대별 스토리 (SRS CON-13/14: Vercel AI SDK + Gemini, env 모델 교체).
+// ★ Phase 3 = DayPreviewData(Phase 2 extractDayData 출력) 주입 → 구조화 JSON 스토리. UI 는 Phase 4.
 // ★ 서버 전용 키 — GOOGLE_GENERATIVE_AI_API_KEY (NEXT_PUBLIC 아님: 키 브라우저 노출 금지).
 export const dynamic = "force-dynamic";
-// CLAUDE.md §3 — Vercel 무료 함수 10초 한도. 짧은 프롬프트 단발 호출로 회피(스트리밍은 Phase 3 UI 검토).
+// CLAUDE.md §3 — Vercel 무료 함수 10초 한도. thinkingBudget=0 + Flash 단발로 회피.
 export const maxDuration = 10;
 
 const API_KEY = process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "";
@@ -14,7 +21,20 @@ const API_KEY = process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "";
 // ★ gemini-2.0-flash 는 free tier 쿼터 0(limit:0)인 키가 있어 2.5-flash 기본(무료 동작 확인).
 const MODEL_ID = process.env.GEMINI_MODEL ?? "gemini-2.5-flash";
 
-// POST /api/insight  { dong: string }  → { insight: string }
+// 입력 최소 검증 — DayPreviewData 핵심 필드(없으면 프롬프트 생성 불가).
+function isValidInput(d: unknown): d is DayPreviewData {
+  const x = d as DayPreviewData | null;
+  return (
+    !!x &&
+    typeof x.dong === "string" &&
+    !!x.morning?.a &&
+    typeof x.morning.a.time === "number" &&
+    !!x.night &&
+    typeof x.night === "object"
+  );
+}
+
+// POST /api/insight  { ...DayPreviewData }  → { story: {morning, afternoon|null, night} }
 export async function POST(request: Request) {
   // 키 없음 → graceful 503 (크래시 X — ODsay fallback 정신과 동일, 호출처가 안내/생략 처리).
   if (!API_KEY) {
@@ -24,29 +44,38 @@ export async function POST(request: Request) {
     );
   }
 
-  let dong = "";
+  let data: DayPreviewData;
   try {
     const body = await request.json();
-    dong = typeof body?.dong === "string" ? body.dong.trim() : "";
+    if (!isValidInput(body)) {
+      return NextResponse.json(
+        { error: "동네 데이터(DayPreviewData)가 올바르지 않습니다" },
+        { status: 400 },
+      );
+    }
+    data = body;
   } catch {
     return NextResponse.json({ error: "잘못된 요청입니다" }, { status: 400 });
-  }
-  if (!dong) {
-    return NextResponse.json({ error: "dong 이 필요합니다" }, { status: 400 });
   }
 
   try {
     const google = createGoogleGenerativeAI({ apiKey: API_KEY });
-    const { text } = await generateText({
+    // generateObject = 스키마 강제 JSON(자유 텍스트 파싱보다 견고). 스키마 불일치 시 throw → graceful.
+    const { object } = await generateObject({
       model: google(MODEL_ID),
-      // ★ Phase 1 최소 프롬프트 — 실제 동선 데이터는 Phase 2~3 에서 주입. 거짓 수치 방지 가드만.
-      prompt: `"${dong}" 동네에 사는 하루를 한 문장으로 친근하게 묘사해줘. 추측성 구체 수치나 사실은 넣지 말고 분위기만.`,
-      // ★ thinking 비활성 — 한 문장 인사이트엔 추론 불필요, 지연만 늘어 Vercel 10초 한도 위협.
+      schema: storySchema,
+      prompt: buildStoryPrompt(data),
+      // ★ thinking 비활성 — 지연만 늘어 Vercel 10초 위협. 짧은 묘사엔 추론 불필요.
       providerOptions: { google: { thinkingConfig: { thinkingBudget: 0 } } },
     });
-    return NextResponse.json({ insight: text });
+    // ★ 거짓 방지 강제(여가 없으면 evening=null, 역 keyword 차단) + keywords 부분문자열 검증.
+    const story = sanitizeStory(object, data);
+    // 거짓 방지(로깅) — 등급 미화 모순은 차단 대신 경고(차단은 프롬프트가 담당).
+    const mismatch = auditGradeMismatch(story, data);
+    if (mismatch) console.warn("[API] /api/insight", mismatch);
+    return NextResponse.json({ story });
   } catch (error) {
-    // Gemini 실패/타임아웃/쿼터 → graceful 502 (크래시 X).
+    // Gemini 실패/타임아웃/쿼터/스키마 불일치 → graceful 502 (크래시 X).
     console.error("[API] POST /api/insight error:", error);
     return NextResponse.json(
       { error: "인사이트 생성에 실패했습니다" },

--- a/onday-app/src/lib/insight/story.ts
+++ b/onday-app/src/lib/insight/story.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import type { SafetyGrade } from "@/lib/types";
+import type { DayCommuteSlot, DayPreviewData } from "./extract-day-data";
+
+// 동네 하루 미리보기 (Phase 3) — DayPreviewData → Gemini 시간대별 스토리(morning/evening/night).
+// ★ 거짓 방지: 사실 데이터의 값만, 없는 시간대는 null, 등급 미화·근거 없는 평가어 금지.
+
+// 시간대 조각 — text + keywords(text 안에 그대로 등장하는 핵심 부분문자열, UI 강조용).
+export const storySlotSchema = z.object({
+  text: z.string(),
+  keywords: z.array(z.string()),
+});
+
+// 출력 — morning(출근)/evening(여가)/night(야간). evening 은 여가 데이터 없으면 null.
+export const storySchema = z.object({
+  morning: storySlotSchema,
+  evening: storySlotSchema.nullable(),
+  night: storySlotSchema,
+});
+
+export type StorySlot = z.infer<typeof storySlotSchema>;
+export type DayStory = z.infer<typeof storySchema>;
+
+// 야간 등급 사실 라벨 — 미화 금지(C·D 를 "안전한"으로 포장 방지). 프롬프트에 그대로 제공.
+const GRADE_LABEL: Record<SafetyGrade, string> = {
+  A: "안심",
+  B: "양호",
+  C: "보통",
+  D: "주의",
+};
+
+function describeSlot(s: DayCommuteSlot): string {
+  const parts = [`${s.time}분`];
+  if (s.transfers != null) {
+    parts.push(s.transfers === 0 ? "환승 없음" : `환승 ${s.transfers}회`);
+  }
+  if (s.departureStation) parts.push(`${s.departureStation}에서 출발`);
+  return parts.join(", ");
+}
+
+/** DayPreviewData → 시스템 프롬프트 + 사실 데이터. 없는 필드는 줄 자체를 빼거나 "데이터 없음". */
+export function buildStoryPrompt(data: DayPreviewData): string {
+  const facts: string[] = [];
+  facts.push(`- 출근(아침): ${describeSlot(data.morning.a)}`);
+  if (data.morning.b) facts.push(`- 출근(배우자): ${describeSlot(data.morning.b)}`);
+  facts.push(
+    data.leisure
+      ? `- 여가(저녁): 여가거점까지 ${describeSlot(data.leisure)}`
+      : `- 여가(저녁): 데이터 없음`,
+  );
+  const n = data.night;
+  const nightParts: string[] = [];
+  if (n.grade) nightParts.push(`야간 치안 등급 ${n.grade}(${GRADE_LABEL[n.grade]})`);
+  if (n.convenience != null) nightParts.push(`편의점 ${n.convenience}곳`);
+  if (n.cafes != null) nightParts.push(`카페 ${n.cafes}곳`);
+  facts.push(`- 야간: ${nightParts.length ? nightParts.join(", ") : "데이터 없음"}`);
+
+  return [
+    `너는 1인 가구의 이사를 돕는 다정하고 전문적인 동네 큐레이터야. 반드시 제공된 [사용자 데이터]에 있는 수치와 정보만 사용하여, "${data.gu} ${data.dong}"의 하루 일과를 따뜻한 묘사체로 작성해.`,
+    ``,
+    `[사용자 데이터]`,
+    ...facts,
+    ``,
+    `[엄격한 규칙]`,
+    `1. 각 시간대(morning/evening/night)별 2~3문장.`,
+    `2. 데이터에 없는 내용(특정 역 이름, 가상 편의시설, 없는 수치)은 절대 지어내거나 추측하지 마. 출발역이 데이터에 없으면 역 이름을 언급하지 마.`,
+    `3. 평가 형용사("쾌적한", "편리한", "안전한" 등)는 데이터가 뒷받침할 때만 써. 통근이 길면 "쾌적" 금지, 야간 등급이 낮으면(C·D) "안전/안심" 금지. 수치는 그대로, 평가는 사실에 부합하게.`,
+    `4. 데이터 없는 시간대는 해당 키를 null 로 둬(여가가 "데이터 없음"이면 evening 은 반드시 null — 여가 문장 창작 금지).`,
+    `5. 야간 등급은 사실대로: A=안심, B=양호, C=보통, D=주의.`,
+    `6. 강조할 핵심 데이터(수치·등급·역 이름)는 keywords 배열에 담되, text 안에 그대로 등장하는 부분문자열만 넣어(text 에 없는 단어 금지).`,
+    ``,
+    `[톤] 따뜻한 묘사체("~해요/~예요"), 장면이 그려지게.`,
+  ].join("\n");
+}
+
+// keywords 후처리 — text 에 실제 포함된 부분문자열만 유지(UI 부분문자열 매칭 보장).
+//   stripStations: 출발역 데이터가 없을 때 "○○역" 형태 keyword 제거(역 이름 창작 차단, 가능 범위).
+function filterKeywords(slot: StorySlot, stripStations: boolean): StorySlot {
+  let kept = slot.keywords.filter((k) => k.length > 0 && slot.text.includes(k));
+  if (stripStations) kept = kept.filter((k) => !/역$/.test(k.trim()));
+  return { text: slot.text, keywords: kept };
+}
+
+/**
+ * 거짓 방지 강제 + keywords 검증.
+ * ★ 여가 데이터가 없으면 모델 출력과 무관하게 evening 을 강제 null(여가 창작 차단).
+ * ★ 출발역 데이터 없는 시간대는 "○○역" keyword 제거(역 이름 창작 차단, 가능 범위).
+ */
+export function sanitizeStory(story: DayStory, data: DayPreviewData): DayStory {
+  const morningHasStation = !!(
+    data.morning.a.departureStation || data.morning.b?.departureStation
+  );
+  const eveningHasStation = !!data.leisure?.departureStation;
+  return {
+    morning: filterKeywords(story.morning, !morningHasStation),
+    evening:
+      data.leisure && story.evening
+        ? filterKeywords(story.evening, !eveningHasStation)
+        : null,
+    night: filterKeywords(story.night, true), // 야간엔 출발역 개념 없음 → 역 keyword 항상 차단.
+  };
+}
+
+/** 거짓 방지(로깅 전용) — 야간 C/D 인데 text 에 "안전/안심" 미화 흔적이면 경고 반환(차단은 프롬프트가 담당). */
+export function auditGradeMismatch(
+  story: DayStory,
+  data: DayPreviewData,
+): string | null {
+  const g = data.night.grade;
+  if ((g === "C" || g === "D") && /안전|안심/.test(story.night.text)) {
+    return `야간 등급 ${g} 인데 text 에 미화 표현 포함: "${story.night.text}"`;
+  }
+  return null;
+}


### PR DESCRIPTION
## 목표
Phase 2의 `DayPreviewData` 를 Gemini에 주입해 **시간대별(morning/evening/night) 스토리** 생성. `/api/insight` 를 더미 → 실데이터 프롬프트로. UI는 Phase 4. (4단계 중 3단계)

## 변경
- **`lib/insight/story.ts`** (신규): `storySchema`(zod) + `buildStoryPrompt` + `sanitizeStory` + `auditGradeMismatch`.
  - **시스템 프롬프트**(사용자 확정안): "1인 가구 이사 돕는 다정한 동네 큐레이터", 따뜻한 묘사체, **사실 데이터만**.
  - **엄격 규칙**: 데이터 외 창작 금지(역 이름·가상 편의시설·없는 수치) · 평가 형용사는 데이터 뒷받침될 때만(**통근 길면 "쾌적" 금지, 야간 C/D면 "안전" 금지**) · 여가 없으면 `evening=null` · 등급 사실대로(A안심/B양호/C보통/D주의).
- **`/api/insight`**: `{ dong }` 더미 → `DayPreviewData` 입력. **`generateObject`**(스키마 강제 JSON — 자유 텍스트 파싱보다 견고) + `thinkingBudget:0`. 응답 `{ story: { morning, evening|null, night } }`, 각 슬롯 `{ text, keywords }`.

## ★ 거짓 방지 (다층)
1. **프롬프트**(1차): 데이터 외 창작·등급 미화·근거 없는 평가어 금지.
2. **`evening` 강제 null**: 여가 데이터 없으면 모델 출력 무관하게 null(여가 창작 차단).
3. **`keywords` = text 부분문자열만**: UI 강조 매칭 보장(hallucinated keyword 제거).
4. **출발역 데이터 없으면 "○○역" keyword 제거**(역 이름 창작 차단, 가능 범위).
5. **등급↔미화 모순 로깅**(`auditGradeMismatch`): C/D인데 "안전/안심" 흔적이면 경고(차단은 프롬프트 담당).

## 검증 (로컬, 실 키)
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ 0 errors.
- **실데이터 curl** — 시간대별 JSON 스토리:
  - **싱글 happy**: `morning`(뚝섬역·1번 환승·28분) + `evening`(15분·환승 없이) + `night`(등급 A·8곳·22곳). keywords 전부 text 포함. **3.7s**.
  - **부부**: `morning`(75분·3번 환승) + **`evening: null`** + `night`(D·주의). **2.1s**.
- **★ 거짓 방지 4종**:
  - **(a)** 출발역 없는 동네 → 역 **이름 창작 0** (generic "역까지"만, keyword에도 역 없음)
  - **(b)** 여가 null(부부) → **`evening: null`**
  - **(c)** 야간 D → **"주의 필요"**, 안전/안심 미화 0
  - **(d)** 통근 75분(긴) → **"쾌적" 0**, 사실만
- **keywords ⊆ text 부분문자열** ✅ (live + 결정론 테스트).
- **결정론 가드**: 역 keyword strip("쌍문역"→제거)·`evening` 강제 null·등급 미화 로깅(C+안전→경고) 동작 ✅.
- **graceful**: 키없음 503 / 잘못된 입력 400 / Gemini·스키마 실패 502 (크래시 0). 속도 2~3.7s(10초 안전).

## 유지(무변경)
Phase 1 인프라(graceful·모델 env·서버키)·Phase 2 추출 헬퍼 **재사용**. 통근/시세/캐싱 무변경. UI 없음(Phase 4).

## 후속
- **Phase 4**: DetailSheet "하루 미리보기" 섹션 UI — `extractDayData` → `/api/insight` 호출 → `{story}` 렌더(keywords 강조). 싱글 우선, 부부 evening 생략.

🤖 Generated with [Claude Code](https://claude.com/claude-code)