### PR TITLE
feat(summary): #4+#54/#51 Phase 1 — 30분 요약 백엔드 (데이터 + AI rationale)

### DIFF
--- a/onday-app/src/app/api/summary/route.ts
+++ b/onday-app/src/app/api/summary/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { generateObject } from "ai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { SummaryFacts } from "@/lib/summary/extract-summary";
+import {
+  buildRationalePrompt,
+  generateFallbackRationale,
+  rationaleSchema,
+  sanitizeRationale,
+} from "@/lib/summary/rationale";
+import { createAppError } from "@/lib/helpers/app-error";
+import { reportErrorToSentry } from "@/lib/helpers/sentry-error";
+import { CommonErrorCode } from "@/lib/types/errors";
+
+// 30분 요약 — Gemini "이 동네 추천 이유" 한 줄 (UI-011/QRY-DL-002 Phase 1).
+//   /api/insight(하루 미리보기) 패턴 복제 — createGoogleGenerativeAI + generateObject + thinkingBudget=0.
+//   ★ route = 후보 1건 → rationale 1건. 클라(Phase 3)가 Top3 Promise.all (Vercel 10초 한도·CLAUDE.md §3).
+//   ★ 빈 카드 방지(spec getSummary §3.2): AI 실패/키 없음 → 룰 기반 fallback 200 반환(502 아님). 400=잘못된 입력만.
+//   ★ 서버 전용 키 — GOOGLE_GENERATIVE_AI_API_KEY (NEXT_PUBLIC 아님: 키 브라우저 노출 금지).
+export const dynamic = "force-dynamic";
+// CLAUDE.md §3 — Vercel 무료 함수 10초 한도. thinkingBudget=0 + Flash 단발로 회피.
+export const maxDuration = 10;
+
+const API_KEY = process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "";
+// CON-14 — 모델은 env 만으로 교체 가능(provider 분기는 GA 이연). 미설정 시 무료 동작 Flash 기본.
+const MODEL_ID = process.env.GEMINI_MODEL ?? "gemini-2.5-flash";
+// ★ Gemini 호출 상한 — Vercel 10초 한도 안쪽에서 abort → fallback (빈 카드 방지).
+const AI_TIMEOUT_MS = 8000;
+
+// 입력 최소 검증 — SummaryFacts 핵심 필드(없으면 프롬프트 생성 불가).
+function isValidFacts(d: unknown): d is SummaryFacts {
+  const x = d as SummaryFacts | null;
+  return (
+    !!x &&
+    typeof x.dong === "string" &&
+    typeof x.gu === "string" &&
+    !!x.commuteA &&
+    typeof x.commuteA.time === "number" &&
+    typeof x.livingScore === "number" &&
+    typeof x.priceLabel === "string"
+  );
+}
+
+// POST /api/summary  { ...SummaryFacts }  → { rationale, source: "ai" | "fallback" }
+export async function POST(request: Request) {
+  let facts: SummaryFacts;
+  try {
+    const body = await request.json();
+    if (!isValidFacts(body)) {
+      return NextResponse.json(
+        { error: "동네 데이터(SummaryFacts)가 올바르지 않습니다" },
+        { status: 400 },
+      );
+    }
+    facts = body;
+  } catch {
+    return NextResponse.json({ error: "잘못된 요청입니다" }, { status: 400 });
+  }
+
+  // 키 없음 → 룰 기반 fallback (빈 카드 방지 — 데모는 키 없이도 카드 표시).
+  if (!API_KEY) {
+    return NextResponse.json({
+      rationale: generateFallbackRationale(facts),
+      source: "fallback",
+    });
+  }
+
+  try {
+    const google = createGoogleGenerativeAI({ apiKey: API_KEY });
+    // generateObject = 스키마 강제 JSON(자유 텍스트 파싱보다 견고).
+    const { object } = await generateObject({
+      model: google(MODEL_ID),
+      schema: rationaleSchema,
+      prompt: buildRationalePrompt(facts),
+      // ★ thinking 비활성 — 지연만 늘어 Vercel 10초 위협. 짧은 한 줄엔 추론 불필요.
+      providerOptions: { google: { thinkingConfig: { thinkingBudget: 0 } } },
+      // ★ 8초 abort — Gemini 가 느릴 때 Vercel 10초 kill 전에 abort → catch → fallback (빈 카드 방지).
+      abortSignal: AbortSignal.timeout(AI_TIMEOUT_MS),
+    });
+    // 거짓 방지 + 빈 값 방지 — 비거나 등급 미화면 throw → fallback 으로 대체.
+    const rationale = sanitizeRationale(object.rationale, facts);
+    return NextResponse.json({ rationale, source: "ai" });
+  } catch (error) {
+    // Gemini 실패/타임아웃/쿼터/스키마 불일치/미화 차단 → Sentry 기록 후 룰 fallback (빈 카드 0).
+    reportErrorToSentry(
+      createAppError(CommonErrorCode.INTERNAL_SERVER_ERROR, error),
+    );
+    return NextResponse.json({
+      rationale: generateFallbackRationale(facts),
+      source: "fallback",
+    });
+  }
+}

