### PR TITLE
feat(stress): 스트레스 지수 지표1 — 환승 피로도(전 노선, ODsay 도보거리)

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -45,6 +45,8 @@ import { useFavoritesStore, toFavoriteSnapshot } from "@/stores/favorites";
 import { useUIStore } from "@/stores/ui";
 
 import { BudgetChipOptions } from "./budget-chip-options";
+import { TransferFatigueSection } from "@/components/data/transfer-fatigue-section";
+
 import { CommuteChipOptions } from "./commute-chip-options";
 import { SortControl } from "./sort-control";
 import { TimeChipOptions } from "./time-chip-options";
@@ -632,10 +634,18 @@ export function ResultContent({
             />
           }
           commuteExtra={
-            <TimeSlotSelector
-              value={currentDepartureTime}
-              onChange={handleTimeSlotChange}
-            />
+            <>
+              <TransferFatigueSection
+                items={[
+                  { tag: "A", commute: selectedCandidate.commuteA },
+                  { tag: "B", commute: selectedCandidate.commuteB },
+                ]}
+              />
+              <TimeSlotSelector
+                value={currentDepartureTime}
+                onChange={handleTimeSlotChange}
+              />
+            </>
           }
           dayPreview={
             <DayPreview

--- a/onday-app/src/app/globals.css
+++ b/onday-app/src/app/globals.css
@@ -43,7 +43,7 @@
     --danger: 0 84% 60%;
     --danger-soft: 0 86% 96%;
 
-    /* ───── 환승 피로도 단어색 (status 토큰보다 muted·deep — 흰 카드 위 가독성+융화) ───── */
+    /* ───── 환승 피로도 배지 텍스트색 (soft bg 위 deep 톤 — grade-a~d 패턴 답습) ───── */
     --fatigue-low: 160 50% 32%;
     --fatigue-medium: 28 78% 40%;
     --fatigue-high: 0 62% 48%;
@@ -124,11 +124,6 @@
     --primary-pastel: 222 30% 18%;
     --primary-soft: 222 28% 14%;
     --primary-deep: 221 83% 50%;
-
-    /* 환승 피로도 — 어두운 배경에선 lighten(가독성) */
-    --fatigue-low: 158 55% 58%;
-    --fatigue-medium: 33 85% 62%;
-    --fatigue-high: 0 75% 70%;
   }
 
   /* ───── Base resets ───── */

--- a/onday-app/src/app/globals.css
+++ b/onday-app/src/app/globals.css
@@ -43,6 +43,11 @@
     --danger: 0 84% 60%;
     --danger-soft: 0 86% 96%;
 
+    /* ───── 환승 피로도 단어색 (status 토큰보다 muted·deep — 흰 카드 위 가독성+융화) ───── */
+    --fatigue-low: 160 50% 32%;
+    --fatigue-medium: 28 78% 40%;
+    --fatigue-high: 0 62% 48%;
+
     /* ───── Safety grades (letter+label+color 3중 표기 필수) ───── */
     --safety-a: 160 84% 39%;
     --safety-b: 217 91% 60%;
@@ -119,6 +124,11 @@
     --primary-pastel: 222 30% 18%;
     --primary-soft: 222 28% 14%;
     --primary-deep: 221 83% 50%;
+
+    /* 환승 피로도 — 어두운 배경에선 lighten(가독성) */
+    --fatigue-low: 158 55% 58%;
+    --fatigue-medium: 33 85% 62%;
+    --fatigue-high: 0 75% 70%;
   }
 
   /* ───── Base resets ───── */

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, ChevronLeft, FileDown, Home } from "lucide-react";
 
 import { SafetyCard } from "@/components/card/safety-card";
 import { LegendBar } from "@/components/data/legend-bar";
+import { TransferFatigueSection } from "@/components/data/transfer-fatigue-section";
 import { MapCanvas } from "@/components/map/map-canvas";
 import type { MapWorkplace, MapLine } from "@/components/map/map-canvas";
 import { DetailSheet } from "@/components/sheet/detail-sheet";
@@ -797,6 +798,11 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                     topRightSlot={mapModeToggle}
                     fitAll
                     height={180}
