### PR TITLE
fix(persist): 이전조건·찜도 로그인만 persist — 심사관/게스트 흔적 0 (#216 stack)

### DIFF
--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -21,13 +21,14 @@ import { useAddressSuggest } from "@/features/diagnosis/use-address-suggest";
 // ★ Mismatch ⑬ 정정: isWithinSeoulMetropolitan → isWithinMetroBounds (★ CMD-DIAG-001 산출물 정합, α₁ page.tsx 책임).
 import { isWithinMetroBounds } from "@/lib/diagnosis";
 import { trackDiagnosisStarted } from "@/lib/analytics/mixpanel";
-import { useDiagnosisStore } from "@/stores/diagnosis-store";
+import { LAST_CONFIG_KEY, useDiagnosisStore } from "@/stores/diagnosis-store";
+import { useSessionStore } from "@/stores/session";
 import { useUIStore } from "@/stores/ui";
 import { cn } from "@/lib/utils";
 import { PREFERENCE_TAGS } from "@/lib/diagnosis/preference-tags";
 
 // ★ REFACTOR-UI-002-FEEDBACK-2 (#96) — 이전 조건 불러오기 (localStorage 직접 + 명시적 패턴, Zustand store 보존 답습).
-const LAST_CONFIG_KEY = "onday-last-config";
+//   LAST_CONFIG_KEY 는 diagnosis-store 에서 import(진입/로그아웃 제거와 단일 소스 공유).
 
 // ★ REFACTOR-COMMUTE-LEGACY (#102) — Issue #102 머지 이전 사용자가 timeRange 박힌 채 localStorage 저장 시 자가 치유.
 //   "morning" → 평일 08:00, "evening" → 평일 18:00, "flexible"/기타 → commuteSchedule 미박힘 (사용자 재입력).
@@ -200,7 +201,8 @@ export default function DiagnosisPage() {
       // MON-003 v1.4 부활 (Issue #127) — REQ-NF-008 funnel 시작점.
       trackDiagnosisStarted(data.diagnosisId);
       // ★ REFACTOR-UI-002-FEEDBACK-2 (#96) — 진단 시작 성공 시 localStorage 저장 (★ "이전 조건 불러오기" 버튼 호출처).
-      if (typeof window !== "undefined") {
+      //   ★ 로그인(user!==null)만 저장 — 게스트/심사관은 직장 주소가 남지 않게(#216 정합, 토스트 일치).
+      if (typeof window !== "undefined" && useSessionStore.getState().user !== null) {
         try {
           localStorage.setItem(
             LAST_CONFIG_KEY,

--- a/onday-app/src/components/auth/login-form.tsx
+++ b/onday-app/src/components/auth/login-form.tsx
@@ -10,7 +10,7 @@ import { MOCK_USER } from "@/mocks/users";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { IS_MOCK_AUTH } from "@/lib/auth/flags";
 import { useSessionStore } from "@/stores/session";
-import { DIAGNOSIS_PERSIST_KEY } from "@/stores/diagnosis-store";
+import { clearGuestPersisted } from "@/lib/auth/clear-guest-persisted";
 import { useUIStore } from "@/stores/ui";
 import { cn } from "@/lib/utils";
 
@@ -76,8 +76,8 @@ export function LoginForm() {
   const handleGuest = () => {
     setInFlight("guest");
     enterGuestMode();
-    // 게스트는 회원 정보 미저장 — 이전 로그인 사용자가 남긴 입력좌표 blob 제거(물려받기 방지).
-    localStorage.removeItem(DIAGNOSIS_PERSIST_KEY);
+    // 게스트는 회원 정보 미저장 — 이전 로그인 사용자가 남긴 좌표·이전조건·찜 제거(물려받기 방지).
+    clearGuestPersisted();
     router.push("/diagnosis");
   };
 
@@ -85,8 +85,8 @@ export function LoginForm() {
   //   세션 내(in-memory + favorites localStorage) 동작, 회원 정보에는 귀속되지 않음.
   const handleReviewer = () => {
     enterReviewerMode();
-    // 심사관도 회원 정보 미저장 — 이전 로그인 사용자가 남긴 입력좌표 blob 제거.
-    localStorage.removeItem(DIAGNOSIS_PERSIST_KEY);
+    // 심사관도 회원 정보 미저장 — 이전 로그인 사용자가 남긴 좌표·이전조건·찜 제거.
+    clearGuestPersisted();
     // CMD-AUTH-004 — 진입 이벤트 기록(Sentry 미초기화 시 silent no-op).
     Sentry.captureMessage("reviewer_mode_entered", "info");
     pushToast({

--- a/onday-app/src/lib/auth/clear-guest-persisted.ts
+++ b/onday-app/src/lib/auth/clear-guest-persisted.ts
@@ -1,0 +1,12 @@
+import { DIAGNOSIS_PERSIST_KEY, LAST_CONFIG_KEY } from "@/stores/diagnosis-store";
+import { FAVORITES_PERSIST_KEY } from "@/stores/favorites";
+
+// 게스트/심사관 진입·로그아웃 시 — 로그인 사용자만 남기는 localStorage 흔적을 전부 제거.
+//   입력좌표(#216) · 이전조건(직장 주소) · 찜 — 이전 로그인 사용자 데이터 물려받기/잔존 방지.
+//   (persist storage 게이팅은 '쓰기'만 막으므로, 기존 blob 제거는 진입·로그아웃에서 전담.)
+export function clearGuestPersisted(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(DIAGNOSIS_PERSIST_KEY);
+  localStorage.removeItem(LAST_CONFIG_KEY);
+  localStorage.removeItem(FAVORITES_PERSIST_KEY);
+}

--- a/onday-app/src/providers/session-bridge.tsx
+++ b/onday-app/src/providers/session-bridge.tsx
@@ -6,7 +6,7 @@ import type { User } from "@supabase/supabase-js";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { IS_MOCK_AUTH } from "@/lib/auth/flags";
 import { useSessionStore, type SessionUser } from "@/stores/session";
-import { DIAGNOSIS_PERSIST_KEY } from "@/stores/diagnosis-store";
+import { clearGuestPersisted } from "@/lib/auth/clear-guest-persisted";
 
 function toSessionUser(user: User): SessionUser {
   const meta = user.user_metadata ?? {};
@@ -45,8 +45,8 @@ export function SessionBridge() {
         setUser(toSessionUser(session.user));
       } else if (event === "SIGNED_OUT") {
         signOut();
-        // 로그아웃 후 입력좌표·결과가 localStorage 에 잔존하지 않게 제거(프라이버시).
-        localStorage.removeItem(DIAGNOSIS_PERSIST_KEY);
+        // 로그아웃 후 좌표·이전조건·찜이 localStorage 에 잔존하지 않게 제거(프라이버시).
+        clearGuestPersisted();
       }
     });
 

--- a/onday-app/src/stores/diagnosis-store.ts
+++ b/onday-app/src/stores/diagnosis-store.ts
@@ -7,6 +7,9 @@ import { useSessionStore } from "./session";
 
 // persist localStorage key — 게스트/심사관 진입·로그아웃 시 직접 제거에도 재사용(단일 소스).
 export const DIAGNOSIS_PERSIST_KEY = "onday-diagnosis-input";
+// "이전 조건 불러오기"(diagnosis/page.tsx)가 직접 localStorage 에 쓰는 키 — 직장 주소 포함.
+//   persist store 가 아니므로 저장 시 모드 게이팅 + 진입/로그아웃 제거를 호출처에서 한다.
+export const LAST_CONFIG_KEY = "onday-last-config";
 
 interface DiagnosisState {
   // Input

--- a/onday-app/src/stores/favorites.ts
+++ b/onday-app/src/stores/favorites.ts
@@ -8,6 +8,10 @@ import type {
   DiagnosisMode,
   SafetyGrade,
 } from "@/lib/types";
+import { useSessionStore } from "./session";
+
+// persist localStorage key — 게스트/심사관 진입·로그아웃 시 직접 제거에도 재사용(단일 소스).
+export const FAVORITES_PERSIST_KEY = "onday-favorites";
 
 // 저장한 동네 (즐겨찾기) — localStorage persist.
 // ★ id만 저장하면 새로고침 후 후보 상세(이름·등급·통근·시세)를 못 그림(diagnosis-store는 메모리).
@@ -100,11 +104,24 @@ export const useFavoritesStore = create<FavoritesState>()(
       clear: () => set(initialState),
     }),
     {
-      name: "onday-favorites",
+      name: FAVORITES_PERSIST_KEY,
       version: 1,
       // v0(Record<id,true>)는 스냅샷이 없어 복원 불가 → 초기화. 이후 찜은 스냅샷 저장됨.
       migrate: () => ({ favorites: {} }),
-      storage: createJSONStorage(() => localStorage),
+      // ★ 로그인(카카오)만 찜 persist — 게스트/심사관(user=null)은 localStorage 에 안 남김
+      //   (회원 정보 미저장 정합, #216 좌표·이전조건과 동일). 찜 로직(toggleFavorite/remove/
+      //   스냅샷)은 무변경 — storage 계층만 게이팅 → 세션 내 찜은 동작, 새로고침 후 persist 만 빠짐.
+      //   ★ setItem 에서 user===null 이면 '쓰기만 건너뜀'(키 미생성). 삭제까지 하면 rehydrate 쓰기
+      //     (init 시 로그인도 user=null, Supabase 비동기)가 로그인 찜을 지워 회귀 → 삭제는 진입·
+      //     로그아웃이 전담. getItem 도 게이팅 안 함(같은 init-시점 user=null 이유).
+      storage: createJSONStorage(() => ({
+        getItem: (name) => localStorage.getItem(name),
+        setItem: (name, value) => {
+          if (useSessionStore.getState().user === null) return;
+          localStorage.setItem(name, value);
+        },
+        removeItem: (name) => localStorage.removeItem(name),
+      })),
     },
   ),
 );


### PR DESCRIPTION
> ⚠️ **#216(`fix/persist-login-only`) 위에 stack된 PR입니다.** base가 main이 아니라 #216 브랜치 — #216 머지 후 자동으로 main 기준이 됩니다. (#216 미머지 상태라 충돌 회피 위해 stack.)

## 목표
#216(입력 좌표)에 이어, 게스트/심사관에게 남던 나머지 두 저장소도 **로그인(`user!==null`)만** persist하게. 셋 다 막아 심사관 토스트 **"회원 정보에 저장되지 않아요"** 완전 정합.
- ① **`onday-last-config`** (이전 조건 불러오기 — **직장 주소 포함**)
- ② **`onday-favorites`** (찜)
- (③ `deadline-banner-*`는 비민감 → 보류)

## 구현
### ① onday-last-config — 직접 localStorage(zustand 아님)
- 저장(`diagnosis/page.tsx`)을 `if (... && useSessionStore.getState().user !== null)`로 게이팅 → 로그인만 저장.
- 키를 `diagnosis-store.ts`에 `LAST_CONFIG_KEY`로 상수화·export(진입/로그아웃 제거와 단일 소스 공유).

### ② onday-favorites — #216과 동일 custom storage
\`\`\`ts
storage: createJSONStorage(() => ({
  getItem: (name) => localStorage.getItem(name),              // 게이팅 X
  setItem: (name, value) => {
    if (useSessionStore.getState().user === null) return;     // 게스트/심사관: 쓰기만 skip
    localStorage.setItem(name, value);
  },
  removeItem: (name) => localStorage.removeItem(name),
})),
\`\`\`
- ★ **찜 로직(`toggleFavorite`/`remove`/스냅샷/`FavoritesMenu`) 무변경** — storage 계층만 게이팅. **세션 내 찜은 그대로 동작**, 새로고침 후 persist만 빠짐.
- `favorites → session` 단방향 import(순환 없음).

### 진입/로그아웃 clearing — `clearGuestPersisted()` 헬퍼
3키(좌표·이전조건·찜)를 일괄 제거하는 헬퍼 신설(`lib/auth/clear-guest-persisted.ts`). #216이 만든 `removeItem(DIAGNOSIS_PERSIST_KEY)`를 이 헬퍼(상위집합)로 대체:
- **게스트/심사관 진입**(`login-form` `enterGuest/Reviewer`) → 3키 제거(이전 로그인 사용자 데이터 물려받기 방지)
- **로그아웃**(`session-bridge` `signOut`) → 3키 제거(잔존 0)

## ★ #216 교훈 답습 — skip-but-not-delete
storage `setItem`은 `user===null`일 때 **쓰기만 skip**(삭제 X). 삭제까지 하면 zustand **rehydrate 쓰기**(init 시 로그인도 `user=null` — Supabase 비동기 `setUser` 전)가 로그인 사용자 blob을 지워 **복원 회귀**. → 기존 blob 제거는 진입·로그아웃이 전담. `getItem`도 같은 이유로 게이팅 안 함.

## 동작
| 시나리오 | 결과 |
|---|---|
| 게스트/심사관 입력 후 새로고침 | `onday-diagnosis-input`·`onday-last-config`·`onday-favorites` **키 전부 없음**, 입력값·이전조건·찜 안 남음 |
| 로그인 | 셋 다 저장/복원 **그대로(회귀 0)** |
| 로그인→로그아웃→게스트 진입 | 이전 주소·찜 **안 보임**(clearing) |
| 세션 내 찜 | 추가 즉시 보임, 새로고침 전까진 유지(로직 무변경) |

## 유지(무변경)
- 로그인 사용자: 좌표(#216)·이전조건·찜 현행 저장/복원(회귀 0).
- #216 변경·deadline-banner·session 스토어·#24 게스트 차단·심사관 모드·찜 기능 로직 무변경.

## 검증
- ✅ `tsc --noEmit` 통과(exit 0) / ✅ `eslint` 통과(0 errors; 잔존 9 warnings 무관)
- ✅ 한글 인코딩 깨짐 0 / ✅ 순환 import 없음(session은 어떤 store도 import 안 함)

## ⚠️ 실기기/브라우저 최종 확인
1. **게스트/심사관**: 주소 입력+찜 → 새로고침 → DevTools localStorage에 3키 전부 없음, 이전 조건 불러오기에 주소 없음, 찜 안 남음
2. **로그인(카카오)**: 이전 조건·찜 새로고침 복원 그대로(회귀 0)
3. **물려받기 0**: 로그인→로그아웃→게스트 진입 시 이전 주소·찜 안 보임
4. **세션 내 찜**: 추가 즉시 반영, 새로고침 전까진 보임
> 로컬은 mock auth — "카카오로 시작"=즉시 로그인. 단 실 로그아웃 clearing은 real auth(session-bridge) 경로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)