--- a/onday-app/src/lib/summary/extract-summary.ts
+++ b/onday-app/src/lib/summary/extract-summary.ts
@@ -1,0 +1,108 @@
+import type {
+  CandidateArea,
+  CommuteInfo,
+  CommuteMode,
+  DealType,
+  DiagnosisMode,
+  SafetyGrade,
+} from "@/lib/types";
+import type { SummaryCardDTO } from "@/lib/types/deadline";
+import { getSafetyByGu } from "@/features/single/safety-index";
+import { getNearestSchool } from "@/lib/schools-index";
+import { buildNaverRealEstateUrl } from "@/lib/deadline/naver-url-builder";
+import { formatDealValue } from "@/features/diagnosis/result-utils";
+
+// 30분 요약 (Phase 1) — CandidateArea 에서 요약 카드 재료 추출. extract-day-data.ts 답습.
+// ★ 외부 API 없음, 기존 데이터 구조화만. 없는 값은 생략 — 거짓값 금지(채우지 않음).
+//   · rationale(AI) 입력 재료 = SummaryFacts (route 로 전송, generateObject 프롬프트 소비).
+//   · 카드 결정값(시세·통근·네이버URL·학교) = buildSummaryCardBase (AI 무관, 결정적).
+//   ★ 야간 등급은 종합 야간안전 지수(getSafetyByGu) 단일 소스 — 화면과 동일.
+//     낡은 mock 필드 c.safetyGrade 는 읽지 않음(stale 금지, #192/#193 교훈). no_data 면 생략.
+
+/** 통근 한 구간 재료 — 시간 + 수단(대중교통/자차). */
+export interface SummaryCommute {
+  time: number; // 분
+  mode: CommuteMode;
+}
+
+/** rationale 생성 입력 재료 — 주어진 데이터만(거짓 방지). */
+export interface SummaryFacts {
+  dong: string;
+  gu: string;
+  mode: DiagnosisMode;
+  commuteA: SummaryCommute; // 직장 A 통근(필수)
+  commuteB?: SummaryCommute; // 직장 B 통근(부부 모드일 때만)
+  livingScore: number; // 종합 적합도 점수 (0~100)
+  priceLabel: string; // 예상 시세 ("전세 7.2억")
+  safetyGrade?: SafetyGrade; // 야간안전 등급 — getSafetyByGu ok 일 때만(stale 금지)
+  convenience?: number; // 편의점 밀집도
+  cafes?: number; // 카페 밀집도
+}
+
+function toCommute(c: CommuteInfo): SummaryCommute {
+  return { time: c.time, mode: c.mode };
+}
+
+/** 통근 표시 문자열 — "대중교통 35분" / "자차 35분". */
+export function formatCommuteLabel(c: CommuteInfo): string {
+  const label = c.mode === "driving" ? "자차" : "대중교통";
+  return `${label} ${c.time}분`;
+}
+
+/**
+ * 후보 동네 → rationale 입력 재료(SummaryFacts). 없는 값은 생략(거짓값 금지).
+ * @param dealType 시세 표시 거래유형(전세/매매/월세) — filters.dealType.
+ */
+export function extractSummaryFacts(
+  c: CandidateArea,
+  mode: DiagnosisMode,
+  dealType?: DealType,
+): SummaryFacts {
+  // ★ 안전등급은 종합 야간안전 지수 — ok 일 때만 채움(no_data·비수도권은 생략, 날조 금지).
+  const safety = getSafetyByGu(c.gu);
+  return {
+    dong: c.dong,
+    gu: c.gu,
+    mode,
+    commuteA: toCommute(c.commuteA),
+    ...(c.commuteB ? { commuteB: toCommute(c.commuteB) } : {}),
+    livingScore: c.score,
+    priceLabel: formatDealValue(c, dealType),
+    ...(safety.status === "ok" ? { safetyGrade: safety.grade } : {}),
+    ...(c.facilities?.convenience != null
+      ? { convenience: c.facilities.convenience }
+      : {}),
+    ...(c.facilities?.cafes != null ? { cafes: c.facilities.cafes } : {}),
+  };
+}
+
+/**
+ * 후보 동네 → 카드 결정값(rationale 제외). AI 무관, 결정적.
+ * rationale 은 route(AI) 또는 fallback 에서 채워 SummaryCardDTO 완성.
+ */
+export function buildSummaryCardBase(
+  c: CandidateArea,
+  rank: number,
+  dealType?: DealType,
+): Omit<SummaryCardDTO, "rationale"> {
+  const school = getNearestSchool(c.id);
+  return {
+    candidateId: c.id,
+    candidateName: `${c.gu} ${c.dong}`,
+    estimatedPrice: formatDealValue(c, dealType),
+    commuteToA: formatCommuteLabel(c.commuteA),
+    commuteToB: c.commuteB ? formatCommuteLabel(c.commuteB) : "—",
+    livingScore: c.score,
+    naverSearchUrl: buildNaverRealEstateUrl(c.coordinate, dealType ? { dealType } : {}),
+    ...(school ? { schoolDistrict: school.name } : {}),
+    rank,
+  };
+}
+
+/** Top N 선정 — 종합 점수(score) 내림차순. 기본 3. */
+export function selectTopCandidates(
+  candidates: CandidateArea[],
+  n = 3,
+): CandidateArea[] {
+  return [...candidates].sort((a, b) => b.score - a.score).slice(0, n);
+}

