### PR TITLE
feat(insight): 동네 하루 미리보기 Phase 4 — DetailSheet UI (4단계 완료)

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/features/diagnosis/result-utils";
 import { recomputeWhatIf } from "@/lib/diagnosis/whatif";
 import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
+import { DayPreview } from "@/components/insight/day-preview";
 import { latLngToPixel } from "@/lib/coordinate-transform";
 import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
 import { refilterPool } from "@/lib/diagnosis/refilter";
@@ -634,6 +635,13 @@ export function ResultContent({
             <TimeSlotSelector
               value={currentDepartureTime}
               onChange={handleTimeSlotChange}
+            />
+          }
+          dayPreview={
+            <DayPreview
+              key={selectedCandidate.id}
+              candidate={selectedCandidate}
+              mode={mode}
             />
           }
           primaryCta={{

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -9,6 +9,7 @@ import { LegendBar } from "@/components/data/legend-bar";
 import { MapCanvas } from "@/components/map/map-canvas";
 import type { MapWorkplace, MapLine } from "@/components/map/map-canvas";
 import { DetailSheet } from "@/components/sheet/detail-sheet";
+import { DayPreview } from "@/components/insight/day-preview";
 import { TradeOffSection } from "@/components/diagnosis/trade-off-section";
 import { PreferenceBanner } from "@/components/diagnosis/preference-banner";
 import { buildPreferenceReason } from "@/features/diagnosis/preference-reason";
@@ -796,6 +797,13 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                     topRightSlot={mapModeToggle}
                     fitAll
                     height={180}
+                  />
+                }
+                dayPreview={
+                  <DayPreview
+                    key={selectedCandidate.id}
+                    candidate={selectedCandidate}
+                    mode="single"
                   />
                 }
                 primaryCta={{

--- a/onday-app/src/components/insight/day-preview.tsx
+++ b/onday-app/src/components/insight/day-preview.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import * as React from "react";
+import { RotateCw, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { extractDayData } from "@/lib/insight/extract-day-data";
+import type { DayStory, StorySlot } from "@/lib/insight/story";
+import type { CandidateArea, DiagnosisMode } from "@/lib/types";
+
+// 동네 하루 미리보기 (Phase 4 UI) — 버튼 클릭 시 extractDayData → /api/insight → story 렌더.
+//   클릭 전엔 호출 안 함(비용·속도). 한 번 생성하면 상태에 보관(같은 동네 재요청 방지).
+//   ★ key={candidate.id} 로 마운트 → 동네 바뀌면 자연 초기화.
+
+const SLOTS = [
+  { key: "morning", emoji: "🚌", label: "아침" },
+  { key: "evening", emoji: "🍽️", label: "저녁" },
+  { key: "night", emoji: "🌙", label: "밤" },
+] as const;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// keywords 강조 — text 를 keyword 부분문자열 경계로 쪼개 브랜드 컬러+볼드.
+//   ★ cn 드롭 회피: 색 강조는 자식 <strong> 에만(부모 <p> 의 fontSize 토큰과 cn 병합 안 함).
+//   Phase 3 에서 keywords ⊆ text 보장되나 방어적으로 포함 확인 + 긴 것 우선(부분겹침 방지).
+function highlightKeywords(
+  text: string,
+  keywords: string[],
+): React.ReactNode {
+  const valid = [...new Set(keywords)]
+    .filter((k) => k.length > 0 && text.includes(k))
+    .sort((a, b) => b.length - a.length);
+  if (valid.length === 0) return text;
+  const re = new RegExp(`(${valid.map(escapeRegExp).join("|")})`, "g");
+  return text.split(re).map((part, i) =>
+    valid.includes(part) ? (
+      <strong key={i} className="font-bold text-primary">
+        {part}
+      </strong>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    ),
+  );
+}
+
+function DayPreviewSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="하루 미리보기 생성 중"
+      className="space-y-s-3"
+    >
+      <p className="text-center text-caption text-ink-3">
+        AI가 이 동네에서의 완벽한 하루를 스케치하고 있어요 ✍️
+      </p>
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="space-y-s-2 rounded-lg border border-card-border bg-surface px-s-4 py-s-3"
+        >
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-4/5" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+type Status = "idle" | "loading" | "done" | "error";
+
+interface DayPreviewProps {
+  candidate: CandidateArea;
+  mode: DiagnosisMode;
+}
+
+export function DayPreview({ candidate, mode }: DayPreviewProps) {
+  const [status, setStatus] = React.useState<Status>("idle");
+  const [story, setStory] = React.useState<DayStory | null>(null);
+
+  const generate = React.useCallback(async () => {
+    setStatus("loading");
+    try {
+      const data = extractDayData(candidate, mode);
+      const res = await fetch("/api/insight", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) throw new Error(String(res.status));
+      const json = (await res.json()) as { story?: DayStory };
+      if (!json.story) throw new Error("no story");
+      setStory(json.story);
+      setStatus("done");
+    } catch {
+      setStatus("error"); // 503/502/400/네트워크 모두 graceful (크래시·빈 화면 금지).
+    }
+  }, [candidate, mode]);
+
+  return (
+    <section aria-label="동네 하루 미리보기" className="space-y-s-3">
+      <div className="flex items-center gap-s-1">
+        <Sparkles aria-hidden className="size-4 text-primary" />
+        <p className="text-caption font-bold text-ink-2">동네 하루 미리보기</p>
+      </div>
+
+      {status === "idle" && (
+        <Button variant="outline" fullWidth onClick={generate}>
+          AI로 이 동네 하루 미리보기 ✨
+        </Button>
+      )}
+
+      {status === "loading" && <DayPreviewSkeleton />}
+
+      {status === "error" && (
+        <div className="space-y-s-2 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 text-center">
+          <p className="text-body-sm text-ink-3">
+            지금은 미리보기를 불러올 수 없어요
+          </p>
+          <Button variant="outline" size="sm" onClick={generate}>
+            <RotateCw aria-hidden className="size-3.5" />
+            다시 시도
+          </Button>
+        </div>
+      )}
+
+      {status === "done" && story && (
+        <ol className="space-y-s-3">
+          {SLOTS.map(({ key, emoji, label }) => {
+            const slot = story[key] as StorySlot | null;
+            if (!slot) return null; // evening null(부부·여가 없음) → 저녁 카드 생략.
+            return (
+              <li
+                key={key}
+                className="rounded-lg border border-card-border bg-surface px-s-4 py-s-3 shadow-card"
+              >
+                <p className="flex items-center gap-s-1 text-caption font-bold text-ink-2">
+                  <span aria-hidden>{emoji}</span>
+                  {label}
+                </p>
+                <p className="mt-1 text-body-sm leading-relaxed text-ink">
+                  {highlightKeywords(slot.text, slot.keywords)}
+                </p>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/onday-app/src/components/sheet/detail-sheet.tsx
+++ b/onday-app/src/components/sheet/detail-sheet.tsx
@@ -45,6 +45,8 @@ interface DetailSheetProps {
   map?: React.ReactNode;
   /** commute rows와 metrics 사이 inject (예: TimeSlotSelector) */
   commuteExtra?: React.ReactNode;
+  /** metrics와 primary CTA 사이 inject (예: 동네 하루 미리보기 AI 섹션) */
+  dayPreview?: React.ReactNode;
   primaryCta: {
     label: string;
     href?: string;
@@ -62,6 +64,7 @@ export function DetailSheet({
   onShare,
   map,
   commuteExtra,
+  dayPreview,
   primaryCta,
 }: DetailSheetProps) {
   return (
@@ -207,6 +210,8 @@ export function DetailSheet({
             ))}
           </div>
         )}
+
+        {dayPreview}
 
         {primaryCta.href ? (
           <Button


### PR DESCRIPTION
## 목표
Phase 1~3 으로 만든 AI 하루 스토리를 **DetailSheet에 표시**. 버튼 생성 → 스켈레톤 로딩 → 🚌🍽️🌙 시간대 카드 + keywords 강조. 싱글·부부 공용. **4단계 완료.**

## STEP 0 — 디자인 토큰 확인 (코딩 전)
- **기존 재사용**: `Skeleton`(`components/ui/skeleton.tsx`, `animate-pulse-soft`), `Button`(variant `outline`/size `sm`/`fullWidth`), `DetailSheet`(슬롯 패턴).
- **색**: `text-primary`(브랜드, `hsl(var(--primary))`), `text-ink/ink-2/ink-3`, `bg-surface`, `border-card-border`, `shadow-card`.
- **fontSize 토큰**: `text-body-sm`(13px)·`text-caption`(12px). 폰트 Pretendard(글로벌).
- **★ cn 드롭 버그 회피**: keyword 강조 색은 **fontSize 토큰이 없는 자식 `<strong>` 에만** `text-primary font-bold` 적용, **cn() 병합 안 씀**(literal className). → fontSize↔color `text-` 충돌 자체가 없어 드롭 불가. 부모 `<p>` 가 fontSize 담당, strong 은 색·굵기만.

## 변경
- **`components/insight/day-preview.tsx`** (신규, 자족형):
  - **idle** → 버튼 "AI로 이 동네 하루 미리보기 ✨" (클릭 전 호출 안 함 — 비용·속도)
  - **loading** → 3단 스켈레톤 + "AI가 이 동네에서의 완벽한 하루를 스케치하고 있어요 ✍️"
  - **done** → `extractDayData`(P2) → POST `/api/insight`(P3) → 시간대 카드. **`evening` null이면 저녁 카드 생략**(부부·여가 없음)
  - **error**(503/502/400/네트워크) → graceful "지금은 미리보기를 불러올 수 없어요" + 다시 시도 버튼
  - **캐시**: 상태 보관 + `key={candidate.id}`(동네 바뀌면 초기화) → 같은 시트 재요청 방지
- **`DetailSheet`**: `dayPreview` 슬롯 추가(metrics ↔ primary CTA 사이). 두 뷰 공용.
- **`result-content`**(부부, `mode` 전달) · **`single-result-view`**(싱글) 주입.

## ★ keywords 강조
`text` 를 keyword 부분문자열 경계로 split → keyword 조각만 `<strong class="text-primary font-bold">`. 긴 keyword 우선 정렬(부분겹침 방지) + `text.includes` 방어 필터(P3에서 ⊆ 보장).

## 검증 (로컬)
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ 0 errors.
- **페이지 렌더**: `/diagnosis`·`/diagnosis/result/[id]`·`/single/[id]` 전부 **200** (DayPreview 추가로 SSR 크래시 0).
- **highlight split 정확성**(단위): keyword만 강조 / 미포함 단어("없는단어") 제외 / 겹침("28분" vs "8분") 최장 우선 ✅.
- **end-to-end**: `extractDayData` 형태 payload → `/api/insight` → story 정상(싱글 3시간대, ~3s).
- **cn 드롭**: 색 강조 자식 분리로 fontSize 정상(글씨 크기 깨짐 0).

## ⚠️ 사용자 브라우저 확인 (시각 검증)
샌드박스엔 JS 브라우저가 없어 **실제 클릭→스켈레톤→카드 시각 렌더는 미확인**입니다. dev 서버에서:
1. 진단 → 카드/마커 클릭 → DetailSheet → "AI로 이 동네 하루 미리보기 ✨" 클릭
2. 스켈레톤+다정한 텍스트 → 시간대 카드(🚌아침/🍽️저녁/🌙밤) + keywords 브랜드 컬러 강조
3. 싱글(3시간대)·부부(저녁 생략) 둘 다 / 에러 시 재시도 / 글씨 크기 정상

## 유지(무변경)
Phase 1~3(인프라·추출·프롬프트) **재사용**. 통근/시세/캐싱/네이버링크/토글 무변경.

🤖 4단계 완료. Generated with [Claude Code](https://claude.com/claude-code)