### PR TITLE
fix(persist): 로그인 사용자만 입력좌표·결과 persist — 심사관/게스트 제외

### DIFF
--- a/onday-app/src/components/auth/login-form.tsx
+++ b/onday-app/src/components/auth/login-form.tsx
@@ -10,6 +10,7 @@ import { MOCK_USER } from "@/mocks/users";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { IS_MOCK_AUTH } from "@/lib/auth/flags";
 import { useSessionStore } from "@/stores/session";
+import { DIAGNOSIS_PERSIST_KEY } from "@/stores/diagnosis-store";
 import { useUIStore } from "@/stores/ui";
 import { cn } from "@/lib/utils";
 
@@ -75,6 +76,8 @@ export function LoginForm() {
   const handleGuest = () => {
     setInFlight("guest");
     enterGuestMode();
+    // 게스트는 회원 정보 미저장 — 이전 로그인 사용자가 남긴 입력좌표 blob 제거(물려받기 방지).
+    localStorage.removeItem(DIAGNOSIS_PERSIST_KEY);
     router.push("/diagnosis");
   };
 
@@ -82,6 +85,8 @@ export function LoginForm() {
   //   세션 내(in-memory + favorites localStorage) 동작, 회원 정보에는 귀속되지 않음.
   const handleReviewer = () => {
     enterReviewerMode();
+    // 심사관도 회원 정보 미저장 — 이전 로그인 사용자가 남긴 입력좌표 blob 제거.
+    localStorage.removeItem(DIAGNOSIS_PERSIST_KEY);
     // CMD-AUTH-004 — 진입 이벤트 기록(Sentry 미초기화 시 silent no-op).
     Sentry.captureMessage("reviewer_mode_entered", "info");
     pushToast({

--- a/onday-app/src/providers/session-bridge.tsx
+++ b/onday-app/src/providers/session-bridge.tsx
@@ -6,6 +6,7 @@ import type { User } from "@supabase/supabase-js";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { IS_MOCK_AUTH } from "@/lib/auth/flags";
 import { useSessionStore, type SessionUser } from "@/stores/session";
+import { DIAGNOSIS_PERSIST_KEY } from "@/stores/diagnosis-store";
 
 function toSessionUser(user: User): SessionUser {
   const meta = user.user_metadata ?? {};
@@ -44,6 +45,8 @@ export function SessionBridge() {
         setUser(toSessionUser(session.user));
       } else if (event === "SIGNED_OUT") {
         signOut();
+        // 로그아웃 후 입력좌표·결과가 localStorage 에 잔존하지 않게 제거(프라이버시).
+        localStorage.removeItem(DIAGNOSIS_PERSIST_KEY);
       }
     });
 

--- a/onday-app/src/stores/diagnosis-store.ts
+++ b/onday-app/src/stores/diagnosis-store.ts
@@ -3,6 +3,10 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import type { CandidateArea, Coordinate, DiagnosisFilters, DiagnosisMode } from "@/lib/types";
 import type { DayStory } from "@/lib/insight/story";
 import type { SummaryResult } from "@/lib/types/deadline";
+import { useSessionStore } from "./session";
+
+// persist localStorage key — 게스트/심사관 진입·로그아웃 시 직접 제거에도 재사용(단일 소스).
+export const DIAGNOSIS_PERSIST_KEY = "onday-diagnosis-input";
 
 interface DiagnosisState {
   // Input
@@ -130,10 +134,25 @@ export const useDiagnosisStore = create<DiagnosisState>()(
       reset: () => set(initialState),
     }),
     {
-      name: "onday-diagnosis-input",
-      storage: createJSONStorage(() => localStorage),
-      // ★ 입력 좌표(마커·통근선 복원) + candidates·deadlineDate(데드라인 reload 복원).
-      //   diagnosisId·filters·캐시(commutePool/stories/summary)는 제외(위 설명 참조).
+      name: DIAGNOSIS_PERSIST_KEY,
+      // ★ 로그인(카카오)만 입력 좌표·결과 persist — 게스트/심사관(user=null)은 localStorage 에
+      //   아무것도 안 남김(심사관 토스트 "회원 정보에 저장되지 않아요" 정합).
+      //   ★ 분기는 쓰기(setItem)에서만 — 그 시점엔 모드 확정(진입 후 입력)이라 안전. 게스트면
+      //     '쓰기만 건너뜀'(키 미생성). 기존 blob 제거는 진입(login-form)·로그아웃(session-bridge)
+      //     의 removeItem 이 전담 — 여기서 삭제까지 하면 로그인 rehydrate 쓰기(init 시 user=null,
+      //     Supabase 비동기 setUser 전)가 blob 을 지워 복원 회귀가 나므로 삭제는 하지 않는다.
+      //   ★ 읽기(getItem)도 게이팅하지 않음 — 같은 init-시점 user=null 이유. partialize {} 는
+      //     빈 blob 을 남겨 "키 없음" 을 못 지키므로 미사용(storage 분기로 키 자체를 안 만든다).
+      storage: createJSONStorage(() => ({
+        getItem: (name) => localStorage.getItem(name),
+        setItem: (name, value) => {
+          if (useSessionStore.getState().user === null) return;
+          localStorage.setItem(name, value);
+        },
+        removeItem: (name) => localStorage.removeItem(name),
+      })),
+      // 입력 좌표(마커·통근선 #209) + candidates·deadlineDate(데드라인 reload #214).
+      //   diagnosisId·filters·캐시(commutePool/stories/summary)는 제외.
       partialize: (s) => ({
         addressA: s.addressA,
         addressB: s.addressB,


### PR DESCRIPTION
## 목표
심사관 모드 토스트 **"회원 정보에 저장되지 않아요"** 정합 — **로그인(카카오)만** 입력 좌표(직장 주소)·candidates·deadlineDate를 localStorage에 남기고, **심사관·게스트는 안 남김**.

배경: #209(입력좌표)·#214(candidates·deadlineDate)가 모드 무관 전부 persist돼, 심사관/게스트도 직장 주소가 localStorage에 남아 토스트와 어긋남.

## 핵심 조건 (조사 정정)
`enterReviewerMode`는 `isGuest: true, isReviewer: true`(session.ts:44) — **심사관도 게스트 인프라**. 따라서 "둘 다 제외 = 로그인만 통과"의 정확한 술어는 `isGuest && !isReviewer`(게스트만, ❌)가 아니라 **`user === null`**(게스트·심사관 모두 user=null).

## 구현
### 1. diagnosis-store — custom storage의 `setItem` 게이팅
\`\`\`ts
storage: createJSONStorage(() => ({
  getItem: (name) => localStorage.getItem(name),              // 게이팅 X
  setItem: (name, value) => {
    if (useSessionStore.getState().user === null) return;     // 게스트/심사관: 쓰기만 건너뜀
    localStorage.setItem(name, value);
  },
  removeItem: (name) => localStorage.removeItem(name),
})),
\`\`\`
- **왜 `getItem`은 게이팅 안 하나**: 로그인 사용자도 store **init 시점엔 `user=null`**(Supabase 세션→`setUser`가 마운트 후 비동기). getItem을 게이팅하면 **로그인 새로고침 복원이 깨짐**.
- **왜 게이트에서 `removeItem` 안 하고 '건너뛰기만' 하나**: zustand persist는 **rehydrate 시점에도 `setItem`을 호출**할 수 있는데 그 init 순간 `user=null` → 만약 삭제까지 하면 **로그인 사용자 blob을 지워 복원 회귀**. 그래서 게이트는 쓰기만 skip, 기존 blob 제거는 진입·로그아웃이 전담.
- **왜 동적 `partialize {}`를 안 쓰나**: `{}` 반환해도 zustand는 빈 blob `{"state":{},"version":0}`을 **여전히 씀** → "키 없음" 검증을 못 지킴. storage 분기로 **키 자체를 안 만듦**.

### 2. 기존 blob 제거 (이전 사용자 좌표 물려받기·로그아웃 잔존 방지)
- **게스트/심사관 진입**: `login-form.tsx` `enterGuestMode()/enterReviewerMode()` 직후 `localStorage.removeItem(DIAGNOSIS_PERSIST_KEY)`.
- **로그아웃**: `session-bridge.tsx` `signOut()` 직후 동일 제거.
- `DIAGNOSIS_PERSIST_KEY` 상수 export(단일 소스). `diagnosis-store → session` **단방향 import**(순환 없음 — session은 어떤 store도 import 안 함).

## 동작
| 시나리오 | 결과 |
|---|---|
| 게스트/심사관 입력 후 새로고침 | localStorage에 `onday-diagnosis-input` **키 없음**, 입력값 안 남음, 지도 복원 안 됨(의도) |
| 로그인 입력·candidates·D-day 새로고침 | **복원 그대로(회귀 0)** — getItem 게이팅 X + rehydrate 시 삭제 X |
| 게스트가 이전 로그인 사용자 좌표 | 진입 시 removeItem → **물려받지 않음** |
| 로그아웃 후 | blob 제거 → **잔존 0** |
| 게스트→로그인 전환 후 | 이후 입력부터 정상 persist |

## 유지 (무변경)
- 로그인 사용자 persist 현행 동일(회귀 0). session 스토어·#24 게스트 차단·심사관 모드·favorites persist 무변경.

## 검증
- ✅ `tsc --noEmit` 통과 (exit 0)
- ✅ `eslint` 통과 (exit 0, 0 errors; 잔존 9 warnings 무관 기존 파일)
- ✅ 한글 인코딩 깨짐 0
- ✅ 순환 import 없음(session은 diagnosis import 안 함)

## ⚠️ 실기기/브라우저 최종 확인 필요
1. **게스트/심사관**: 직장 주소 입력 → 새로고침 → DevTools Application▸localStorage에 `onday-diagnosis-input` **키 없음** + 지도 마커 복원 안 됨
2. **로그인(카카오)**: 입력·candidates·D-day 새로고침 복원 그대로(회귀 0)
3. **게스트가 이전 로그인 좌표 안 물려받음** / **로그아웃 후 키 제거**
4. 토스트 "저장 안 됨"과 체감 정합
> 로컬은 mock auth(`NEXT_PUBLIC_USE_MOCK=true`) — 카카오=즉시 setUser라 로그인/게스트 구분 검증 가능. 실 로그아웃 clearing은 real auth(session-bridge) 경로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)