### PR TITLE
feat(map): 새로고침 시 직장 마커·통근선 복원 — 입력 좌표 persist

### DIFF
--- a/onday-app/src/stores/diagnosis-store.ts
+++ b/onday-app/src/stores/diagnosis-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 import type { CandidateArea, Coordinate, DiagnosisFilters, DiagnosisMode } from "@/lib/types";
 import type { DayStory } from "@/lib/insight/story";
 import type { SummaryResult } from "@/lib/types/deadline";
@@ -71,44 +72,73 @@ const initialState = {
   error: null,
 };
 
-export const useDiagnosisStore = create<DiagnosisState>((set) => ({
-  ...initialState,
+// ★ 입력 좌표만 localStorage persist — 새로고침 시 지도 직장 마커·통근선 복원.
+//   직장 마커/선은 coordinateA/B(입력값)에 의존하는데, candidates(숫자 마커)와 달리
+//   서버 GET 복원 경로가 없어(DB에 좌표 컬럼 없음) 인메모리 리셋 시 사라졌음.
+//   ★ 결과/캐시(candidates·commutePool·stories·summary)는 persist 제외 — 용량·정합상
+//     기존대로 서버 GET(result-view)으로 복원. filters 도 서버 GET 복원이라 제외.
+//   session/favorites 와 동일 패턴(zustand persist), 별도 storage key.
+export const useDiagnosisStore = create<DiagnosisState>()(
+  persist(
+    (set) => ({
+      ...initialState,
 
-  setAddressA: (address, coordinate) =>
-    set({ addressA: address, ...(coordinate && { coordinateA: coordinate }) }),
+      setAddressA: (address, coordinate) =>
+        set({ addressA: address, ...(coordinate && { coordinateA: coordinate }) }),
 
-  setAddressB: (address, coordinate) =>
-    set({ addressB: address, ...(coordinate && { coordinateB: coordinate }) }),
+      setAddressB: (address, coordinate) =>
+        set({ addressB: address, ...(coordinate && { coordinateB: coordinate }) }),
 
-  setLeisureA: (address, coordinate) =>
-    set({ leisureA: address, ...(coordinate && { leisureCoordA: coordinate }) }),
+      setLeisureA: (address, coordinate) =>
+        set({ leisureA: address, ...(coordinate && { leisureCoordA: coordinate }) }),
 
-  setLeisureB: (address, coordinate) =>
-    set({ leisureB: address, ...(coordinate && { leisureCoordB: coordinate }) }),
+      setLeisureB: (address, coordinate) =>
+        set({ leisureB: address, ...(coordinate && { leisureCoordB: coordinate }) }),
 
-  setMode: (mode) => set({ mode }),
-  setFilters: (filters) => set({ filters }),
-  setDeadlineDate: (deadlineDate) => set({ deadlineDate }),
+      setMode: (mode) => set({ mode }),
+      setFilters: (filters) => set({ filters }),
+      setDeadlineDate: (deadlineDate) => set({ deadlineDate }),
 
-  // 새 진단 결과 = 통근데이터 달라짐 → 옛 스토리·요약 무효(stories·summary 비움 → 재생성).
-  setResult: (diagnosisId, candidates) =>
-    set({
-      diagnosisId,
-      candidates,
-      stories: {},
-      summary: null,
-      isLoading: false,
-      error: null,
+      // 새 진단 결과 = 통근데이터 달라짐 → 옛 스토리·요약 무효(stories·summary 비움 → 재생성).
+      //   입력 좌표는 진단 생성 직전 setAddress* 로 이미 새 값이 박힘 → setResult 가 따로 손댈 필요 없음.
+      setResult: (diagnosisId, candidates) =>
+        set({
+          diagnosisId,
+          candidates,
+          stories: {},
+          summary: null,
+          isLoading: false,
+          error: null,
+        }),
+
+      setStory: (candidateId, story) =>
+        set((s) => ({ stories: { ...s.stories, [candidateId]: story } })),
+
+      setSummary: (summary) => set({ summary }),
+
+      setCommutePool: (commutePool) => set({ commutePool }),
+
+      setLoading: (isLoading) => set({ isLoading }),
+      setError: (error) => set({ error, isLoading: false }),
+      // reset = 새 진단 시작 등에서 입력 좌표까지 초기화 → persist 블롭도 비워져 옛 좌표 잔존 0.
+      reset: () => set(initialState),
     }),
-
-  setStory: (candidateId, story) =>
-    set((s) => ({ stories: { ...s.stories, [candidateId]: story } })),
-
-  setSummary: (summary) => set({ summary }),
-
-  setCommutePool: (commutePool) => set({ commutePool }),
-
-  setLoading: (isLoading) => set({ isLoading }),
-  setError: (error) => set({ error, isLoading: false }),
-  reset: () => set(initialState),
-}));
+    {
+      name: "onday-diagnosis-input",
+      storage: createJSONStorage(() => localStorage),
+      // ★ 입력 좌표만 — 지도 직장 마커·통근선 복원에 필요한 최소 필드.
+      //   결과(candidates)·캐시(commutePool/stories/summary)·filters 는 제외(서버 GET 복원).
+      partialize: (s) => ({
+        addressA: s.addressA,
+        addressB: s.addressB,
+        coordinateA: s.coordinateA,
+        coordinateB: s.coordinateB,
+        leisureA: s.leisureA,
+        leisureB: s.leisureB,
+        leisureCoordA: s.leisureCoordA,
+        leisureCoordB: s.leisureCoordB,
+        mode: s.mode,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## 문제
결과 페이지 새로고침 시 지도의 **직장 마커(내/배우자)·통근선이 사라짐**. 숫자(순위) 마커는 정상.

원인: 직장 마커(`result-content.tsx:233-253`)·통근선(`buildLinesFor`, `!wp`면 null)은 `coordinateA/B`(diagnosis-store)에 의존하는데, **store에 persist가 없어**(순수 인메모리) 새로고침 시 null로 리셋. 숫자 마커는 candidates가 서버 GET(`/api/diagnosis/[id]`)으로 복원돼 살아남지만, **직장 입력 좌표는 DB에 좌표 컬럼이 없어 복원 경로가 없음**.

## 방향 (a2) — localStorage persist (session/favorites 패턴 답습)
`diagnosis-store`에 zustand `persist` 추가, `partialize`로 **입력 좌표만** 저장:
- `addressA/B`, `coordinateA/B`, 여가거점 좌표(`leisureCoordA/B`+텍스트), `mode`
- storage key: `onday-diagnosis-input`

**persist 제외 (의도)**:
- `candidates`·`commutePool`·`stories`·`summary` (결과/캐시) → 기존대로 서버 GET 복원, 용량·정합 보존
- `filters` → 서버 GET(`result-view`)에서 복원
- `diagnosisId` → 제외 유지 → 새로고침 시 `inSync=false` → candidates 재요청 흐름 **무변경**

## 정합 (옛 좌표 잔존 방지)
- 입력 좌표는 진단 생성 직전 `setAddress*`로 새 값이 박힘 → `setResult`가 따로 손댈 필요 없음.
- `reset()` = `initialState` → persist 블롭도 비워짐 → 옛 좌표 잔존 0.

## 검증
- `tsc --noEmit` PASS / ESLint 0 warnings / 한글 인코딩 OK.
- 새로고침 후: `coordinateA/B` 복원 → 직장 마커(내/배우자) + 통근선(실선/점선) 복원.
- 숫자 마커: candidates 서버 복원 흐름 무변경(회귀 0).
- 부부/싱글 둘 다 + `mode` 복원. persist 페이로드 = 입력값만(좌표 2~4개+짧은 문자열, 과하지 않음).

## ⚠️ 범위 밖 (명시)
- **공유 링크(`/share/[uuid]`) 수신자는 localStorage가 없어** 직장 마커 미복원 — (a2) 범위 밖. 공유 지도까지 필요하면 별도로 **(a1) DB 좌표 컬럼** 필요.
- 엣지: 직전 입력과 **다른 diagnosisId**의 결과를 다시 열어 새로고침하면 persist된 좌표가 그 결과와 불일치할 수 있음(직전 입력 좌표 기준). result-view 무변경 제약상 (a2)에선 미해결 — 지배적 흐름(생성→새로고침)은 정상. 필요 시 (a1) DB 좌표로 근본 해결.
- 부수효과: 입력 폼이 직전 입력을 기억(`mode` 포함). "이전 조건 불러오기"와 결이 같아 수용 가능.

자동 머지/Close 금지 — 리뷰용 Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)