### PR TITLE
fix(naver-link): 모바일 매물 링크 같은 탭 열기 — 뒤로가기로 데드라인 복귀

### DIFF
--- a/onday-app/src/app/deadline/page.tsx
+++ b/onday-app/src/app/deadline/page.tsx
@@ -253,7 +253,13 @@ export default function DeadlinePage() {
           c.coordinate,
           filters.dealType ? { dealType: filters.dealType } : {},
         );
-    window.open(url, "_blank", "noopener,noreferrer");
+    // 모바일=같은 탭(뒤로가기 1회로 데드라인 복귀 — #214 persist 가 candidates·D-day 복원),
+    //   PC=새 탭(데드라인 페이지 유지). 네이버 지도 SPA 히스토리가 데드라인 탭에 안 쌓이게.
+    if (isMobile) {
+      window.location.href = url;
+    } else {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
   };
 
   return (

--- a/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-content.tsx
@@ -681,7 +681,12 @@ export function ResultContent({
                 : buildNaverRealEstateUrl(selectedCandidate.coordinate, {
                     dealType: filters.dealType ?? "jeonse",
                   });
-              window.open(url, "_blank", "noopener,noreferrer");
+              // 모바일=같은 탭(뒤로가기로 복귀), PC=새 탭.
+              if (isMobile) {
+                window.location.href = url;
+              } else {
+                window.open(url, "_blank", "noopener,noreferrer");
+              }
             },
           }}
           primaryCtaNote={isMobile ? <NaverMobileNote /> : undefined}

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -841,7 +841,12 @@ export function SingleResultView({ id }: SingleResultViewProps) {
                       : buildNaverRealEstateUrl(selectedCandidate.coordinate, {
                           dealType: dealType ?? "jeonse",
                         });
-                    window.open(url, "_blank", "noopener,noreferrer");
+                    // 모바일=같은 탭(뒤로가기로 복귀), PC=새 탭.
+                    if (isMobile) {
+                      window.location.href = url;
+                    } else {
+                      window.open(url, "_blank", "noopener,noreferrer");
+                    }
                   },
                 }}
                 primaryCtaNote={isMobile ? <NaverMobileNote /> : undefined}

