### PR TITLE
chore(auth): 네이버 로그인 버튼 제거(GA 이연) + 로그인 화면 완결

### DIFF
--- a/onday-app/src/components/auth/login-form.tsx
+++ b/onday-app/src/components/auth/login-form.tsx
@@ -16,12 +16,14 @@ import { cn } from "@/lib/utils";
 // 패턴 A — controlled props 유지
 //   OAuthButton / Button은 props만 받고, store 연결은 본 LoginForm에서만
 //   ★ W1-2: IS_MOCK_AUTH(=false) 시 카카오 = 실 supabase.auth.signInWithOAuth →
-//     카카오 redirect → /auth/callback 복귀. 네이버는 #22 이연("준비 중" 토스트).
+//     카카오 redirect → /auth/callback 복귀.
 //     mock-auth 모드는 기존 즉시 setUser + 라우팅 유지.
+//   ★ 네이버 로그인 = GA 이연 — 버튼/핸들러 제거. 카카오 + 게스트 + 심사관으로 완결.
+//     (콜백·user-sync·session-bridge 의 naver 분기는 재개 대비 보존.)
 
 const MOCK_LATENCY_MS = 400;
 
-type AuthInFlight = "kakao" | "naver" | "guest" | null;
+type AuthInFlight = "kakao" | "guest" | null;
 
 export function LoginForm() {
   const router = useRouter();
@@ -31,27 +33,17 @@ export function LoginForm() {
   const pushToast = useUIStore((s) => s.pushToast);
   const [inFlight, setInFlight] = React.useState<AuthInFlight>(null);
 
-  const handleOAuth = async (provider: "kakao" | "naver") => {
-    setInFlight(provider);
+  const handleKakao = async () => {
+    setInFlight("kakao");
     try {
       if (IS_MOCK_AUTH) {
         await new Promise((resolve) => setTimeout(resolve, MOCK_LATENCY_MS));
         setUser({
           id: MOCK_USER.id,
           nickname: MOCK_USER.email.split("@")[0],
-          provider,
+          provider: "kakao",
         });
         router.push("/diagnosis");
-        return;
-      }
-
-      // 네이버는 #22 이연 — 카카오 패턴 복제 예정. 크래시 대신 안내.
-      if (provider === "naver") {
-        pushToast({
-          variant: "default",
-          message: "네이버 로그인은 준비 중이에요. 카카오로 시작해 주세요.",
-        });
-        setInFlight(null);
         return;
       }
 
@@ -135,15 +127,9 @@ export function LoginForm() {
 
       <OAuthButton
         provider="kakao"
-        onClick={() => handleOAuth("kakao")}
+        onClick={handleKakao}
         loading={inFlight === "kakao"}
         disabled={isBusy && inFlight !== "kakao"}
-      />
-      <OAuthButton
-        provider="naver"
-        onClick={() => handleOAuth("naver")}
-        loading={inFlight === "naver"}
-        disabled={isBusy && inFlight !== "naver"}
       />
 
       <div

--- a/onday-app/src/lib/services/user-sync.ts
+++ b/onday-app/src/lib/services/user-sync.ts
@@ -7,6 +7,7 @@ import type { AuthProviderType } from "@/lib/types/user";
 // RLS off(DB-007 RLS 이연) 상태라 Prisma(postgres role)로 직접 write.
 export async function syncUserFromAuth(user: User): Promise<void> {
   const rawProvider = user.app_metadata?.provider;
+  // ★ 네이버 로그인은 GA 이연(버튼 제거) — naver 분기는 재개 대비 보존.
   const authProvider: AuthProviderType =
     rawProvider === "naver" ? "naver" : "kakao";
 

--- a/onday-app/src/providers/session-bridge.tsx
+++ b/onday-app/src/providers/session-bridge.tsx
@@ -9,6 +9,7 @@ import { useSessionStore, type SessionUser } from "@/stores/session";
 
 function toSessionUser(user: User): SessionUser {
   const meta = user.user_metadata ?? {};
+  // ★ 네이버 로그인은 GA 이연(버튼 제거) — naver 분기는 재개 대비 보존.
   const provider = user.app_metadata?.provider === "naver" ? "naver" : "kakao";
   const nickname =
     meta.name ?? meta.nickname ?? meta.full_name ?? user.email?.split("@")[0] ?? "사용자";


### PR DESCRIPTION
## 개요
네이버 로그인을 GA로 이연하고 버튼을 제거. 로그인 화면을 **카카오 + 게스트 + 심사관**으로 완결.

## 변경
- **`login-form.tsx`** — 네이버 `OAuthButton` + "준비 중" 토스트 핸들러 제거. `handleOAuth` → `handleKakao`로 단순화, `AuthInFlight`에서 `"naver"` 제거. 레이아웃: 심사관(최상단) → 카카오 → 게스트(네이버 빈자리 없음).
- **`user-sync.ts` / `session-bridge.tsx`** — naver 분기는 **재개 대비 보존** + "GA 이연" 주석 명시(가벼운 죽은 분기).

## 변경 없음
- 카카오 문구 "카카오로 1초 만에 시작"은 `oauth-button.tsx:11` 기존값 그대로 — **이미 일치**, 수정 불필요.
- 카카오 OAuth·게스트·심사관 모드·콜백·세션·미들웨어 전부 무변경.

## 검증
- `tsc --noEmit` PASS / ESLint 0 warnings / 한글 인코딩 OK.
- 로그인 화면 렌더 순서: 심사관 → (일반 사용자 구분선) → 카카오("1초 만에") → (또는) → 게스트. 네이버 없음.
- 회귀 0 (카카오·게스트·심사관 동작 무변경).

## 비고
자동 머지/Close 금지 — 리뷰용 Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)