### PR TITLE
feat(insight): 동네 하루 미리보기 Phase 5 — diagnosis-store 세션 캐시

### DIFF
--- a/onday-app/src/components/insight/day-preview.tsx
+++ b/onday-app/src/components/insight/day-preview.tsx
@@ -7,11 +7,14 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { extractDayData } from "@/lib/insight/extract-day-data";
 import type { DayStory, StorySlot } from "@/lib/insight/story";
+import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import type { CandidateArea, DiagnosisMode } from "@/lib/types";
 
 // 동네 하루 미리보기 (Phase 4 UI) — 버튼 클릭 시 extractDayData → /api/insight → story 렌더.
-//   클릭 전엔 호출 안 함(비용·속도). 한 번 생성하면 상태에 보관(같은 동네 재요청 방지).
-//   ★ key={candidate.id} 로 마운트 → 동네 바뀌면 자연 초기화.
+//   클릭 전엔 호출 안 함(비용·속도).
+//   ★ Phase 5 세션 캐시 — 생성한 story 는 diagnosis-store 에 보관(candidate.id 키). 시트 close/reopen·
+//     탭 이동에도 재호출 0(Gemini 절약). 진단 스코프라 setResult/reset 시 비워짐(다른 통근데이터 → 재생성).
+//   ★ key={candidate.id} 유지(방어) — 캐시는 store 가 담당, 새로고침 시 소멸(의도).
 
 const SLOTS = [
   { key: "morning", emoji: "🚌", label: "아침" },
@@ -70,7 +73,8 @@ function DayPreviewSkeleton() {
   );
 }
 