--- a/onday-app/src/lib/summary/rationale.ts
+++ b/onday-app/src/lib/summary/rationale.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import type { SafetyGrade } from "@/lib/types";
+import type { SummaryFacts } from "./extract-summary";
+
+// 30분 요약 (Phase 1) — SummaryFacts → Gemini "이 동네 추천 이유" 한 줄. story.ts 답습.
+// ★ 거짓 방지(하루 미리보기 원칙 그대로): 주어진 데이터(통근·점수·등급·시세)만,
+//   미화·창작 금지. 안전등급 낮으면(C·D) "안전/안심" 금지. 데이터 없는 항목 언급 금지.
+
+/** 추천 이유 출력 — 단일 텍스트(따뜻+간결). */
+export const rationaleSchema = z.object({
+  rationale: z.string(),
+});
+
+export type RationaleObject = z.infer<typeof rationaleSchema>;
+
+// 야간 등급 사실 라벨 — 미화 금지(story.ts 와 동일 기준).
+const GRADE_LABEL: Record<SafetyGrade, string> = {
+  A: "안심",
+  B: "양호",
+  C: "보통",
+  D: "주의",
+};
+
+function commuteLine(label: string, c: { time: number; mode: string }): string {
+  const mode = c.mode === "driving" ? "자차" : "대중교통";
+  return `- ${label}: ${mode} ${c.time}분`;
+}
+
+/** SummaryFacts → 시스템 프롬프트 + 사실 데이터. 없는 항목은 줄 자체를 뺀다(거짓 방지). */
+export function buildRationalePrompt(facts: SummaryFacts): string {
+  const lines: string[] = [];
+  lines.push(commuteLine("직장 A 통근", facts.commuteA));
+  if (facts.commuteB) lines.push(commuteLine("직장 B 통근", facts.commuteB));
+  lines.push(`- 생활 적합도 점수: ${facts.livingScore}점 (100점 만점)`);
+  lines.push(`- 예상 시세: ${facts.priceLabel}`);
+  if (facts.safetyGrade) {
+    lines.push(
+      `- 야간 안전 등급: ${facts.safetyGrade}(${GRADE_LABEL[facts.safetyGrade]})`,
+    );
+  }
+  if (facts.convenience != null) lines.push(`- 편의점: ${facts.convenience}곳`);
+  if (facts.cafes != null) lines.push(`- 카페: ${facts.cafes}곳`);
+
+  return [
+    `너는 이사를 돕는 다정하고 전문적인 동네 큐레이터야. 반드시 제공된 [동네 데이터]에 있는 수치와 정보만 사용하여, "${facts.gu} ${facts.dong}"을(를) 왜 추천하는지 한 문장(최대 2문장)으로 따뜻하게 설명해.`,
+    ``,
+    `[동네 데이터]`,
+    ...lines,
+    ``,
+    `[엄격한 규칙]`,
+    `1. 1~2문장, 60자 내외로 간결하게.`,
+    `2. 데이터에 없는 내용(특정 역 이름, 가상 시설, 없는 수치)은 절대 지어내거나 추측하지 마.`,
+    `3. 평가 형용사("쾌적한", "편리한", "안전한" 등)는 데이터가 뒷받침할 때만 써. 통근이 길면 "쾌적" 금지, 야간 등급이 낮으면(C·D) "안전/안심" 금지. 수치는 그대로, 평가는 사실에 부합하게.`,
+    `4. 야간 등급은 사실대로: A=안심, B=양호, C=보통, D=주의.`,
+    `5. 추천 이유는 가장 강한 강점(짧은 통근·높은 점수 등)을 중심으로.`,
+    ``,
+    `[톤] 따뜻한 권유체("~예요/~해요"), 군더더기 없이.`,
+  ].join("\n");
+}
+
+/**
+ * 거짓 방지 + 빈 값 방지. 공백 정리 후 비어 있으면 throw(호출처가 fallback 으로 대체).
+ * ★ 안전등급 낮은데(C·D) "안전/안심" 미화 흔적이면 throw — fallback(중립 룰)으로 대체.
+ */
+export function sanitizeRationale(raw: string, facts: SummaryFacts): string {
+  const text = raw.replace(/\s+/g, " ").trim();
+  if (!text) throw new Error("EMPTY_RATIONALE");
+  const g = facts.safetyGrade;
+  if ((g === "C" || g === "D") && /안전|안심/.test(text)) {
+    throw new Error("GRADE_MISMATCH_RATIONALE");
+  }
+  return text;
+}
+
+/**
+ * AI 실패 시 룰 기반 추천 이유 한 줄. 결정적(≤500ms, 외부 호출 0) — 빈 카드 방지.
+ * 예: "직장A 35분 · 직장B 42분 · 생활점수 78점"
+ */
+export function generateFallbackRationale(facts: SummaryFacts): string {
+  const parts: string[] = [];
+  parts.push(`직장A ${facts.commuteA.time}분`);
+  if (facts.commuteB) parts.push(`직장B ${facts.commuteB.time}분`);
+  parts.push(`생활점수 ${facts.livingScore}점`);
+  if (facts.safetyGrade) parts.push(`야간 ${facts.safetyGrade}등급`);
+  return parts.join(" · ");
+}

