### PR TITLE
fix(insight): 하루 미리보기 야간 등급 stale mock → 종합 지수 단일 소스

### DIFF
--- a/onday-app/src/lib/insight/extract-day-data.ts
+++ b/onday-app/src/lib/insight/extract-day-data.ts
@@ -4,10 +4,13 @@ import type {
   DiagnosisMode,
   SafetyGrade,
 } from "@/lib/types";
+import { getSafetyByGu } from "@/features/single/safety-index";
 
 // 동네 하루 미리보기 (Phase 2) — CandidateArea 에서 3시간대(출근/여가/야간) 스토리 재료 추출.
 // ★ 외부 API 없음, 기존 데이터 구조화만. 없는 필드는 null/생략 — 거짓값 금지(채우지 않음).
 //   프롬프트(Phase 3)·UI(Phase 4)는 본 구조만 소비. 통근/캐싱/점수 로직과 무관.
+//   ★ 야간 등급은 종합 야간안전 지수(getSafetyByGu) 단일 소스 — 화면(resolveGrade)과 동일.
+//     낡은 mock 필드 c.safetyGrade 는 읽지 않음(화면과 불일치 방지). no_data 면 생략(거짓값 금지).
 
 /** 한 구간(출근/여가) 통근 재료 — 있는 값만 채움. */
 export interface DayCommuteSlot {
@@ -53,8 +56,10 @@ export function extractDayData(
   c: CandidateArea,
   mode: DiagnosisMode,
 ): DayPreviewData {
+  // 싱글 한정 — 부부 모드는 등급 미포함(기존 동작 보존). 싱글은 종합 지수 ok 일 때만 grade 채움.
+  const safety = mode === "single" ? getSafetyByGu(c.gu) : null;
   const night: DayNight = {
-    ...(c.safetyGrade ? { grade: c.safetyGrade } : {}),
+    ...(safety && safety.status === "ok" ? { grade: safety.grade } : {}),
     ...(c.facilities?.convenience != null
       ? { convenience: c.facilities.convenience }
       : {}),


### PR DESCRIPTION
## 문제
싱글 **하루 미리보기**의 야간 치안 등급이 낡은 mock 필드 `c.safetyGrade`(예: 염창동 = `"A"`, `neighborhoods.ts:194`)를 읽어, 앱 전체가 쓰는 **종합 야간안전 지수** `getSafetyByGu`(강서구 = **B**)와 불일치. 화면엔 B로 표시되는데 스토리는 "야간 치안 등급 A로 안심"이라 미화. **안전 정보 거짓 표기**.

- 앱 단일 등급 소스 = `getSafetyByGu(c.gu)` (`single-result-view.tsx:67` "유일한 등급 소스", #57/#59 종합 지수).
- 미리보기만 `extract-day-data.ts:57`이 stale `c.safetyGrade`를 읽음 (`mock-calculator.ts:173`에서 싱글 모드일 때 mock 필드를 그대로 복사).
- Gemini 환각/매핑 버그 아님 — 입력이 A였고 출력 A. **입력 데이터가 틀림**.

## 수정
`extract-day-data.ts` — 야간 등급을 화면과 동일한 `getSafetyByGu(c.gu)` 단일 소스로:
- `status === "ok"` 일 때만 `grade` 채움, `no_data` 면 생략(거짓값 금지).
- **싱글 한정** (`mode === "single"`) — 부부 모드는 기존대로 등급 미포함(동작 보존, 갑자기 새 등급 안 생김).
- `c.safetyGrade` 더 이상 읽지 않음 → 화면(resolveGrade)과 미리보기 등급 항상 일치.

## 유지(무변경)
- `getSafetyByGu`/safety-index 로직(읽기만), 프롬프트·`GRADE_LABEL`·UI, mock `neighborhoods.ts` `safetyGrade` 필드(scoring 등 다른 소비처 영향 방지), 통근/시세/캐싱.

## 검증
- ✅ `npx tsc --noEmit` (exit 0) / `npm run lint` 0 errors (기존 무관 warning 10건만)
- ✅ `tsx` 직접 호출:
  - 염창동(강서구): 화면 **B** = 미리보기 **B** (불일치 해소, "안심" 아님)
  - 관악구 **C** = C / 금천구 **B** = B (mock은 전부 A였음)
  - 부부 모드: 등급 미생성(보존)
  - no_data(춘천시): 등급 생략(거짓값 미주입)
  - 강남구 C·용산구 D·종로구 D가 올바른 등급으로 흘러 → C/D + "안심/안전" 시 `auditGradeMismatch` 정상 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)