### PR TITLE
fix(single): 결과 지도 마커 클릭 시 DetailSheet 안 열림 (핫픽스)

### DIFF
--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -682,6 +682,7 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                 workplaces={workplaces}
                 lines={lines}
                 topRightSlot={mapModeToggle}
+                onMarkerClick={open}
               />
             </div>
 


### PR DESCRIPTION
## 핫픽스 — 싱글 결과 지도 마커 클릭이 시트를 안 엶

### 증상
싱글 모드 결과 지도의 숫자 마커(1·2·3…) 클릭이 `DetailSheet`를 열지 않음. (싱글 카드 클릭은 정상, 부부 모드는 마커 클릭도 정상)

### 원인
- 부부(`result-content.tsx`): 메인 `<MapCanvas … onMarkerClick={open} />` 전달 → 마커 클릭 시 시트 오픈.
- 싱글(`single-result-view.tsx`): 메인 MapCanvas가 **`onMarkerClick`을 전달하지 않음** → 마커 클릭 no-op.
- `MapCanvas`의 `onMarkerClick?: (id) => void`는 optional이라 미전달 시 조용히 무동작.
- 싱글에 `open` setter(`setOpenId`)·markers `id: c.id` 모두 이미 준비됨 → **콜백 연결만 누락**.

### 수정
- 싱글 메인 MapCanvas에 **`onMarkerClick={open}` 한 줄 추가**(부부 패턴 동일).
- 디테일 시트 내부 MapCanvas(단일 후보 표시용)는 무변경.

### 검증
- `npx tsc --noEmit` → **0 에러** / `npm run lint` → **0 에러**
- 마커 id가 candidate `c.id`이고 `open(cid)=setOpenId(cid)` → 클릭한 동네의 시트가 정확히 열림(id 매칭 OK)
- 카드 클릭·부부 모드·MapCanvas 컴포넌트·open setter 무변경 (회귀 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)