### PR TITLE
fix(deadline): 외부링크 뒤로가기 시 급매 매물·요약 빈 값 해소 — candidates persist

### DIFF
--- a/onday-app/src/stores/diagnosis-store.ts
+++ b/onday-app/src/stores/diagnosis-store.ts
@@ -72,11 +72,17 @@ const initialState = {
   error: null,
 };
 
-// ★ 입력 좌표만 localStorage persist — 새로고침 시 지도 직장 마커·통근선 복원.
-//   직장 마커/선은 coordinateA/B(입력값)에 의존하는데, candidates(숫자 마커)와 달리
-//   서버 GET 복원 경로가 없어(DB에 좌표 컬럼 없음) 인메모리 리셋 시 사라졌음.
-//   ★ 결과/캐시(candidates·commutePool·stories·summary)는 persist 제외 — 용량·정합상
-//     기존대로 서버 GET(result-view)으로 복원. filters 도 서버 GET 복원이라 제외.
+// ★ 입력 좌표 + 데드라인 결과(candidates·deadlineDate) localStorage persist.
+//   ① 입력 좌표(coordinateA/B 등): 새로고침 시 지도 직장 마커·통근선 복원(#209).
+//   ② candidates·deadlineDate: 데드라인 페이지(/deadline)는 정적 라우트(URL [id] 없음)라
+//      result-view 식 서버 GET 복원이 불가능 → 외부 링크(네이버) 후 모바일 뒤로가기 reload 시
+//      candidates 가 리셋돼 "급매 매물·30분 요약" 이 빈 값이 됐음. 둘을 persist 해 reload 에도 유지.
+//      · candidates: 급매 매물·요약 파생 소스. 새 진단 시 setResult 가 덮어씀(staleness 자동 정합).
+//      · deadlineDate: D-day. 데드라인 페이지가 candidates 와 함께 쓰는 화면 상태.
+//   ★ diagnosisId 는 persist 제외 — result/single 의 복원 가드(inSync = storeId === id)가
+//     reload 때 true 가 되면 서버 GET 이 건너뛰어져 filters(persist 제외) 복원이 깨짐. 제외해야
+//     result/single 의 GET 복원 흐름이 무변경 유지된다(데드라인은 diagnosisId 를 쓰지 않음).
+//   ★ 캐시(commutePool·stories·summary)·filters 는 여전히 제외 — 무겁고 재생성/서버 GET 가능.
 //   session/favorites 와 동일 패턴(zustand persist), 별도 storage key.
 export const useDiagnosisStore = create<DiagnosisState>()(
   persist(
@@ -126,8 +132,8 @@ export const useDiagnosisStore = create<DiagnosisState>()(
     {
       name: "onday-diagnosis-input",
       storage: createJSONStorage(() => localStorage),
-      // ★ 입력 좌표만 — 지도 직장 마커·통근선 복원에 필요한 최소 필드.
-      //   결과(candidates)·캐시(commutePool/stories/summary)·filters 는 제외(서버 GET 복원).
+      // ★ 입력 좌표(마커·통근선 복원) + candidates·deadlineDate(데드라인 reload 복원).
+      //   diagnosisId·filters·캐시(commutePool/stories/summary)는 제외(위 설명 참조).
       partialize: (s) => ({
         addressA: s.addressA,
         addressB: s.addressB,
@@ -138,6 +144,8 @@ export const useDiagnosisStore = create<DiagnosisState>()(
         leisureCoordA: s.leisureCoordA,
         leisureCoordB: s.leisureCoordB,
         mode: s.mode,
+        candidates: s.candidates,
+        deadlineDate: s.deadlineDate,
       }),
     },
   ),


### PR DESCRIPTION
## 문제
데드라인 페이지(`/deadline`)에서 네이버 매물 외부 링크로 나갔다가 **모바일에서 뒤로가기**로 돌아오면 "교집합 급매 매물"·"30분 요약"이 빈 값("진단을 먼저 하면…")으로 표시됨.

**원인:** 둘 다 `candidates`에서 파생되는데, `candidates`가 **in-memory 전용 + 데드라인 페이지에 복원 로직 없음**. 모바일은 `_blank` 외부 링크/인앱 브라우저에서 돌아올 때 원 페이지가 bfcache 복원 못 하고 풀 reload → store 리셋 → `candidates = []`. (PC는 새 탭이라 원 페이지가 살아있어 미발생.)
`result`/`single` 페이지는 URL `[id]`로 서버 GET 복원되지만, `/deadline`은 **정적 라우트라 id가 없어** 같은 방식을 못 씀.

## 해결 — `candidates` + `deadlineDate` persist 추가
`src/stores/diagnosis-store.ts`의 `partialize`에 두 필드 추가:
\`\`\`diff
  mode: s.mode,
+ candidates: s.candidates,
+ deadlineDate: s.deadlineDate,
\`\`\`
- **candidates**: 급매 매물·요약 파생 소스 → reload에도 유지
- **deadlineDate**: D-day → 함께 유지(데드라인 화면 상태 정합)
- 입력 좌표 persist(#209)·result/single 서버 GET 복원·캐시 제외는 **무변경**

### ⚠️ `diagnosisId`는 의도적으로 persist 제외 (지시한 3필드 세트에서 1개 제외)
요청은 candidates·diagnosisId·deadlineDate 3개였으나, **`diagnosisId` persist는 result/single 회귀를 유발**하여 제외했습니다:
- `result-view.tsx:57-58`·`single-result-view.tsx:250-251`: `inSync = storeId === id` → `useDiagnosis(inSync ? null : id)`로 GET 여부 결정.
- `diagnosisId`를 persist하면 reload 시 `inSync = true`가 되어 **서버 GET이 안 돌고 → `filters`(persist 제외) 복원이 깨짐**(dealType·budget·통근 스케줄 등 초기화).
- 이는 본 작업의 "result 회귀 0 / 서버 GET 복원 흐름 무변경" 요건과 정면 충돌.
- `diagnosisId`는 **데드라인 페이지가 사용하지 않으므로** 제외해도 픽스에 지장 없음. 제외해야 result/single GET 복원이 그대로 유지됨.

> diagnosisId까지 꼭 persist하려면 `filters`도 함께 persist해야 회귀가 없으나, 이는 result 복원 흐름을 GET→persist로 바꾸는 더 큰 변경이라 본 PR 범위에서 제외했습니다. 필요 시 후속으로 논의.

## 정합성 (코드 확인)
- **staleness**: 새 진단 시 `setResult`(`:104-112`)가 `candidates`를 덮어씀 → persist 블롭 갱신. 옛 candidates 잔존 0.
- **reset**: `reset`(`:124`)이 `set(initialState)` → `candidates=[]`·`deadlineDate=null` → persist 블롭도 비워짐.
- 둘 다 zustand persist가 매 `set`마다 기록하므로 **추가 코드 없이 자동 정합**.
- **용량**: `candidates`는 CandidateArea ~8개(좌표·점수·통근 정보) ≈ 십수 KB → localStorage(5MB) 대비 무시 가능. summary·stories·commutePool은 무거워 계속 제외.

## 검증
- ✅ `tsc --noEmit` 통과 (exit 0)
- ✅ `eslint` 통과 (exit 0, 0 errors; 잔존 9 warnings는 무관 기존 파일)
- ✅ 한글 인코딩 깨짐 0

## ⚠️ 실기기 검증 필요(사용자)
코드/타입 레벨까지만 검증했습니다. **모바일 실기**에서 다음 시나리오 최종 확인 권장:
1. 진단 → 데드라인 → 네이버 매물 외부 링크 → **브라우저 뒤로가기** → 급매 매물·30분 요약·D-day가 유지되는지(빈 값 안 되는지)
2. 새 진단 후 데드라인 → 옛 후보가 아닌 새 후보가 보이는지(staleness)
3. PC/모바일 둘 다, 부부/싱글 모드
4. result/single 페이지 reload 시 필터(dealType 등)·결과 정상 복원(회귀 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)