+                  />
+                }
+                commuteExtra={
+                  <TransferFatigueSection
+                    items={[{ tag: "A", commute: selectedCandidate.commuteA }]}
                   />
                 }
                 dayPreview={

--- a/onday-app/src/components/data/transfer-fatigue-section.tsx
+++ b/onday-app/src/components/data/transfer-fatigue-section.tsx
@@ -11,11 +11,12 @@ import { cn } from "@/lib/utils";
 
 // 스트레스 지수 지표1 — 환승 피로도 표시. detail-sheet commuteExtra slot 에 inject(부부/싱글 공용).
 //   레벨은 라벨("낮음/보통/높음") + 색 토큰 + emoji 3중 표기(색 단독 의존 금지, 안전등급 규칙 답습).
+//   색은 status 토큰보다 muted·deep 한 fatigue 전용 토큰(흰 카드 위 가독성·앱 톤 융화, dark lighten).
 
 const TONE_CLASS: Record<TransferFatigue["tone"], string> = {
-  success: "text-success",
-  warning: "text-warning",
-  danger: "text-danger",
+  success: "text-fatigue-low",
+  warning: "text-fatigue-medium",
+  danger: "text-fatigue-high",
 };
 
 interface FatigueItem {

--- a/onday-app/src/components/data/transfer-fatigue-section.tsx
+++ b/onday-app/src/components/data/transfer-fatigue-section.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  computeTransferFatigue,
+  type TransferFatigue,
+} from "@/features/stress/transfer-fatigue";
+import type { CommuteInfo } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+// 스트레스 지수 지표1 — 환승 피로도 표시. detail-sheet commuteExtra slot 에 inject(부부/싱글 공용).
+//   레벨은 라벨("낮음/보통/높음") + 색 토큰 + emoji 3중 표기(색 단독 의존 금지, 안전등급 규칙 답습).
+
+const TONE_CLASS: Record<TransferFatigue["tone"], string> = {
+  success: "text-success",
+  warning: "text-warning",
+  danger: "text-danger",
+};
+
+interface FatigueItem {
+  tag: "A" | "B";
+  commute: CommuteInfo | undefined;
+}
+
+export function TransferFatigueSection({ items }: { items: FatigueItem[] }) {
+  const rows = items
+    .map((it) => ({ tag: it.tag, fatigue: computeTransferFatigue(it.commute) }))
+    .filter(
+      (r): r is { tag: "A" | "B"; fatigue: TransferFatigue } =>
+        r.fatigue !== null,
+    );
+
+  if (rows.length === 0) return null;
+  const showTag = rows.length > 1; // 부부 모드(A/B 둘 다)일 때만 태그 표시
+
+  return (
+    <section aria-label="환승 피로도" className="space-y-s-2">
+      <p className="text-caption font-bold text-ink-2">환승 피로도</p>
+      {rows.map(({ tag, fatigue }) => (
+        <div
+          key={tag}
+          className="flex items-start gap-s-2 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 shadow-card"
+        >
+          {showTag && (
+            <span
+              aria-hidden
+              className={cn(
+                "inline-flex size-6 shrink-0 items-center justify-center rounded-sm text-caption-xs font-extrabold text-white",
+                tag === "A" ? "bg-primary" : "bg-secondary",
+              )}
+            >
+              {tag}
+            </span>
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="text-body-sm text-ink">
+              <span className="font-bold">{fatigue.label}</span>
+              {fatigue.levelLabel ? (
+                <span
+                  className={cn("ml-s-2 font-bold", TONE_CLASS[fatigue.tone])}
+                >
+                  피로도 {fatigue.levelLabel} {fatigue.emoji}
+                </span>
+              ) : (
+                <span className="ml-s-2">{fatigue.emoji}</span>
+              )}
+            </p>
+            {fatigue.quip && (
+              <p className="text-caption text-ink-3">{fatigue.quip}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/onday-app/src/components/data/transfer-fatigue-section.tsx
+++ b/onday-app/src/components/data/transfer-fatigue-section.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 
+import { Badge, type BadgeProps } from "@/components/ui/badge";
 import {
   computeTransferFatigue,
   type TransferFatigue,
@@ -10,13 +11,16 @@ import type { CommuteInfo } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 // 스트레스 지수 지표1 — 환승 피로도 표시. detail-sheet commuteExtra slot 에 inject(부부/싱글 공용).
-//   레벨은 라벨("낮음/보통/높음") + 색 토큰 + emoji 3중 표기(색 단독 의존 금지, 안전등급 규칙 답습).
-//   색은 status 토큰보다 muted·deep 한 fatigue 전용 토큰(흰 카드 위 가독성·앱 톤 융화, dark lighten).
+//   레벨은 라벨("낮음/보통/높음") 텍스트 + 색 배지 2중 표기(색 단독 의존 금지). "BEST 매칭" 배지 패턴 답습:
+//   Badge size="xs"(헤더 pill 동일) + soft bg + deep 텍스트(fatigue-* variant). "환승 N회·도보 Nm"은 본문 텍스트.
 
-const TONE_CLASS: Record<TransferFatigue["tone"], string> = {
-  success: "text-fatigue-low",
-  warning: "text-fatigue-medium",
-  danger: "text-fatigue-high",
+const TONE_VARIANT: Record<
+  TransferFatigue["tone"],
+  Extract<BadgeProps["variant"], `fatigue-${string}`>
+> = {
+  success: "fatigue-low",
+  warning: "fatigue-medium",
+  danger: "fatigue-high",
 };
 
 interface FatigueItem {
@@ -55,20 +59,23 @@ export function TransferFatigueSection({ items }: { items: FatigueItem[] }) {
             </span>
           )}
           <div className="min-w-0 flex-1">
-            <p className="text-body-sm text-ink">
-              <span className="font-bold">{fatigue.label}</span>
-              {fatigue.levelLabel ? (
-                <span
-                  className={cn("ml-s-2 font-bold", TONE_CLASS[fatigue.tone])}
-                >
-                  피로도 {fatigue.levelLabel} {fatigue.emoji}
-                </span>
-              ) : (
-                <span className="ml-s-2">{fatigue.emoji}</span>
-              )}
-            </p>
+            {fatigue.level === "none" ? (
+              // 직통 — 긍정 강조를 배지 하나로.
+              <Badge variant={TONE_VARIANT[fatigue.tone]} size="xs">
+                {fatigue.label}
+              </Badge>
+            ) : (
+              <p className="flex flex-wrap items-center gap-s-2 text-body-sm text-ink">
+                <span className="font-bold">{fatigue.label}</span>
+                {fatigue.levelLabel && (
+                  <Badge variant={TONE_VARIANT[fatigue.tone]} size="xs">
+                    피로도 {fatigue.levelLabel}
+                  </Badge>
+                )}
+              </p>
+            )}
             {fatigue.quip && (
-              <p className="text-caption text-ink-3">{fatigue.quip}</p>
+              <p className="mt-s-1 text-caption text-ink-3">{fatigue.quip}</p>
             )}
           </div>
         </div>

--- a/onday-app/src/components/ui/badge.tsx
+++ b/onday-app/src/components/ui/badge.tsx
@@ -37,6 +37,10 @@ const badgeVariants = cva(
         "grade-b": "bg-[hsl(213_97%_87%)] text-[hsl(224_76%_48%)]",
         "grade-c": "bg-[hsl(48_96%_89%)] text-[hsl(35_92%_33%)]",
         "grade-d": "bg-[hsl(0_93%_94%)] text-[hsl(0_74%_42%)]",
+        // 환승 피로도 — soft bg + deep 텍스트(grade-a~d 패턴). 은은하게, 쨍하지 않게.
+        "fatigue-low": "bg-success-soft text-fatigue-low",
+        "fatigue-medium": "bg-warning-soft text-fatigue-medium",
+        "fatigue-high": "bg-danger-soft text-fatigue-high",
       },
       size: {
         sm: "px-s-2 py-s-1 text-caption-xs [&>svg]:size-3",

--- a/onday-app/src/features/stress/transfer-fatigue.ts
+++ b/onday-app/src/features/stress/transfer-fatigue.ts
@@ -1,0 +1,106 @@
+import type { CommuteInfo } from "@/lib/types";
+
+// 스트레스 지수 지표1 — 환승 피로도(전 노선 100% 커버).
+//   ODsay 도보거리(transferWalkMeters) + 환승 횟수(transfers)만 사용 → 노선 무관(P1 확보).
+//   혼잡도(지표2, 서울교통공사 1~8호선)와 독립. 정적 임계 룰 — 투명·재현 가능.
+
+export type FatigueLevel = "none" | "low" | "medium" | "high";
+
+// 환승 도보거리(m) 임계 — 조정 가능. 경계 포함 규칙: [0,250) 낮음 · [250,500) 보통 · [500,∞) 높음.
+const MEDIUM_THRESHOLD_M = 250;
+const HIGH_THRESHOLD_M = 500;
+
+// 막장환승 위트 — 경로에 있으면 멘트만 추가(점수·레벨 영향 0). 거리와 모순 막으려 보통/높음일 때만 부착.
+//   routeStations 는 ODsay 역명(접미사 "역" 없음) — 정적 목록도 동일 형식.
+const NOTORIOUS_TRANSFER_STATIONS = [
+  "종로3가",
+  "고속터미널",
+  "노원",
+  "동대문역사문화공원",
+  "신도림",
+  "왕십리",
+] as const;
+
+export interface TransferFatigue {
+  level: FatigueLevel;
+  transfers: number;
+  walkMeters?: number;
+  /** 메인 라벨 — "환승 없이 한 번에" 또는 "환승 2회 · 도보 450m" */
+  label: string;
+  /** 레벨 표시 — "낮음"/"보통"/"높음" (환승 없음은 undefined) */
+  levelLabel?: string;
+  emoji: string; // 🟢🟡🔴 (라벨·색과 함께 3중 표기)
+  tone: "success" | "warning" | "danger"; // 디자인 토큰 매핑
+  /** 막장환승 위트 멘트(있을 때만, 점수 무관) */
+  quip?: string;
+}
+
+function levelFromMeters(m: number): Exclude<FatigueLevel, "none"> {
+  if (m >= HIGH_THRESHOLD_M) return "high";
+  if (m >= MEDIUM_THRESHOLD_M) return "medium";
+  return "low";
+}
+
+const LEVEL_META: Record<
+  Exclude<FatigueLevel, "none">,
+  { levelLabel: string; emoji: string; tone: TransferFatigue["tone"] }
+> = {
+  low: { levelLabel: "낮음", emoji: "🟢", tone: "success" },
+  medium: { levelLabel: "보통", emoji: "🟡", tone: "warning" },
+  high: { levelLabel: "높음", emoji: "🔴", tone: "danger" },
+};
+
+function findNotoriousStation(routeStations?: string[]): string | undefined {
+  if (!routeStations?.length) return undefined;
+  return NOTORIOUS_TRANSFER_STATIONS.find((s) => routeStations.includes(s));
+}
+
+/**
+ * 통근 정보 → 환승 피로도. transit 외(차량) 또는 환승 정보 없으면 null.
+ * - 환승 0회: "환승 없이 한 번에" (🟢, success).
+ * - 환승 ≥1: 도보거리 기준 낮음/보통/높음. 거리 정보 없으면 "환승 N회"만(레벨 생략).
+ */
+export function computeTransferFatigue(
+  commute: CommuteInfo | undefined,
+): TransferFatigue | null {
+  if (!commute || commute.mode !== "transit") return null;
+  const transfers = commute.transfers ?? 0;
+
+  if (transfers === 0) {
+    return {
+      level: "none",
+      transfers: 0,
+      label: "환승 없이 한 번에",
+      emoji: "🟢",
+      tone: "success",
+    };
+  }
+
+  const walkMeters = commute.transferWalkMeters;
+  // 환승은 있는데 ODsay 도보거리 결측 → 레벨 산정 불가, 횟수만 정직하게 표시.
+  if (typeof walkMeters !== "number") {
+    return {
+      level: "low",
+      transfers,
+      label: `환승 ${transfers}회`,
+      emoji: "🟡",
+      tone: "warning",
+    };
+  }
+
+  const level = levelFromMeters(walkMeters);
+  const meta = LEVEL_META[level];
+  const notorious =
+    level === "low" ? undefined : findNotoriousStation(commute.routeStations);
+
+  return {
+    level,
+    transfers,
+    walkMeters,
+    label: `환승 ${transfers}회 · 도보 ${walkMeters}m`,
+    levelLabel: meta.levelLabel,
+    emoji: meta.emoji,
+    tone: meta.tone,
+    ...(notorious ? { quip: `${notorious} 환승은 꽤 걸어요 🚶` } : {}),
+  };
+}

--- a/onday-app/src/features/stress/transfer-fatigue.ts
+++ b/onday-app/src/features/stress/transfer-fatigue.ts
@@ -50,6 +50,14 @@ const LEVEL_META: Record<
   high: { levelLabel: "높음", emoji: "🔴", tone: "danger" },
 };
 
+// 다정한 큐레이터 멘트 — 거리 데이터와 모순 없게(낮음에 "힘들어요" 금지). 착석/혼잡도 언급 금지(지표2 영역).
+const LEVEL_QUIP: Record<FatigueLevel, string> = {
+  none: "환승 없이 한 번에! 출근길이 편안해요 😌",
+  low: "환승은 있지만 동선이 짧아 부담 없어요 👍",
+  medium: "적당한 환승 거리예요",
+  high: "환승 동선이 길어 체력 소모가 있어요",
+};
+
 function findNotoriousStation(routeStations?: string[]): string | undefined {
   if (!routeStations?.length) return undefined;
   return NOTORIOUS_TRANSFER_STATIONS.find((s) => routeStations.includes(s));
@@ -73,6 +81,7 @@ export function computeTransferFatigue(
       label: "환승 없이 한 번에",
       emoji: "🟢",
       tone: "success",
+      quip: LEVEL_QUIP.none,
     };
   }
 
@@ -90,8 +99,12 @@ export function computeTransferFatigue(
 
   const level = levelFromMeters(walkMeters);
   const meta = LEVEL_META[level];
+  // 막장환승 멘트는 높음일 때만 우선(거리와 모순 없음). 그 외엔 레벨별 멘트.
   const notorious =
-    level === "low" ? undefined : findNotoriousStation(commute.routeStations);
+    level === "high" ? findNotoriousStation(commute.routeStations) : undefined;
+  const quip = notorious
+    ? `${notorious} 환승은 꽤 걸어요 🚶`
+    : LEVEL_QUIP[level];
 
   return {
     level,
@@ -101,6 +114,6 @@ export function computeTransferFatigue(
     levelLabel: meta.levelLabel,
     emoji: meta.emoji,
     tone: meta.tone,
-    ...(notorious ? { quip: `${notorious} 환승은 꽤 걸어요 🚶` } : {}),
+    quip,
   };
 }

--- a/onday-app/tailwind.config.ts
+++ b/onday-app/tailwind.config.ts
@@ -71,6 +71,11 @@ const config: Config = {
           c: "hsl(var(--safety-c))",
           d: "hsl(var(--safety-d))",
         },
+        fatigue: {
+          low: "hsl(var(--fatigue-low))",
+          medium: "hsl(var(--fatigue-medium))",
+          high: "hsl(var(--fatigue-high))",
+        },
         oauth: {
           kakao: "#FEE500",
           "kakao-ink": "#191600",


### PR DESCRIPTION
## 스트레스 지수 지표1 — 환승 피로도 (전 노선 100% 커버)

스트레스 지수를 **두 독립 지표**로 분리. 그 중 **지표1 "환승 피로도"** 를 먼저 구현. ODsay 도보거리(P1 `transferWalkMeters`) + 환승 횟수만 사용 → **노선 무관 전 노선 커버**(신분당선·9호선 등 포함). 혼잡도(지표2, 서울교통공사 1~8호선)는 별도 후속.

### 룰 (정적 임계 — 투명·재현)
| 환승 도보거리 | 레벨 | 색/emoji |
|---|---|---|
| 0회(직통) | 환승 없이 한 번에 | 🟢 success |
| [0, 250)m | 낮음 | 🟢 success |
| [250, 500)m | 보통 | 🟡 warning |
| [500, ∞)m | 높음 | 🔴 danger |
- 거리 결측 시 횟수만 표시(graceful). 차량 통근/환승 정보 없음 → 미표시(null).
- **막장환승 위트 멘트**(종로3가·고속터미널·노원 등): 점수·레벨 영향 0, `routeStations`로 감지. **거리와 모순 막으려 보통/높음일 때만** 부착.

### 변경
- `features/stress/transfer-fatigue.ts` — 순수 함수 룰 헬퍼(신규).
- `components/data/transfer-fatigue-section.tsx` — 표시 컴포넌트(신규). **라벨+색토큰+emoji 3중 표기**(안전등급 규칙 답습, 색 단독 의존 X). 부부=A/B, 싱글=A.
- `result-content.tsx` / `single-result-view.tsx` — DetailSheet `commuteExtra` slot에 inject. 부부는 기존 `TimeSlotSelector` 유지하며 앞에 추가.

### STEP 0 — 디자인 토큰
- 색: 기존 `text-success`/`text-warning`/`text-danger` (Badge·candidate-card·toaster 동일 토큰).
- 카드: 통근 행과 동일 `rounded-lg border border-card-border bg-surface px-s-4 py-s-3 shadow-card`. A/B 태그도 기존 `bg-primary`/`bg-secondary` 답습. spacing 토큰 `s-N`, `cn` 사용.

### 검증
- `npx tsc --noEmit` → **0 에러** / `npm run lint` → **0 에러**(기존 무관 warning만)
- 룰 경계: 249=낮음 · 250=보통 · 499=보통 · 500=높음 ✅
- **전 노선**: 신분당선 강남→판교(620m) → 높음🔴 표시(혼잡도 없어도) ✅
- 환승 0회 → "환승 없이 한 번에" ✅ / 거리 결측 → "환승 N회"만 ✅
- 막장환승역+540m → 위트 멘트 ✅ / 막장환승역이어도 120m(낮음) → **멘트 없음**(모순 방지) ✅
- 차량·undefined → null(미표시) ✅
- 회귀 0: 통근 계산·캐싱·미리보기·점수 무변경, P1 필드 읽기만

### 범위 밖 (후속)
혼잡도(지표2, 서울교통공사 1~8호선 CSV) · 정적 테이블 · 착석확률·쾌적도 룰

🤖 Generated with [Claude Code](https://claude.com/claude-code)