### PR TITLE
feat(auth): 게스트 저장/공유 차단 + 심사관 데모 모드 (#24)

### DIFF
--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -43,6 +43,7 @@ import { cn } from "@/lib/utils";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useFavoritesStore, toFavoriteSnapshot } from "@/stores/favorites";
 import { useUIStore } from "@/stores/ui";
+import { useGuestGate } from "@/features/auth/use-guest-gate";
 
 import { BudgetChipOptions } from "./budget-chip-options";
 import { StressInfoSection } from "@/components/data/stress-info-section";
@@ -72,6 +73,7 @@ export function ResultContent({
   const searchParams = useSearchParams();
   const sort = parseSortKey(searchParams.get("sort"));
   const pushToast = useUIStore((s) => s.pushToast);
+  const guestGate = useGuestGate();
 
   const addressA = useDiagnosisStore((s) => s.addressA);
   const addressB = useDiagnosisStore((s) => s.addressB);
@@ -385,6 +387,7 @@ export function ResultContent({
 
   const handleLike = () => {
     if (!selectedCandidate) return;
+    if (guestGate("save")) return;
     const wasLiked = Boolean(favorites[selectedCandidate.id]);
     toggleFavorite(
       toFavoriteSnapshot(

--- a/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
@@ -28,6 +28,7 @@ import type { DiagnosisFilters } from "@/lib/types";
 import { copyToClipboard } from "@/lib/utils/clipboard";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useUIStore } from "@/stores/ui";
+import { useGuestGate } from "@/features/auth/use-guest-gate";
 
 import { ResultContent } from "./result-content";
 
@@ -49,6 +50,7 @@ export function ResultView({ id }: ResultViewProps) {
   const leisureCoordA = useDiagnosisStore((s) => s.leisureCoordA);
   const leisureCoordB = useDiagnosisStore((s) => s.leisureCoordB);
   const pushToast = useUIStore((s) => s.pushToast);
+  const guestGate = useGuestGate();
 
   // ★ 버그수정: length>0 제거 — 토글/필터로 결과가 0개가 돼도 "미로드"로 오판해 DB 원본을
   //   재로드(dealType 롤백)하던 것 방지. 정당한 0개 결과는 EmptyState(완화 제안)로 처리.
@@ -116,6 +118,7 @@ export function ResultView({ id }: ResultViewProps) {
 
   const handleShare = async () => {
     if (isSharing) return;
+    if (guestGate("share")) return;
     setIsSharing(true);
     try {
       const res = await fetch("/api/share", {

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -58,6 +58,7 @@ import { FavoritesMenu } from "@/components/favorites/favorites-menu";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useFavoritesStore, toFavoriteSnapshot } from "@/stores/favorites";
 import { useUIStore } from "@/stores/ui";
+import { useGuestGate } from "@/features/auth/use-guest-gate";
 
 import { LayerToggle, type SingleLayer } from "./layer-toggle";
 
@@ -218,6 +219,7 @@ function LayerSources({
 
 export function SingleResultView({ id }: SingleResultViewProps) {
   const pushToast = useUIStore((s) => s.pushToast);
+  const guestGate = useGuestGate();
   const storeId = useDiagnosisStore((s) => s.diagnosisId);
   const storeCandidates = useDiagnosisStore((s) => s.candidates);
   const storeAddressA = useDiagnosisStore((s) => s.addressA);
@@ -504,6 +506,7 @@ export function SingleResultView({ id }: SingleResultViewProps) {
 
   const handleLike = () => {
     if (!selectedCandidate) return;
+    if (guestGate("save")) return;
     const wasLiked = Boolean(favorites[selectedCandidate.id]);
     toggleFavorite(
       toFavoriteSnapshot(
@@ -525,6 +528,7 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   const [isSharing, setIsSharing] = React.useState(false);
   const handleShare = async () => {
     if (isSharing) return;
+    if (guestGate("share")) return;
     setIsSharing(true);
     try {
       const res = await fetch("/api/share", {

--- a/onday-app/src/components/auth/login-form.tsx
+++ b/onday-app/src/components/auth/login-form.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
+import * as Sentry from "@sentry/nextjs";
 
 import { Button } from "@/components/ui/button";
 import { OAuthButton } from "@/components/ui/oauth-button";
@@ -10,6 +11,7 @@ import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { IS_MOCK_AUTH } from "@/lib/auth/flags";
 import { useSessionStore } from "@/stores/session";
 import { useUIStore } from "@/stores/ui";
+import { cn } from "@/lib/utils";
 
 // 패턴 A — controlled props 유지
 //   OAuthButton / Button은 props만 받고, store 연결은 본 LoginForm에서만
@@ -25,6 +27,7 @@ export function LoginForm() {
   const router = useRouter();
   const setUser = useSessionStore((s) => s.setUser);
   const enterGuestMode = useSessionStore((s) => s.enterGuestMode);
+  const enterReviewerMode = useSessionStore((s) => s.enterReviewerMode);
   const pushToast = useUIStore((s) => s.pushToast);
   const [inFlight, setInFlight] = React.useState<AuthInFlight>(null);
 
@@ -83,10 +86,53 @@ export function LoginForm() {
     router.push("/diagnosis");
   };
 
+  // ★ #24 심사관(채용 담당자) 데모 모드 — 로그인 없이 풀 기능(저장/공유 차단 면제).
+  //   세션 내(in-memory + favorites localStorage) 동작, 회원 정보에는 귀속되지 않음.
+  const handleReviewer = () => {
+    enterReviewerMode();
+    // CMD-AUTH-004 — 진입 이벤트 기록(Sentry 미초기화 시 silent no-op).
+    Sentry.captureMessage("reviewer_mode_entered", "info");
+    pushToast({
+      variant: "default",
+      message:
+        "👨‍💻 심사관 전용 데모 모드로 접속했습니다. (테스트 데이터는 회원 정보에 저장되지 않아요.)",
+    });
+    router.push("/diagnosis");
+  };
+
   const isBusy = inFlight !== null;
 
   return (
     <div className="space-y-s-3">
+      {/* ★ #24 심사관 진입 — 최상단 강조 버튼. navy(primary) 톤 융화 + 좌측 accent. */}
+      <button
+        type="button"
+        onClick={handleReviewer}
+        disabled={isBusy}
+        className={cn(
+          "w-full rounded-md border-2 border-primary bg-primary/[0.04] px-s-4 py-s-3 text-left",
+          "transition-all hover:bg-primary/[0.08] disabled:opacity-50",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+        )}
+      >
+        <span className="block text-body-sm font-bold text-primary">
+          👨‍💻 채용 담당자 · 심사관이신가요?
+        </span>
+        <span className="mt-0.5 block text-caption text-ink-2">
+          원클릭으로 풀버전 체험하기 (로그인 불필요)
+        </span>
+      </button>
+
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        className="flex items-center gap-s-3 py-s-1"
+      >
+        <span aria-hidden className="h-px flex-1 bg-line-2" />
+        <span className="text-caption text-ink-3">일반 사용자</span>
+        <span aria-hidden className="h-px flex-1 bg-line-2" />
+      </div>
+
       <OAuthButton
         provider="kakao"
         onClick={() => handleOAuth("kakao")}

--- a/onday-app/src/features/auth/use-guest-gate.ts
+++ b/onday-app/src/features/auth/use-guest-gate.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import * as React from "react";
+
+import { useSessionStore } from "@/stores/session";
+import { useUIStore } from "@/stores/ui";
+
+// ★ #24 게스트 제약 — 저장(찜)/공유는 로그인 사용자 전용.
+//   심사관(isReviewer)은 게스트지만 차단 면제 → 세션 내에서 그대로 동작.
+//   limitations 타입(no_save/no_share)은 MOCK 계약일 뿐 실 스토어 미연결이라,
+//   1인 MVP 답게 isGuest 를 직접 읽어 2 액션만 게이트한다.
+
+type GuestAction = "save" | "share";
+
+const GUEST_PROMPT: Record<GuestAction, string> = {
+  save: "로그인하면 찜한 동네를 저장할 수 있어요",
+  share: "로그인하면 공유 링크를 만들 수 있어요",
+};
+
+/**
+ * 반환된 함수를 핸들러 첫 줄에서 호출.
+ * 게스트면 로그인 유도 토스트를 띄우고 `true`(차단) 반환 → 호출처는 즉시 return.
+ * 로그인 사용자·심사관이면 `false`.
+ */
+export function useGuestGate() {
+  const isGuest = useSessionStore((s) => s.isGuest);
+  const isReviewer = useSessionStore((s) => s.isReviewer);
+  const pushToast = useUIStore((s) => s.pushToast);
+
+  return React.useCallback(
+    (action: GuestAction): boolean => {
+      if (isGuest && !isReviewer) {
+        pushToast({ variant: "default", message: GUEST_PROMPT[action] });
+        return true;
+      }
+      return false;
+    },
+    [isGuest, isReviewer, pushToast],
+  );
+}

--- a/onday-app/src/providers/session-bridge.tsx
+++ b/onday-app/src/providers/session-bridge.tsx
@@ -28,6 +28,7 @@ function toSessionUser(user: User): SessionUser {
 export function SessionBridge() {
   const setUser = useSessionStore((s) => s.setUser);
   const signOut = useSessionStore((s) => s.signOut);
+  const clearGuestSession = useSessionStore((s) => s.clearGuestSession);
 
   React.useEffect(() => {
     if (IS_MOCK_AUTH) return;
@@ -37,6 +38,8 @@ export function SessionBridge() {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, session) => {
       if (session?.user) {
+        // ★ CMD-AUTH-004 — 게스트/심사관 → 인증 전환 시 게스트 세션 플래그 정리.
+        clearGuestSession();
         setUser(toSessionUser(session.user));
       } else if (event === "SIGNED_OUT") {
         signOut();
@@ -44,7 +47,7 @@ export function SessionBridge() {
     });
 
     return () => subscription.unsubscribe();
-  }, [setUser, signOut]);
+  }, [setUser, signOut, clearGuestSession]);
 
   return null;
 }

--- a/onday-app/src/stores/session.ts
+++ b/onday-app/src/stores/session.ts
@@ -14,10 +14,16 @@ export interface SessionUser {
 interface SessionState {
   user: SessionUser | null;
   isGuest: boolean;
-  /** OAuth 콜백 성공 시 호출 — 게스트 모드 종료 */
+  /** 심사관(채용 담당자) 데모 모드 — 게스트지만 저장/공유 차단 면제(세션 내 동작) */
+  isReviewer: boolean;
+  /** OAuth 콜백 성공 시 호출 — 게스트/심사관 모드 종료 */
   setUser: (user: SessionUser) => void;
-  /** 게스트 체험 모드 진입 — Mock 모드에서도 동일 동작 */
+  /** 게스트 체험 모드 진입 — Mock 모드에서도 동일 동작 (저장/공유 제약 O) */
   enterGuestMode: () => void;
+  /** 심사관 데모 모드 진입 — 게스트 인프라 재사용 + 차단 면제 (CMD-AUTH-004) */
+  enterReviewerMode: () => void;
+  /** 게스트→인증 전환 시 게스트 세션 플래그 정리 (찜=favorites store 는 보존) */
+  clearGuestSession: () => void;
   /** 로그아웃 — user/guest 모두 초기화 */
   signOut: () => void;
 }
@@ -25,6 +31,7 @@ interface SessionState {
 const initialState = {
   user: null,
   isGuest: false,
+  isReviewer: false,
 };
 
 export const useSessionStore = create<SessionState>()(
@@ -32,15 +39,23 @@ export const useSessionStore = create<SessionState>()(
     (set) => ({
       ...initialState,
 
-      setUser: (user) => set({ user, isGuest: false }),
-      enterGuestMode: () => set({ user: null, isGuest: true }),
+      setUser: (user) => set({ user, isGuest: false, isReviewer: false }),
+      enterGuestMode: () => set({ user: null, isGuest: true, isReviewer: false }),
+      enterReviewerMode: () => set({ user: null, isGuest: true, isReviewer: true }),
+      clearGuestSession: () => set({ isGuest: false, isReviewer: false }),
       signOut: () => set(initialState),
     }),
     {
+      // ★ CMD-AUTH-004 — sessionStorage: 탭 종료 시 게스트/심사관 모드 소멸.
+      //   찜(onday-favorites)은 별도 store(localStorage) 로 보존 — 본 전환과 무관.
       name: "onday-session",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => sessionStorage),
       // 서버 state(예: 진단 결과)는 별도 store 또는 TanStack Query 책임
-      partialize: (state) => ({ user: state.user, isGuest: state.isGuest }),
+      partialize: (state) => ({
+        user: state.user,
+        isGuest: state.isGuest,
+        isReviewer: state.isReviewer,
+      }),
     },
   ),
 );


### PR DESCRIPTION
## 개요
#24 — (A) 게스트 모드 저장/공유 제약 + 로그인 유도, (B) 심사관(채용 담당자) 데모 모드 신설, (C') CMD-AUTH-004 축소판.

## 변경 (A) 게스트 차단
- `features/auth/use-guest-gate.ts` 신설 — `isGuest && !isReviewer` 시 로그인 유도 토스트 + 차단(true) 반환.
- 차단 4지점: `result-content` handleLike / `single-result-view` handleLike·handleShare / `result-view` handleShare.
- 심사관은 면제.

## 변경 (B) 심사관 모드
- `stores/session.ts` — `isReviewer` + `enterReviewerMode()` + `clearGuestSession()`.
- `login-form.tsx` — 최상단 심사관 진입 버튼(navy 톤) + 진입 토스트 + `Sentry.captureMessage`.
- 게스트 인프라 재사용 → 찜(localStorage)·공유(in-memory `/api/share`) 세션 내 실동작.

## 변경 (C') CMD-AUTH-004 축소판
- session 스토어 persist를 **sessionStorage**로 전환 → 탭 종료 시 게스트/심사관 모드 소멸.
- 게스트→인증 전환 시 `clearGuestSession` (`session-bridge.tsx`).
- ★ favorites(찜)는 **무변경**(localStorage 유지) — 잘 동작하는 기능 미수정, 회귀 0.

## 검증
- `tsc --noEmit` PASS / ESLint 0 warnings.
- 게스트: 찜·공유 누르면 차단 + 유도 토스트(4지점).
- 심사관: 버튼 → 진입 토스트 → 찜·공유 정상.
- 로그인 사용자: 기존 그대로(real auth는 Supabase httpOnly 쿠키 → SessionBridge 재동기화, storage 전환 무영향).
- 한글 인코딩 검증 통과.

## 비고
자동 머지/Close 금지 — 리뷰용 Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)