### PR TITLE
feat(stress): 2-B — P1.5 (역+호선) 매칭 보강 + 출근길 혼잡도 룰

### DIFF
--- a/onday-app/src/features/stress/route-congestion.ts
+++ b/onday-app/src/features/stress/route-congestion.ts
@@ -13,9 +13,9 @@ export type CongestionLevel = "low" | "medium" | "high" | "veryHigh";
 
 // 혼잡도 % → 레벨/문구. 서울교통공사 정의: 좌석만 차면 ~34%, 100%=입석 포함 정원.
 const LEVELS: { level: CongestionLevel; min: number; label: string }[] = [
-  { level: "veryHigh", min: 150, label: "많이 혼잡해요, 각오하세요 😣" },
-  { level: "high", min: 130, label: "서서 가기 힘들 수 있어요" },
-  { level: "medium", min: 80, label: "출근길이 꽤 붐벼요" },
+  { level: "veryHigh", min: 150, label: "매우 혼잡해요 😣" },
+  { level: "high", min: 130, label: "서서 가기 힘들 수 있어요 😥" },
+  { level: "medium", min: 80, label: "출근길이 꽤 붐벼요 🚶" },
   { level: "low", min: 0, label: "비교적 여유로워요 😌" },
 ];
 

--- a/onday-app/src/features/stress/route-congestion.ts
+++ b/onday-app/src/features/stress/route-congestion.ts
@@ -1,0 +1,99 @@
+import type { CommuteInfo } from "@/lib/types";
+import { getCongestion } from "./congestion";
+
+// 스트레스 지수 2-B — 출근길 혼잡도 룰. P1.5 routeSegments 의 각 지하철 구간을
+//   (호선+승차역+출근시각) 으로 2-A congestion 조회 → 경로 대표 혼잡도 + 부드러운 문구.
+//   ★ 착석 "가능/불가" 단정 금지 — 혼잡도 %(객관 팩트) + 사실 기반 문구만.
+//   ★ 방향(상/하·내/외선)은 평균(getCongestion direction 미지정). 1~8호선만, 그 외 no_data.
+//   표시 UI 는 2-C — 여기선 값 반환까지.
+
+const DEFAULT_DEPARTURE = "08:00";
+
+export type CongestionLevel = "low" | "medium" | "high" | "veryHigh";
+
+// 혼잡도 % → 레벨/문구. 서울교통공사 정의: 좌석만 차면 ~34%, 100%=입석 포함 정원.
+const LEVELS: { level: CongestionLevel; min: number; label: string }[] = [
+  { level: "veryHigh", min: 150, label: "많이 혼잡해요, 각오하세요 😣" },
+  { level: "high", min: 130, label: "서서 가기 힘들 수 있어요" },
+  { level: "medium", min: 80, label: "출근길이 꽤 붐벼요" },
+  { level: "low", min: 0, label: "비교적 여유로워요 😌" },
+];
+
+function levelFor(percent: number): { level: CongestionLevel; label: string } {
+  const m = LEVELS.find((l) => percent >= l.min) ?? LEVELS[LEVELS.length - 1];
+  return { level: m.level, label: m.label };
+}
+
+export interface RouteCongestionOk {
+  status: "ok";
+  percent: number; // 경로 대표 혼잡도(최고 혼잡 구간)
+  level: CongestionLevel;
+  label: string; // 부드러운 상태 문구
+  peakLine: string; // 대표(최고) 구간 호선
+  peakStation: string; // 대표(최고) 구간 승차역
+  coveredSegments: number; // 혼잡도 조회된 지하철 구간 수
+  totalSubwaySegments: number; // 경로의 지하철 구간 수
+  departureTime: string; // 조회 기준 출근 시각(HH:MM)
+  basisNote: string; // 정직성 — 산출 기준 표기
+}
+
+export interface RouteCongestionNoData {
+  status: "no_data";
+  reason: string; // 사람이 읽는 사유(1~8호선 외 등)
+  totalSubwaySegments: number;
+  departureTime: string;
+}
+
+export type RouteCongestion = RouteCongestionOk | RouteCongestionNoData;
+
+/**
+ * 통근 정보 → 출근길 혼잡도. transit 아님/지하철 구간 없음/routeSegments 없음 → null(미해당).
+ * 지하철 구간은 있으나 전부 1~8호선 외(신분당선·9호선 등) → no_data.
+ */
+export function computeRouteCongestion(
+  commute: CommuteInfo | undefined,
+  departureTime: string = DEFAULT_DEPARTURE,
+): RouteCongestion | null {
+  if (!commute || commute.mode !== "transit") return null;
+
+  const subwaySegs = (commute.routeSegments ?? []).filter(
+    (s) => s.line.type === "subway",
+  );
+  if (subwaySegs.length === 0) return null; // 버스 전용·경로정보 없음 → 미해당
+
+  const hits: { percent: number; line: string; station: string }[] = [];
+  for (const seg of subwaySegs) {
+    const station = seg.from ?? seg.stations[0];
+    if (!station) continue;
+    const r = getCongestion(seg.line.name, station, departureTime);
+    if (r.status === "ok") {
+      hits.push({ percent: r.percent, line: r.line, station });
+    }
+  }
+
+  if (hits.length === 0) {
+    return {
+      status: "no_data",
+      reason: "혼잡도 미제공 구간이에요 (서울교통공사 1~8호선만 제공)",
+      totalSubwaySegments: subwaySegs.length,
+      departureTime,
+    };
+  }
+
+  // 대표값 = 최고 혼잡 구간(출근 체감은 가장 붐비는 구간이 좌우 — 평균은 가혹한 구간 희석).
+  const peak = hits.reduce((a, b) => (b.percent > a.percent ? b : a));
+  const { level, label } = levelFor(peak.percent);
+
+  return {
+    status: "ok",
+    percent: peak.percent,
+    level,
+    label,
+    peakLine: peak.line,
+    peakStation: peak.station,
+    coveredSegments: hits.length,
+    totalSubwaySegments: subwaySegs.length,
+    departureTime,
+    basisNote: "상·하선 방향 평균, 경로 중 가장 혼잡한 구간 기준",
+  };
+}