--- a/onday-app/src/components/deadline/listing-card.tsx
+++ b/onday-app/src/components/deadline/listing-card.tsx
@@ -42,11 +42,12 @@ export function ListingCard({ listing, mode, rank }: ListingCardProps) {
 
   return (
     <div className="overflow-hidden rounded-lg border border-card-border bg-surface shadow-card">
+      {/* 모바일=같은 탭(뒤로가기로 데드라인 복귀), PC=새 탭. */}
       <a
         href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label={`${rank ? `추천 ${rank}위 동네 ` : ""}${listing.areaName} ${listing.dealType} ${listing.priceLabel}, ${isMobile ? "네이버 지도에서 동네 탐색" : "네이버 부동산에서 보기"} (새 창)`}
+        target={isMobile ? undefined : "_blank"}
+        rel={isMobile ? undefined : "noopener noreferrer"}
+        aria-label={`${rank ? `추천 ${rank}위 동네 ` : ""}${listing.areaName} ${listing.dealType} ${listing.priceLabel}, ${isMobile ? "네이버 지도에서 동네 탐색" : "네이버 부동산에서 보기 (새 창)"}`}
         className="flex items-center gap-s-3 px-s-4 py-s-3 transition-colors hover:bg-bg focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary"
       >
         {/* 지도 마커 숫자(동네 순위)와 시각 일관 — 회색 원 + 흰 숫자 (map-marker 답습). */}

--- a/onday-app/src/components/deadline/summary-card.tsx
+++ b/onday-app/src/components/deadline/summary-card.tsx
@@ -126,11 +126,12 @@ export function SummaryCard({ card, mode }: SummaryCardProps) {
         <p className="text-body-sm leading-relaxed text-ink-2">{card.rationale}</p>
       </div>
 
+      {/* 모바일=같은 탭(뒤로가기로 복귀), PC=새 탭. */}
       <a
         href={naverUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label={`${card.candidateName} ${isMobile ? "네이버 지도에서 동네 탐색" : "네이버 부동산에서 보기"} (새 창)`}
+        target={isMobile ? undefined : "_blank"}
+        rel={isMobile ? undefined : "noopener noreferrer"}
+        aria-label={`${card.candidateName} ${isMobile ? "네이버 지도에서 동네 탐색" : "네이버 부동산에서 보기 (새 창)"}`}
         className="flex items-center justify-center gap-s-1 rounded-md border border-card-border py-s-2 text-body-sm font-bold text-primary transition-colors hover:bg-bg focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary"
       >
         {isMobile ? NAVER_MOBILE_CTA_LABEL : "네이버 매물 보기"}

--- a/onday-app/src/components/favorites/favorites-menu.tsx
+++ b/onday-app/src/components/favorites/favorites-menu.tsx
@@ -181,8 +181,8 @@ export function FavoritesMenu() {
                               dealType: it.dealType ?? "jeonse",
                             })
                       }
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      target={isMobile ? undefined : "_blank"}
+                      rel={isMobile ? undefined : "noopener noreferrer"}
                       aria-label={`${it.gu} ${it.dong} ${isMobile ? "네이버 지도에서 동네 탐색" : "매물 보기"}`}
                       className="inline-flex size-9 shrink-0 items-center justify-center rounded-sm text-ink-3 hover:text-ink"
                     >


### PR DESCRIPTION
## 문제
모바일에서 매물(네이버 지도) 링크가 `_blank`(새 탭)로 열려, 사용자가 **뒤로가기로 데드라인에 못 돌아오고 탭을 전환**해야 함. 인앱 브라우저가 `_blank`를 same-tab으로 처리하는 경우엔 네이버 지도 SPA 히스토리가 누적돼 **뒤로가기가 지도 사이에서 맴돔**(#213 후속 조사 결과).

## 방향 — 모바일=같은 탭, PC=새 탭
- **모바일**(`useIsMobile=true`): 같은 탭에서 열기 → 뒤로가기 1회로 데드라인 복귀.
- **PC**(`useIsMobile=false`): 현행 `_blank`(새 탭) 유지 — 데드라인 페이지 보존.
- 여는 방식(탭)만 변경. **URL 분기(#213)·PC 새 탭 동작·#214 persist는 무변경.**

## 변경 — 매물 링크 6곳
| 유형 | 위치 | 변경 |
|---|---|---|
| `window.open` | 데드라인 마커(`deadline/page.tsx`), 부부 CTA(`result-content.tsx`), 싱글 CTA(`single-result-view.tsx`) | 모바일 `window.location.href = url`(같은 탭) / PC `window.open(_blank)` |
| `<a>` | 급매 매물(`listing-card.tsx`), 30분 요약(`summary-card.tsx`), 찜(`favorites-menu.tsx`) | 모바일 `target/rel` 제거(같은 탭) / PC `_blank` + `rel` |

- `<a>` aria-label의 "(새 창)"은 **PC에서만** 표기(모바일은 같은 탭이라 제거).
- 하이드레이션 안전: `useIsMobile`은 마운트 전 false(PC) → SSR·첫 렌더 모두 `_blank`로 서버와 일치, 마운트 후 모바일이면 same-tab으로 전환(mounted 게이트, 기존 패턴).

## ★ #214 persist와의 정합 (핵심)
같은 탭이면 뒤로가기 시 데드라인 페이지가 reload되어 store가 리셋되지만, **#214에서 `candidates`·`deadlineDate`를 persist**했으므로 복원됩니다 — 이 조합이 의도된 동작입니다.
- **급매 매물**: `candidates` 복원 → 카드 정상 표시(빈 값 0).
- **D-day**: `deadlineDate` 복원.
- **30분 요약**: `summary`는 persist 제외(재생성 캐시)라 null → `candidates.length===0` 빈 안내가 **아니라** `deadline/page.tsx:380-388`의 **"AI로 Top 3 동네 30분 요약 보기" 재생성 버튼**이 표시됨(코드 확인). → 빈 값 안내가 아니라 버튼 재노출 = 수용 가능.

## 검증
- ✅ `tsc --noEmit` 통과 (exit 0)
- ✅ `eslint` 통과 (exit 0, 0 errors; 잔존 9 warnings는 무관 기존 파일)
- ✅ 한글 인코딩 깨짐 0
- ✅ 30분 요약 재생성 버튼 동작 코드 확인(`deadline/page.tsx:376-397`)
- ✅ PC 경로 무변경(`isMobile=false`면 6곳 모두 기존 `_blank`/`window.open` 그대로)

## ⚠️ 실기기 최종 확인 필요(폰)
1. **모바일**: 매물 → 같은 탭 지도 → **뒤로가기 1회** → 데드라인 복귀 + 급매 매물·D-day 유지(#214)
2. **30분 요약**: 뒤로가기 후 빈 값 안내가 아니라 "요약 보기" 버튼인지(재생성 가능)
3. **PC**: 새 탭 유지(회귀 0)
4. 부부/싱글 상세시트 CTA 포함 6곳 전부

🤖 Generated with [Claude Code](https://claude.com/claude-code)