### PR TITLE
fix(scoring): 안전 점수 stale mock 등급 → 종합 야간안전 지수 (추천 순위 정확도)

### DIFF
--- a/onday-app/src/lib/diagnosis/scoring.ts
+++ b/onday-app/src/lib/diagnosis/scoring.ts
@@ -1,4 +1,3 @@
-import type { SafetyGrade } from "@/lib/types";
 import { getSafetyByGu } from "@/features/single/safety-index";
 
 import { getCommunityByGu } from "./community-index";
@@ -9,8 +8,7 @@ import { getCommunityByGu } from "./community-index";
 
 /** 점수 계산에 필요한 동네 속성만 (MOCK_NEIGHBORHOODS 항목이 구조적으로 할당 가능). */
 export interface ScoringNeighborhood {
-  gu: string; // #조용한동네 가중 — getCommunityByGu(gu) 조회
-  safetyGrade: SafetyGrade;
+  gu: string; // 안전(getSafetyByGu)·#조용한동네(getCommunityByGu) 가중 조회 키
   facilities: { convenience: number; cafes: number; schools?: number };
 }
 
@@ -34,10 +32,12 @@ function priorityBonus(
 ): number {
   switch (priority) {
     case "safety": {
-      // no_data(미수집 시군구)는 mock 등급 가산 금지(#59 옵션2) — 표시 "준비중"과 일관.
-      if (getSafetyByGu(n.gu).status !== "ok") return 0;
+      // ★ 종합 야간안전 지수(getSafetyByGu, 표시·SSoT 동일) 등급으로 가산 — stale mock 등급 안 씀.
+      //   no_data(미수집 시군구)는 가산 금지(#59 옵션2) — 표시 "준비중"과 일관.
+      const safety = getSafetyByGu(n.gu);
+      if (safety.status !== "ok") return 0;
       const b: Record<string, number> = { A: 10, B: 5, C: 0, D: -10 };
-      return b[n.safetyGrade] ?? 0;
+      return b[safety.grade] ?? 0;
     }
     case "convenience":
       return Math.min(10, Math.max(0, (n.facilities.convenience - 15) / 10));
@@ -77,10 +77,12 @@ export function scoreCandidate({
   const avgCommute = commuteB != null ? (commuteA + commuteB) / 2 : commuteA;
   score -= Math.min(40, avgCommute * 0.8);
 
-  // 안전등급 가산 — no_data(미수집 시군구)는 mock 등급 가산 금지(#59 옵션2, 표시 "준비중"과 일관).
+  // 안전등급 가산 — 종합 야간안전 지수(#57/#59, 표시·SSoT 동일) 등급 기준. stale mock 안 씀(화면 등급과 순위 정합).
+  //   no_data(미수집 시군구)는 가산 제외(#59 옵션2, 표시 "준비중"과 일관).
   const safetyBonus: Record<string, number> = { A: 10, B: 5, C: 0, D: -10 };
-  if (getSafetyByGu(neighborhood.gu).status === "ok") {
-    score += safetyBonus[neighborhood.safetyGrade] ?? 0;
+  const safety = getSafetyByGu(neighborhood.gu);
+  if (safety.status === "ok") {
+    score += safetyBonus[safety.grade] ?? 0;
   }
 
   // 편의시설 가산 — 실데이터(편의점+카페 반경1km). 합 분포 ~12~828(중앙 213) → /40 으로 0~10.


### PR DESCRIPTION
## 문제 (추천 정확도)
`scoring.ts`의 안전 가산이 **no_data 게이트는 `getSafetyByGu`(올바름)인데 점수 값은 `neighborhood.safetyGrade`(stale 하드코딩 mock)** 를 사용. 두 소스가 **44개 중 33개(75%)에서 불일치**.

- 단일 점수 오차 **±20**(`#안심귀가` 선택 시 **±40**) — 지배 요인인 통근 패널티(40)와 동급.
- 실제 D 동네가 안전상 상위로 랭크, **`#안심귀가`(안전 우선) 태그가 위험 동네를 추천**(역효과).
- 화면 표시(`resolveGrade`=`getSafetyByGu`=D)와 순위(mock=A) **모순**.

근거: `scoring.ts:81-84`(기본 안전 가산), `:36-41`(#안심귀가 가중) 모두 게이트 `getSafetyByGu(gu).status==="ok"` + 값 `neighborhood.safetyGrade`. mock 분포는 23A/16B/4C/1D(전부 A 아님)지만 실제 지수와 75% 어긋남.

## 수정
두 곳에서 보너스 인덱스를 `neighborhood.safetyGrade` → **`getSafetyByGu(gu).grade`** 로. 게이트와 같은 lookup을 1회로 묶어 재사용.
- `no_data` 처리 **무변경**(이미 게이트로 제외 — 정상).
- 더 이상 안 쓰는 `ScoringNeighborhood.safetyGrade` 필드 + `SafetyGrade` import 제거.
- 통근/시세/편의/여가 공식 **무변경** — 안전 값 소스만 교정.
- `candidate.safetyGrade` 표시 필드(`run-real:201`/`mock-calc:173`)는 점수 무관 → 이 PR 범위 밖.

## ★ 순위 변동 동네 (의도된 정합성 수정)
mock과 실제 지수가 어긋났던 33개 중 대표:

**하락** (mock이 과대평가 → 실제 C/D):
- 성남 분당 서현·정자·판교, 수정 위례, 종로 평창동 (mock A → 실제 **D**): 기본 −20, #안심귀가 시 −40
- 종로3가·이태원·부천 상동·김포 사우/풍무·성남 수정동 (mock B → 실제 **D**): −15~
- 강남 역삼, 마포 공덕, 여의도, 일산 마두/장항, 송도 (mock A → 실제 **C**): −10

**상승** (mock이 과소평가):
- 금천 시흥동 (mock **D** → 실제 **B**): +15

**무변동**: 수원 등 no_data(가산 0 유지), 실제=mock 일치 10개.

## 검증
- ✅ `npx tsc --noEmit`(exit 0) / `npm run lint` 0 errors (기존 무관 warning 10건)
- ✅ `scoreCandidate` 직접 호출 (통근 25분 단조): **A=90 · B=85 · C=80 · D=70** — 보너스 테이블대로 실제 등급 기준 정렬
- ✅ `#안심귀가` 선택 시: 분당 판교/서현/정자·종로3가·이태원·평창동(실제 D) 하위로, 금천 시흥동(실제 B) 상위로 (역효과 해소)
- ✅ 수원(no_data): 안전 가산 0(제외 정상)
- ✅ mock·real / 싱글·부부 모두 동일 적용(공유 `scoreCandidate`), 통근·시세 등 다른 점수 불변

🤖 Generated with [Claude Code](https://claude.com/claude-code)