### PR TITLE
feat(stress): 스트레스 지수 P1 — ODsay 확장(환승 도보거리·역이름·노선/호선)

### DIFF
--- a/onday-app/src/lib/external/odsay-transit/mapper.ts
+++ b/onday-app/src/lib/external/odsay-transit/mapper.ts
@@ -1,4 +1,4 @@
-import type { Coordinate, CommuteInfo } from "@/lib/types";
+import type { Coordinate, CommuteInfo, RouteLine } from "@/lib/types";
 import type { OdsayPath, OdsayTransitResponse } from "./types";
 import { OdsayTransitError } from "./types";
 
@@ -11,6 +11,41 @@ function extractStationPath(path: OdsayPath): Coordinate[] {
   for (const sp of path.subPath ?? []) {
     for (const st of sp.passStopList?.stations ?? []) {
       out.push({ lat: Number(st.y), lng: Number(st.x) });
+    }
+  }
+  return out;
+}
+
+// ── 스트레스 지수 P1 — 룰 엔진(후속 P3)용 파생 데이터 추출. 전부 additive. ──
+
+/** 도보 구간(trafficType===3)의 distance 합 → 환승 도보 총거리(m). 없으면 0. */
+function sumTransferWalkMeters(path: OdsayPath): number {
+  let m = 0;
+  for (const sp of path.subPath ?? []) {
+    if (sp.trafficType === 3 && typeof sp.distance === "number") m += sp.distance;
+  }
+  return m;
+}
+
+/** 탑승 구간(지하철=1/버스=2)의 노선 목록 → RouteLine[] (쾌적도 룰 입력). */
+function extractRouteLines(path: OdsayPath): RouteLine[] {
+  const out: RouteLine[] = [];
+  for (const sp of path.subPath ?? []) {
+    if (sp.trafficType !== 1 && sp.trafficType !== 2) continue;
+    const lane = sp.lane?.[0];
+    const name = lane?.name ?? lane?.busNo;
+    if (name) out.push({ type: sp.trafficType === 1 ? "subway" : "bus", name });
+  }
+  return out;
+}
+
+/** 탑승 구간 거쳐가는 역 이름 목록(순서대로) — 착석확률/혼잡도 매칭 입력. */
+function extractRouteStations(path: OdsayPath): string[] {
+  const out: string[] = [];
+  for (const sp of path.subPath ?? []) {
+    if (sp.trafficType !== 1 && sp.trafficType !== 2) continue;
+    for (const st of sp.passStopList?.stations ?? []) {
+      if (st.stationName) out.push(st.stationName);
     }
   }
   return out;
@@ -42,6 +77,11 @@ export function mapOdsayResponseToCommuteInfo(
   const transfers = Math.max(0, subwayTransitCount + busTransitCount - 1);
   const stationPath = extractStationPath(path);
 
+  // 스트레스 지수 P1 — 룰 입력 파생 데이터(있을 때만 부착, 거짓값 금지).
+  const transferWalkMeters = sumTransferWalkMeters(path);
+  const routeLines = extractRouteLines(path);
+  const routeStations = extractRouteStations(path);
+
   return {
     time: totalTime,
     mode: "transit",
@@ -50,6 +90,10 @@ export function mapOdsayResponseToCommuteInfo(
     ...(stationPath.length >= 2 ? { routePath: stationPath } : {}),
     // 하루 미리보기 — 첫 탑승역 이름(있을 때만, 거짓값 금지). 기존 로직 무영향(필드 추가만).
     ...(firstStartStation ? { departureStation: firstStartStation } : {}),
+    // 스트레스 지수 P1 — 환승 도보거리/노선/역 목록(있을 때만). 룰·표시는 후속 P2~P4.
+    ...(transferWalkMeters > 0 ? { transferWalkMeters } : {}),
+    ...(routeLines.length ? { routeLines } : {}),
+    ...(routeStations.length ? { routeStations } : {}),
     // totalWalk / payment 는 현재 CommuteInfo 미보유 — 정보 손실 수용 (차후 모델 확장 시).
   } satisfies CommuteInfo;
 }

--- a/onday-app/src/lib/external/odsay-transit/types.ts
+++ b/onday-app/src/lib/external/odsay-transit/types.ts
@@ -28,8 +28,20 @@ export interface OdsayStation {
   y: number | string; // 위도(lat)
   stationName?: string;
 }
+/** subPath[].lane[] — 탑승 노선. 지하철=name/subwayCode, 버스=busNo. 도보 구간엔 없음. */
+export interface OdsayLane {
+  name?: string; // 노선명/호선 (지하철)
+  busNo?: string; // 버스 번호
+  subwayCode?: number; // 지하철 노선 코드
+}
 export interface OdsaySubPath {
   trafficType: number; // 1=지하철, 2=버스, 3=도보
+  // 스트레스 지수 P1 — 원응답 보유 필드(미추출이던 것). 전부 optional.
+  distance?: number; // 구간 이동 거리(m). 도보 구간이면 환승 도보거리.
+  sectionTime?: number; // 구간 소요시간(분)
+  lane?: OdsayLane[]; // 탑승 노선(지하철/버스만)
+  startName?: string; // 승차역 이름
+  endName?: string; // 하차역 이름
   passStopList?: { stations?: OdsayStation[] };
 }
 

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -12,6 +12,12 @@ export interface Coordinate {
   lng: number;
 }
 
+// 스트레스 지수 P1 — 경로상 탑승 노선(지하철 호선/버스 번호). 쾌적도 룰 입력.
+export interface RouteLine {
+  type: "subway" | "bus"; // ODsay trafficType 1=subway, 2=bus
+  name: string; // 노선명/호선 (지하철) 또는 버스 번호
+}
+
 export interface CommuteInfo {
   time: number; // minutes
   mode: CommuteMode;
@@ -21,6 +27,13 @@ export interface CommuteInfo {
   routePath?: Coordinate[];
   // 하루 미리보기 — 첫 탑승역 이름(ODsay firstStartStation). transit 실데이터만, 없으면 생략.
   departureStation?: string;
+  // ── 스트레스 지수 P1 (ODsay transit 실데이터만, 없으면 생략. 룰 엔진·표시는 후속 P2~P4) ──
+  // 환승 시 도보 이동 거리 합(m) — 계단/환승 스트레스 룰 입력.
+  transferWalkMeters?: number;
+  // 경로 탑승 노선 목록 — 쾌적도 룰 입력.
+  routeLines?: RouteLine[];
+  // 경로 탑승 역 이름 목록(순서대로) — 착석확률/혼잡도 매칭 입력.
+  routeStations?: string[];
 }
 
 export interface CandidateArea {


### PR DESCRIPTION
## 스트레스 지수 P1 — ODsay 데이터 그릇 (4단계 중 1단계)

스트레스 지수(착석확률·계단환승·쾌적도) 룰 계산에 필요한 데이터를 ODsay `searchPubTransPathT` 응답에서 추출. **전부 원응답에 이미 존재**(Phase 0 확인) → 타입 + mapper 확장만, **additive**. Phase 2 출발역 추출과 동형.

### 변경
1. **`odsay-transit/types.ts`** — `OdsaySubPath`에 `distance?`/`sectionTime?`/`lane?`/`startName?`/`endName?` 추가, `OdsayLane` 신설. 전부 optional(원응답 보유 필드).
2. **`odsay-transit/mapper.ts`** — 헬퍼 3개 추가:
   - `sumTransferWalkMeters`: 도보 구간(`trafficType===3`) `distance` 합 → `transferWalkMeters`
   - `extractRouteLines`: 탑승 구간 노선 → `routeLines` `[{type, name}]`
   - `extractRouteStations`: 탑승 구간 역 이름 → `routeStations`
   - 전부 **있을 때만 부착**(거짓값 금지). 기존 `transfers`/`time`/`routePath`/`departureStation` 무변경.
3. **`lib/types.ts`** — `CommuteInfo`에 `transferWalkMeters?`/`routeLines?`/`routeStations?` optional 추가, `RouteLine` 타입 신설. 기존 필드 무변경.

### 검증
- `npx tsc --noEmit` → **0 에러**
- `npm run lint` → **0 에러**(기존 무관 파일 경고만, 본 변경 0)
- 실 ODsay 응답 형태(강남→판교, 2호선+신분당선 환승) 매핑:
  - `transferWalkMeters: 620`(도보 180+240+200 합산), `routeLines: [수도권 2호선, 신분당선]`, `routeStations` 추출 ✅
  - **회귀 0**: `time=42 / transfers=1 / departureStation=강남 / routePath(5)` 그대로
- 엣지: 버스 직통(도보 환승 없음) → `transferWalkMeters` graceful 생략, `routeLines=[472]` ✅ (크래시 X)
- 429 rate-limit → 기존 `throw` 유지 (retry/backoff `client.ts` 무변경)

### 범위 밖 (후속)
정적 테이블(혼잡도/시종착역) = P2 · 룰 엔진 = P3 · 표시(DetailSheet/하루 미리보기) = P4

🤖 Generated with [Claude Code](https://claude.com/claude-code)