--- a/onday-app/src/lib/external/odsay-transit/mapper.ts
+++ b/onday-app/src/lib/external/odsay-transit/mapper.ts
@@ -1,4 +1,4 @@
-import type { Coordinate, CommuteInfo, RouteLine } from "@/lib/types";
+import type { Coordinate, CommuteInfo, RouteLine, RouteSegment } from "@/lib/types";
 import type { OdsayPath, OdsayTransitResponse } from "./types";
 import { OdsayTransitError } from "./types";
 
@@ -52,6 +52,31 @@ function extractRouteStations(path: OdsayPath): string[] {
 }
 
 /**
+ * P1.5 — 탑승 구간(지하철=1/버스=2) 1개 = RouteSegment 1개. (역+호선) 묶음 보존.
+ *   routeStations(flat)와 달리 구간 경계 유지 → 환승 경로 혼잡도 매칭(어느 역이 어느 호선).
+ */
+function extractRouteSegments(path: OdsayPath): RouteSegment[] {
+  const out: RouteSegment[] = [];
+  for (const sp of path.subPath ?? []) {
+    if (sp.trafficType !== 1 && sp.trafficType !== 2) continue;
+    const lane = sp.lane?.[0];
+    const name = lane?.name ?? lane?.busNo;
+    if (!name) continue;
+    const stations: string[] = [];
+    for (const st of sp.passStopList?.stations ?? []) {
+      if (st.stationName) stations.push(st.stationName);
+    }
+    out.push({
+      line: { type: sp.trafficType === 1 ? "subway" : "bus", name },
+      ...(sp.startName ? { from: sp.startName } : {}),
+      ...(sp.endName ? { to: sp.endName } : {}),
+      stations,
+    });
+  }
+  return out;
+}
+
+/**
  * ODsay 대중교통 길찾기 응답 → CommuteInfo (앱 모델 무변경 — R2 transit-only).
  * - 추천 경로 result.path[0] 사용 (ODsay 정렬 = 최단/추천 우선).
  * - transfers = (지하철+버스 탑승 횟수) − 1 (첫 탑승은 환승 아님).
@@ -81,6 +106,7 @@ export function mapOdsayResponseToCommuteInfo(
   const transferWalkMeters = sumTransferWalkMeters(path);
   const routeLines = extractRouteLines(path);
   const routeStations = extractRouteStations(path);
+  const routeSegments = extractRouteSegments(path); // P1.5 — (역+호선) 묶음
 
   return {
     time: totalTime,
@@ -94,6 +120,7 @@ export function mapOdsayResponseToCommuteInfo(
     ...(transferWalkMeters > 0 ? { transferWalkMeters } : {}),
     ...(routeLines.length ? { routeLines } : {}),
     ...(routeStations.length ? { routeStations } : {}),
+    ...(routeSegments.length ? { routeSegments } : {}),
     // totalWalk / payment 는 현재 CommuteInfo 미보유 — 정보 손실 수용 (차후 모델 확장 시).
   } satisfies CommuteInfo;
 }

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -18,6 +18,15 @@ export interface RouteLine {
   name: string; // 노선명/호선 (지하철) 또는 버스 번호
 }
 
+// 스트레스 지수 P1.5 — ODsay subPath 1개(탑승 구간) = segment 1개. (역+호선) 묶음 보존.
+//   routeStations/routeLines(flat)로는 환승 경로에서 역-호선 경계가 소실 → 혼잡도 매칭용 묶음.
+export interface RouteSegment {
+  line: RouteLine; // 이 구간 노선
+  from?: string; // 승차역 (ODsay startName)
+  to?: string; // 하차역 (ODsay endName)
+  stations: string[]; // 이 구간 거쳐가는 역 이름(순서대로)
+}
+
 export interface CommuteInfo {
   time: number; // minutes
   mode: CommuteMode;
@@ -34,6 +43,8 @@ export interface CommuteInfo {
   routeLines?: RouteLine[];
   // 경로 탑승 역 이름 목록(순서대로) — 착석확률/혼잡도 매칭 입력.
   routeStations?: string[];
+  // P1.5 — 탑승 구간별 (역+호선) 묶음. 환승 경로 혼잡도 매칭용(routeStations flat 보완).
+  routeSegments?: RouteSegment[];
 }
 
 export interface CandidateArea {


### PR DESCRIPTION
## 스트레스 지수 2-B — (역+호선) 매칭 + 출근길 혼잡도 룰

ODsay 경로의 각 지하철 구간을 **(역+호선)으로 정확 매칭**해 혼잡도(2-A 빌드) 조회 → "출근길 혼잡도" 값 반환. **착석 추정 안 함**(혼잡도 % 팩트 + 부드러운 문구). 1~8호선만. **표시 UI는 2-C**.

### Part 1 — P1.5 mapper 보강 (additive)
- `routeStations`/`routeLines`(flat)는 환승 경로에서 역-호선 경계가 소실(종로3가가 1/3/5호선 중 뭔지 불명). 원응답 `subPath`엔 `lane`+`stations` 묶음이 이미 존재.
- `CommuteInfo.routeSegments?: { line; from?; to?; stations[] }[]` 신규 — 지하철 subPath 1개 = segment 1개.
- ★ 기존 `routeStations`/`routeLines`/`transferWalkMeters` **무변경**(additive). 통근/지표1 회귀 0.

### Part 2 — 혼잡도 룰 (`features/stress/route-congestion.ts`)
- `routeSegments` 지하철 구간을 `(normalizeLine(line.name), from역, departureTime)`으로 2-A `getCongestion` 조회(**방향 미지정=평균**).
- 출근 시각: `filters.commuteSchedule.departureTime`("HH:MM", 기본 `08:00`).
- 대표값 = **경로 중 최고 혼잡 구간**(출근 체감은 가장 붐비는 구간이 좌우 — 평균은 가혹한 구간 희석). `basisNote`에 "상·하선 방향 평균, 경로 중 가장 혼잡한 구간 기준" 명시.
- `no_data` 구간(신분당선·9호선 등)은 skip, 전구간 no_data면 "혼잡도 미제공".
- 문구 4단계(서울교통공사 정의: 좌석만 차면 ~34%, 100%=입석 포함 정원):
  | 혼잡도 | 문구 |
  |---|---|
  | ~80% | 비교적 여유로워요 😌 |
  | 80~130% | 출근길이 꽤 붐벼요 |
  | 130~150% | 서서 가기 힘들 수 있어요 |
  | 150%+ | 많이 혼잡해요, 각오하세요 😣 |
- ★ 정직성: 혼잡도 %(객관), 착석 "가능/불가" 단정 금지.

### 검증
- `npx tsc --noEmit` → **0 에러** / `npm run lint` → **0 에러**(기존 무관 warning만)
- **P1.5**: 종로3가 환승 경로 → `routeSegments`가 1호선 구간(서울역→종로3가)/3호선 구간(종로3가→양재) 정확 분리 ✅. flat `routeStations`엔 종로3가 2번이지만 segment는 호선으로 disambiguate. 회귀(transfers/time) 0.
- **혼잡도 룰**: 강남→판교(2호선+신분당선) → 2호선 강남 8시 75.5% ok + 신분당선 no_data skip → 대표 75.5%, covered 1/2 ✅
- `departureTime` 7/8/9시 → 48 / 75.5 / 64.8 변동 ✅
- 신분당선 단일 → `no_data`("혼잡도 미제공") ✅ / 버스전용·driving·undefined → `null`(미해당) ✅
- 종로3가 경로 → 최고 구간(3호선 67.2%) + `peakLine="3호선"` ✅
- 통근/시세/안전/지표1/캐싱/점수 무변경

### 범위 밖 (2-C)
- 표시 UI(DetailSheet/하루 미리보기) — 부부/싱글
- 356KB JSON 클라이언트 번들 처리(server route 또는 출근시간대만 추리기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)