### PR TITLE
feat(summary): #4+#54/#51 Phase 2 — 30분 요약 카드 UI (SummaryCard + Grid)

### DIFF
--- a/onday-app/src/components/deadline/summary-card-grid.tsx
+++ b/onday-app/src/components/deadline/summary-card-grid.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { RotateCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { SummaryCardDTO } from "@/lib/types/deadline";
+
+import { SummaryCard } from "./summary-card";
+
+// UI-011 — 30분 요약 Top3 반응형 그리드. 모바일 1열 / 태블릿 2열 / 데스크탑 3열.
+//   ★ 표시 전용 — 데이터 fetch·캐싱·"30분 요약" 버튼 연결은 Phase 3 (props 로 상태 주입).
+//   ★ rationale 은 Phase 1 이 fallback 으로 비어있지 않음 보장 → SummaryCard 가 그대로 렌더(빈 카드 0).
+
+const GRID_CLASS = "grid grid-cols-1 gap-s-3 md:grid-cols-2 lg:grid-cols-3";
+
+// 로딩 스켈레톤 — SummaryCard 의 형태(헤더+행+버튼) 모사.
+function SummaryCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-s-3 rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+      <div className="flex items-start justify-between gap-s-2">
+        <div className="flex-1 space-y-s-1">
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-5 w-28" />
+        </div>
+        <Skeleton className="h-8 w-12" />
+      </div>
+      <div className="space-y-s-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-4/6" />
+      </div>
+      <Skeleton className="h-12 w-full rounded-md" />
+      <Skeleton className="h-9 w-full rounded-md" />
+    </div>
+  );
+}
+
+interface SummaryCardGridProps {
+  cards: SummaryCardDTO[];
+  isLoading?: boolean;
+  error?: boolean;
+  onRetry?: () => void;
+}
+
+export function SummaryCardGrid({
+  cards,
+  isLoading,
+  error,
+  onRetry,
+}: SummaryCardGridProps) {
+  if (isLoading) {
+    return (
+      <div className={GRID_CLASS} aria-busy="true" aria-label="30분 요약 불러오는 중">
+        {[0, 1, 2].map((i) => (
+          <SummaryCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  // 에러 + 표시할 카드 없음 → graceful 안내(크래시·빈 화면 금지).
+  if (error && cards.length === 0) {
+    return (
+      <div className="space-y-s-2 rounded-lg border border-card-border bg-surface px-s-4 py-s-5 text-center">
+        <p className="text-body-sm text-ink-3">지금은 요약을 불러올 수 없어요</p>
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            <RotateCw aria-hidden className="size-3.5" />
+            다시 시도
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (cards.length === 0) return null;
+
+  return (
+    <div className={GRID_CLASS}>
+      {cards.map((card) => (
+        <SummaryCard key={card.candidateId} card={card} />
+      ))}
+    </div>
+  );
+}

--- a/onday-app/src/components/deadline/summary-card.tsx
+++ b/onday-app/src/components/deadline/summary-card.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { ArrowUpRight, GraduationCap, Sparkles } from "lucide-react";
+
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { SummaryCardDTO } from "@/lib/types/deadline";
+
+// UI-011 — 30분 요약 카드(동네 단위, Top3 비교). REQ-FUNC-018 — 항목 ≥6개/카드.
+//   항목: ①동네명 ②예상 시세 ③직장A 통근 ④직장B 통근 ⑤생활 점수 ⑥추천 이유 ⑦네이버 버튼 (+⑧학교 선택)
+//   ★ listing-card 네이버 아웃링크 + candidate-card 점수 tier(색 단독 금지 — 숫자+라벨 칩) 답습.
+//   ★ rationale 은 Phase 1 이 비어있지 않음 보장(AI 또는 룰 fallback) → 빈 카드 0.
+
+// 순위 배지 — #1 강조(best), #2·#3 은은하게.
+const RANK_VARIANT: Record<number, BadgeProps["variant"]> = {
+  1: "best",
+  2: "secondary",
+  3: "neutral",
+};
+
+// 생활 점수 → 라벨/색 (candidate-card scoreTier 답습 — 색 단독 금지 3중 표기).
+function scoreTier(score: number): { label: string; text: string; chip: string } {
+  if (score >= 90)
+    return { label: "최상", text: "text-success", chip: "bg-success-soft text-success" };
+  if (score >= 80)
+    return { label: "우수", text: "text-primary", chip: "bg-primary-soft text-primary" };
+  if (score >= 70)
+    return { label: "양호", text: "text-warning", chip: "bg-warning-soft text-warning" };
+  return { label: "보통", text: "text-ink-2", chip: "bg-bg text-ink-2" };
+}
+
+interface InfoRowProps {
+  label: string;
+  value: string;
+}
+
+function InfoRow({ label, value }: InfoRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-s-2 text-body-sm">
+      <span className="shrink-0 text-ink-3">{label}</span>
+      <span className="truncate font-bold text-ink">{value}</span>
+    </div>
+  );
+}
+
+interface SummaryCardProps {
+  card: SummaryCardDTO;
+}
+
+export function SummaryCard({ card }: SummaryCardProps) {
+  const tier = scoreTier(card.livingScore);
+  const rankVariant = RANK_VARIANT[card.rank] ?? "neutral";
+  const ariaLabel = `${card.rank}순위 추천 동네 ${card.candidateName}, 생활 점수 ${card.livingScore}점`;
+
+  return (
+    <article
+      role="article"
+      aria-label={ariaLabel}
+      className="flex flex-col gap-s-3 rounded-lg border border-card-border bg-surface p-s-4 shadow-card"
+    >
+      <header className="flex items-start justify-between gap-s-2">
+        <div className="min-w-0 flex-1">
+          <Badge variant={rankVariant} size="xs">
+            #{card.rank}
+          </Badge>
+          <h3 className="mt-s-1 truncate text-title font-bold text-ink">
+            {card.candidateName}
+          </h3>
+        </div>
+        <div className="shrink-0 text-right">
+          <p className="text-caption text-ink-3">생활 점수</p>
+          <p className="text-ink-2">
+            <span className={cn("tabular text-title-sm font-extrabold", tier.text)}>
+              {card.livingScore}
+            </span>
+            점
+            <span
+              className={cn(
+                "ml-s-1 rounded-full px-1.5 py-0.5 text-[10px] font-extrabold",
+                tier.chip,
+              )}
+            >
+              {tier.label}
+            </span>
+          </p>
+        </div>
+      </header>
+
+      <div className="space-y-s-1">
+        <InfoRow label="예상 시세" value={card.estimatedPrice} />
+        <InfoRow label="직장 A 통근" value={card.commuteToA} />
+        <InfoRow label="직장 B 통근" value={card.commuteToB} />
+        {card.schoolDistrict && (
+          <div className="flex items-center justify-between gap-s-2 text-body-sm">
+            <span className="flex shrink-0 items-center gap-1 text-ink-3">
+              <GraduationCap aria-hidden className="size-3.5" />
+              인근 학교
+            </span>
+            <span className="truncate font-bold text-ink">
+              {card.schoolDistrict}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* 추천 이유 — AI(또는 룰 fallback). 따뜻한 한 줄. */}
+      <div className="flex gap-s-1 rounded-md bg-bg px-s-3 py-s-2">
+        <Sparkles aria-hidden className="mt-0.5 size-3.5 shrink-0 text-primary" />
+        <p className="text-body-sm leading-relaxed text-ink-2">{card.rationale}</p>
+      </div>
+
+      <a
+        href={card.naverSearchUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`${card.candidateName} 네이버 부동산에서 보기 (새 창)`}
+        className="flex items-center justify-center gap-s-1 rounded-md border border-card-border py-s-2 text-body-sm font-bold text-primary transition-colors hover:bg-bg focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary"
+      >
+        네이버 매물 보기
+        <ArrowUpRight aria-hidden className="size-3.5" />
+      </a>
+    </article>
+  );
+}


### PR DESCRIPTION
## 무엇 (#4 + #54/#51 Phase 2 — 카드 UI)

Phase 1(#200)의 `SummaryResult` 를 카드로 표시. **`SummaryCard`(동네별 요약) + `SummaryCardGrid`(Top3 반응형)**. 데이터 fetch·캐싱·"30분 요약" 버튼 연결은 Phase 3.

## 변경 (신규 2개, 표시 전용)
| 파일 | 내용 |
|---|---|
| `components/deadline/summary-card.tsx` | 순위 배지(#1 best / #2·#3) + 항목 ≥6 + 점수 tier 3중 표기 + 네이버 버튼 |
| `components/deadline/summary-card-grid.tsx` | 반응형 1/2/3열 + 로딩 스켈레톤 + 에러 graceful |

## 카드 필드 (REQ-FUNC-018 — 항목 ≥6)
①동네명 ②예상 시세 ③직장 A 통근 ④직장 B 통근 ⑤생활 점수(숫자+라벨 칩, 색 단독 금지) ⑥추천 이유(rationale) ⑦네이버 매물 보기(새 창) + ⑧인근 학교(있을 때만)

## 디자인 토큰 (STEP 0 — 기존 재사용)
- `listing-card` 네이버 아웃링크 패턴(`target=_blank rel=noopener`, ArrowUpRight)
- `candidate-card` `scoreTier`(최상/우수/양호/보통 — 색+라벨+숫자 3중) 답습
- `Badge`(best/secondary/neutral), `Skeleton`, `Button` 재사용 / `cn` 일관
- `role="article"` + aria-label, 모바일 1열 반응형

## 검증 (playwright 3 viewport + DOM)
- `tsc --noEmit` 0 / `eslint` 0
- **카드**: 첫 카드 7개 필드 표시(#1 배지·동네명·생활점수 91 최상·시세·통근 A/B·학교·rationale·네이버버튼), 카드 3개, 네이버 버튼 3개
- **반응형**: 375px=**1열** / 768px=**2열** / 1280px=**3열** (computed grid-template-columns 확인)
- **상태**: 로딩 스켈레톤(`aria-busy`) 1, 에러 "다시 시도" 1
- **fallback rationale**: 빈 카드 0(Phase 1 보장) — #3 룰 rationale(`직장A 55분 · 생활점수 61점`) 정상 표시, `commuteToB "—"`·학교 없음 graceful
- 글씨 크기 정상(cn 드롭 없음), `role="article"` 접근성

스크린샷(데스크탑 3열 / 모바일 1열) 검증 완료 — 임시 미리보기 페이지는 커밋 전 삭제.

## 유지(무변경)
- Phase 1 백엔드(`extract-summary`·`rationale`·`/api/summary`) — 소비만, 무수정
- 하루 미리보기 UI(`day-preview`) — 패턴 참고만, 무변경
- 연결(데드라인 페이지 버튼)·캐싱 = Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)