--- a/onday-app/src/lib/types/deadline.ts
+++ b/onday-app/src/lib/types/deadline.ts
@@ -20,3 +20,34 @@ export interface ListingItem {
   discountPercent: number; // 급매 할인율 (%)
   coordinate: { lat: number; lng: number };
 }
+
+// ── UI-011 / QRY-DL-002 — "30분 요약 카드" (Top 3 동네 요약, REQ-FUNC-018) ──
+//   ListingItem(급매 매물 단위)과 별개 — 본 DTO 는 동네 단위 요약(통근 A/B·생활점수·AI 추천 이유).
+//   카드 UI 는 Phase 2, 표시 연결은 Phase 3. 본 타입은 백엔드(Phase 1) 산출물.
+
+/** 30분 요약 카드 DTO — 항목 ≥6개 강제 (REQ-FUNC-018). */
+export interface SummaryCardDTO {
+  candidateId: string;
+  candidateName: string; // 1. 동네명 ("강남구 역삼동")
+  estimatedPrice: string; // 2. 예상 시세 ("전세 7.2억") — formatDealValue
+  commuteToA: string; // 3. 직장 A 통근 ("대중교통 35분")
+  commuteToB: string; // 4. 직장 B 통근 ("대중교통 42분") — 싱글/단일 직장은 "—"
+  livingScore: number; // 5. 생활편의 점수 (0~100) — 종합 적합도 score
+  naverSearchUrl: string; // 6. 네이버 부동산 링크 (buildNaverRealEstateUrl)
+  schoolDistrict?: string; // 7. 인근 초등학교 (있을 때만, getNearestSchool)
+  rationale: string; // 8. AI 추천 이유 (또는 fallback 룰 기반 — 빈 값 금지)
+  rank: number; // Top 3 순위 (1~3)
+}
+
+/** getSummary 결과 묶음. */
+export interface SummaryResult {
+  cards: SummaryCardDTO[];
+  generatedAt: string; // ISO 8601
+  totalCandidates: number;
+}
+
+/** /api/summary 응답 — rationale 1건 (클라가 Top3 Promise.all). */
+export interface RationaleResponse {
+  rationale: string;
+  source: "ai" | "fallback"; // 데모 투명성 — AI 생성인지 룰 기반인지.
+}


