### PR TITLE
chore(summary): rationale=INFRA-005 동네 추천 요약 추적성 코멘트 (#4 정합)

### DIFF
--- a/onday-app/src/lib/summary/rationale.ts
+++ b/onday-app/src/lib/summary/rationale.ts
@@ -5,6 +5,12 @@ import type { SummaryFacts } from "./extract-summary";
 // 30분 요약 (Phase 1) — SummaryFacts → Gemini "이 동네 추천 이유" 한 줄. story.ts 답습.
 // ★ 거짓 방지(하루 미리보기 원칙 그대로): 주어진 데이터(통근·점수·등급·시세)만,
 //   미화·창작 금지. 안전등급 낮으면(C·D) "안전/안심" 금지. 데이터 없는 항목 언급 금지.
+//
+// ★ INFRA-005(#4) "AI 기반 동네 추천 요약" 실구현 (코드=SSoT 정합):
+//   명세 neighborhoodSummarySchema{summary, commuteAnalysis, lifestyleMatch}(3필드)를
+//   카드 UI 에 맞춰 단일 rationale 로 통합(통근·생활점수·안전을 한 문장에) — 1인 MVP 단순화.
+//   provider 분기(AI_PROVIDER)는 GA 이연 — GEMINI_MODEL env 교체로 CON-14 충족(타 provider 키 부재).
+//   "맞춤 인사이트"(§6.6)는 하루 미리보기(/api/insight)로 별도 구현됨.
 
 /** 추천 이유 출력 — 단일 텍스트(따뜻+간결). */
 export const rationaleSchema = z.object({


### PR DESCRIPTION
## 무엇 (#4 + #54/#51 Phase 4 — 정합 정리)

`lib/summary/rationale.ts` 에 **#4 INFRA-005 "동네 추천 요약" 실구현 추적성 코멘트**만 추가(코드 로직 무변경, 6줄). #4 닫기 정합용.

## 변경
| 파일 | 내용 |
|---|---|
| `lib/summary/rationale.ts` | 헤더 코멘트 — 명세 `neighborhoodSummarySchema`(3필드) → 단일 `rationale` 통합(코드=SSoT), provider 분기 GA 이연, 맞춤 인사이트=하루 미리보기 명시 |

## Phase 4 정합 확인 (코드 변경 없음 — 확인 위주)
- **GEMINI_MODEL = CON-14**: `summary/route.ts:26` `process.env.GEMINI_MODEL ?? "gemini-2.5-flash"` (insight와 동일) ✅
- **provider 분기**: AI_PROVIDER/anthropic/openai/lib/ai 흔적 **0건** — GA 이연 깔끔 ✅
- **Sentry**: `summary/route.ts:83-86` catch → `reportErrorToSentry(createAppError(...))` (insight 일관) ✅
- **fallback 3중**: 키없음(`:63`)/AI실패(`:89`)/클라(`deadline/page.tsx:101`) → 빈 카드 0 ✅
- **동네 추천 요약 = rationale**: 명세 3필드(summary+commuteAnalysis+lifestyleMatch)를 단일 rationale 로 통합(통근·생활점수·안전 한 문장). 코드=SSoT ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)