-type Status = "idle" | "loading" | "done" | "error";
+// done 데이터(story)는 store, 생성 중 전이(loading/error)는 로컬. story 캐시 있으면 status 무관하게 표시.
+type Status = "idle" | "loading" | "error";
 
 interface DayPreviewProps {
   candidate: CandidateArea;
@@ -79,7 +83,9 @@ interface DayPreviewProps {
 
 export function DayPreview({ candidate, mode }: DayPreviewProps) {
   const [status, setStatus] = React.useState<Status>("idle");
-  const [story, setStory] = React.useState<DayStory | null>(null);
+  // ★ 세션 캐시 — 캐시된 story 가 있으면 재호출 없이 바로 렌더(시트 close/reopen 비용 0).
+  const story = useDiagnosisStore((s) => s.stories[candidate.id]) ?? null;
+  const setStory = useDiagnosisStore((s) => s.setStory);
 
   const generate = React.useCallback(async () => {
     setStatus("loading");
@@ -93,12 +99,12 @@ export function DayPreview({ candidate, mode }: DayPreviewProps) {
       if (!res.ok) throw new Error(String(res.status));
       const json = (await res.json()) as { story?: DayStory };
       if (!json.story) throw new Error("no story");
-      setStory(json.story);
-      setStatus("done");
+      setStory(candidate.id, json.story); // store 보관 → 캐시 hit 시 idle 스킵.
+      setStatus("idle"); // story 존재가 done 표시를 주도(아래 렌더 우선순위).
     } catch {
       setStatus("error"); // 503/502/400/네트워크 모두 graceful (크래시·빈 화면 금지).
     }
-  }, [candidate, mode]);
+  }, [candidate, mode, setStory]);
 
   return (
     <section aria-label="동네 하루 미리보기" className="space-y-s-3">
@@ -107,7 +113,7 @@ export function DayPreview({ candidate, mode }: DayPreviewProps) {
         <p className="text-caption font-bold text-ink-2">동네 하루 미리보기</p>
       </div>
 
-      {status === "idle" && (
+      {!story && status === "idle" && (
         <Button variant="outline" fullWidth onClick={generate}>
           AI로 이 동네 하루 미리보기 ✨
         </Button>
@@ -115,7 +121,7 @@ export function DayPreview({ candidate, mode }: DayPreviewProps) {
 
       {status === "loading" && <DayPreviewSkeleton />}
 
-      {status === "error" && (
+      {!story && status === "error" && (
         <div className="space-y-s-2 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 text-center">
           <p className="text-body-sm text-ink-3">
             지금은 미리보기를 불러올 수 없어요
@@ -127,7 +133,7 @@ export function DayPreview({ candidate, mode }: DayPreviewProps) {
         </div>
       )}
 
-      {status === "done" && story && (
+      {story && (
         <ol className="space-y-s-3">
           {SLOTS.map(({ key, emoji, label }) => {
             const slot = story[key] as StorySlot | null;

--- a/onday-app/src/stores/diagnosis-store.ts
+++ b/onday-app/src/stores/diagnosis-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { CandidateArea, Coordinate, DiagnosisFilters, DiagnosisMode } from "@/lib/types";
+import type { DayStory } from "@/lib/insight/story";
 
 interface DiagnosisState {
   // Input
@@ -22,6 +23,9 @@ interface DiagnosisState {
   // ★ 거래유형/예산 토글 재필터용 통근 캐시 — real 진단의 prefilter 12개 풀(실 transit/자차 통근 보존,
   //   예산필터 전). 토글 시 이 풀을 재필터해 통근 열화·API 재호출 0. mock·재오픈 시 빈 배열(재실행 fallback).
   commutePool: CandidateArea[];
+  // 동네 하루 미리보기 세션 캐시 — candidateId → Gemini 스토리. 시트 close/reopen·탭 이동 시 재호출 0.
+  //   진단 스코프(맵 전체가 현재 진단 것)라 키=candidate.id 로 충분. setResult/reset 시 비움(다른 통근데이터 → 재생성).
+  stories: Record<string, DayStory>;
   isLoading: boolean;
   error: string | null;
 
@@ -34,6 +38,7 @@ interface DiagnosisState {
   setFilters: (filters: DiagnosisFilters) => void;
   setDeadlineDate: (date: string | null) => void;
   setResult: (id: string, candidates: CandidateArea[]) => void;
+  setStory: (candidateId: string, story: DayStory) => void;
   setCommutePool: (pool: CandidateArea[]) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
@@ -55,6 +60,7 @@ const initialState = {
   diagnosisId: null,
   candidates: [],
   commutePool: [],
+  stories: {},
   isLoading: false,
   error: null,
 };
@@ -78,8 +84,12 @@ export const useDiagnosisStore = create<DiagnosisState>((set) => ({
   setFilters: (filters) => set({ filters }),
   setDeadlineDate: (deadlineDate) => set({ deadlineDate }),
 
+  // 새 진단 결과 = 통근데이터 달라짐 → 옛 스토리 무효(stories 비움 → 재생성).
   setResult: (diagnosisId, candidates) =>
-    set({ diagnosisId, candidates, isLoading: false, error: null }),
+    set({ diagnosisId, candidates, stories: {}, isLoading: false, error: null }),
+
+  setStory: (candidateId, story) =>
+    set((s) => ({ stories: { ...s.stories, [candidateId]: story } })),
 
   setCommutePool: (commutePool) => set({ commutePool }),
 


### PR DESCRIPTION
## 요약
동네 하루 미리보기 스토리(Gemini 결과) 저장 위치를 `DayPreview` 로컬 state → `diagnosis-store` 로 이전하는 **세션 캐시**. 시트 close/reopen·탭 이동 시 `/api/insight` 재호출을 제거해 Gemini 호출을 절약합니다. (조사 권고 옵션 a)

## 문제
- story 가 `DayPreview` 로컬 `useState` 라, DetailSheet 가 닫히면(`{selectedCandidate && ...}` 조건부 언마운트) story state 가 소멸 → **같은 동네를 다시 열면 재호출**(낭비). 같은 시트 내 재클릭은 이미 캐시됨(버튼 사라짐).
- `candidate.id` 는 정적 슬러그(진단 무관 동일)지만, 스토리는 진단별 통근데이터에 의존 → id 만 키로 쓰면 충돌.

## 해법
- 캐시 맵을 **진단 스코프**인 `diagnosis-store` 에 둠 → 맵 자체가 현재 진단의 것이라 키는 `candidate.id` 로 충분.
- 무효화는 `setResult`(새 진단 결과)·`reset` 단일 지점에서 `stories` 를 `{}` 로 비움(다른 통근데이터 → 재생성).

## 변경
- **`diagnosis-store.ts`**: `stories: Record<string, DayStory>` 필드 + `setStory(candidateId, story)` 액션. `setResult`/`reset`(initialState) 에서 비움.
- **`day-preview.tsx`**: story 를 store 에서 읽음 — 캐시 있으면 idle 버튼 스킵하고 바로 done 렌더(재호출 0). 생성 중 `loading`/`error` 는 로컬 유지, `done` 데이터만 store.
- `key={candidate.id}` 유지(방어). `/api/insight`·프롬프트·`extractDayData`·UI(스켈레톤/카드/keywords 강조) 무변경 — 저장 위치만 이전.

## 검증
- ✅ `npx tsc --noEmit` 통과(exit 0)
- ✅ `npm run lint` 0 errors (기존 무관 파일 warning 10건만, 변경 파일 0)
- ✅ `npm run build` 성공
- 런타임(수동): 시트 close/reopen → `/api/insight` 호출 0 / 같은 시트 재클릭 유지 / 새 진단·reset → stories 비워져 재생성 / 다른 동네 → 캐시 미스 정상 / 새로고침 → 소멸(의도, persist 미추가) / 로딩·에러 상태 정상

## 비고
- store `persist` 미추가 — 새로고침 소멸 = 의도. localStorage 영속은 후속(필요 시 `diagnosisId` 포함 키 + cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)