### PR DESCRIPTION
## 무엇 (#4 + #54/#51 Phase 1 — 백엔드)

"30분 요약 카드"의 백엔드 — **Top 3 동네 요약 데이터 + AI 추천 이유(rationale)**. 하루 미리보기(`/api/insight` + `lib/insight/`) 패턴을 **별도 파일로 복제**(원본 무변경). 카드 UI는 Phase 2, 표시 연결은 Phase 3.

## 결정 사항 (조사 합의 반영)
- **route 방식** (Server Action 아님) — CLAUDE.md §3 Vercel 10초 한도. route=후보 1건→rationale 1건, 클라가 Top3 `Promise.all`(Phase 3).
- **provider 분기 스킵(GA 이연)** — `GEMINI_MODEL` 모델 교체로 CON-14 충족. fallback·Sentry는 구현.
- **fallback을 route 안에서**(spec QRY-DL-002 §3.2 `try AI catch fallback`) → 빈 카드 0 보장. 400=잘못된 입력만.

## 변경
| 파일 | 내용 |
|---|---|
| `lib/types/deadline.ts` | `SummaryCardDTO`(8필드, 항목 ≥6) + `SummaryResult` + `RationaleResponse` 추가 |
| `lib/summary/extract-summary.ts` (신규) | `extractSummaryFacts`(rationale 재료) · `buildSummaryCardBase`(결정값: 시세·통근·네이버URL·학교) · `selectTopCandidates`(score 내림차순 Top3) |
| `lib/summary/rationale.ts` (신규) | `rationaleSchema`(zod) · `buildRationalePrompt`(거짓 방지) · `sanitizeRationale`(미화·빈값 차단) · `generateFallbackRationale`(룰 한 줄) |
| `app/api/summary/route.ts` (신규) | `generateObject` + `thinkingBudget=0` + **8초 abort** + AI 실패/키 없음 → 룰 fallback + Sentry(`reportErrorToSentry`) + 400 가드 |

## ★ 거짓 방지 / 데이터 정합
- 안전등급은 **`getSafetyByGu`** 단일 소스 — stale `c.safetyGrade` 안 읽음(#192/#193 교훈). `ok`일 때만 채움(no_data·비수도권 생략, 날조 금지).
- 프롬프트: 주어진 데이터만, 미화 금지(C·D 등급 "안전/안심" 금지), 없는 항목 언급 금지.
- 시세 `formatDealValue`, 네이버 `buildNaverRealEstateUrl(coordinate,{dealType})` 재사용.

## 검증
- `npx tsc --noEmit` 0 / `npx eslint` 0
- **AI 생성(실호출)**: `강남구 역삼동은 직장 A 통근 28분, 생활 적합도 82점, 야간 A(안심)…` — 데이터 기반, 따뜻·간결
- **거짓 방지**: 등급 없는 후보(행신동)는 등급 미언급 / 안전등급 getSafetyByGu(stale 아님)
- **fallback**: AI `high demand` 재시도 실패 시 룰 rationale(`직장A 28분 · 직장B 35분 · 생활점수 82점 · 야간 A등급`), 빈 카드 0
- **Sentry**: catch → `reportErrorToSentry` 발화 (dev 로그 `[AppError] COMMON_INTERNAL_SERVER_ERROR` 확인)
- **Top3 정렬**: score 내림차순 (90>85>75)
- **속도**: 병렬 Top3 **4.07s** wall-clock, 단건 8초 abort 상한 → Vercel 10초 안전

## 유지(무변경)
- 하루 미리보기(`/api/insight`, `lib/insight`) — 패턴 복제만, 원본 무수정
- 통근/시세/안전/캐싱/점수 로직 무변경
- 카드 UI·표시·"30분 요약" 버튼 = Phase 2~3 (이번 범위 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)