### PR TITLE
fix(guest-gate): 찜·공유 차단 기준 user===null 통일 — predicate mismatch (#217 stack)

### DIFF
--- a/onday-app/src/features/auth/use-guest-gate.ts
+++ b/onday-app/src/features/auth/use-guest-gate.ts
@@ -8,7 +8,10 @@ import { useUIStore } from "@/stores/ui";
 // ★ #24 게스트 제약 — 저장(찜)/공유는 로그인 사용자 전용.
 //   심사관(isReviewer)은 게스트지만 차단 면제 → 세션 내에서 그대로 동작.
 //   limitations 타입(no_save/no_share)은 MOCK 계약일 뿐 실 스토어 미연결이라,
-//   1인 MVP 답게 isGuest 를 직접 읽어 2 액션만 게이트한다.
+//   1인 MVP 답게 세션 상태를 직접 읽어 2 액션만 게이트한다.
+//   ★ 기준 = user === null (모든 비로그인) — isGuest 는 "로그인 없이 체험하기"를 누른 명시적
+//     게스트에서만 true 라, 미인증 초기/로그아웃(isGuest=false, user=null) 상태가 그물을 빠져
+//     나갔음. #217 favorites persist(user===null) 와 동일 기준으로 통일해 일관 차단.
 
 type GuestAction = "save" | "share";
 
@@ -23,18 +26,19 @@ const GUEST_PROMPT: Record<GuestAction, string> = {
  * 로그인 사용자·심사관이면 `false`.
  */
 export function useGuestGate() {
-  const isGuest = useSessionStore((s) => s.isGuest);
+  const user = useSessionStore((s) => s.user);
   const isReviewer = useSessionStore((s) => s.isReviewer);
   const pushToast = useUIStore((s) => s.pushToast);
 
   return React.useCallback(
     (action: GuestAction): boolean => {
-      if (isGuest && !isReviewer) {
+      // 비로그인(게스트·미인증·로그아웃) 차단, 심사관(데모)·로그인은 면제.
+      if (user === null && !isReviewer) {
         pushToast({ variant: "default", message: GUEST_PROMPT[action] });
         return true;
       }
       return false;
     },
-    [isGuest, isReviewer, pushToast],
+    [user, isReviewer, pushToast],
   );
 }

--- a/onday-app/src/lib/auth/clear-guest-persisted.ts
+++ b/onday-app/src/lib/auth/clear-guest-persisted.ts
@@ -1,5 +1,5 @@
 import { DIAGNOSIS_PERSIST_KEY, LAST_CONFIG_KEY } from "@/stores/diagnosis-store";
-import { FAVORITES_PERSIST_KEY } from "@/stores/favorites";
+import { FAVORITES_PERSIST_KEY, useFavoritesStore } from "@/stores/favorites";
 
 // 게스트/심사관 진입·로그아웃 시 — 로그인 사용자만 남기는 localStorage 흔적을 전부 제거.
 //   입력좌표(#216) · 이전조건(직장 주소) · 찜 — 이전 로그인 사용자 데이터 물려받기/잔존 방지.
@@ -9,4 +9,7 @@ export function clearGuestPersisted(): void {
   localStorage.removeItem(DIAGNOSIS_PERSIST_KEY);
   localStorage.removeItem(LAST_CONFIG_KEY);
   localStorage.removeItem(FAVORITES_PERSIST_KEY);
+  // ★ in-memory 찜도 비움 — 이전 로그인 사용자의 찜이 reload 전까지 화면에 남는 것 방지.
+  //   clear() 의 persist 쓰기는 비로그인이라 storage 게이팅에서 skip → localStorage 잔존 0.
+  useFavoritesStore.getState().clear();
 }


### PR DESCRIPTION
> ⚠️ **#217(`fix/persist-login-only-config-favorites`) 위에 stack.** base가 #217 브랜치 — #216→#217→이 PR 순서로 머지. (#216/#217 미머지라 충돌 회피 위해 stack.)

## 문제
게스트/미인증 상태에서 **찜이 차단 안 되고 저장됨**.

## 원인 — 두 가드의 판별 기준 불일치(predicate mismatch)
| 가드 | 조건 | 막는 대상 |
|---|---|---|
| #24 찜·공유 차단 (`use-guest-gate.ts`) | `isGuest && !isReviewer` | **명시적 게스트만** |
| #217 persist 제외 (`favorites.ts`) | `user === null` | 모든 비로그인 |

`isGuest`는 **"로그인 없이 체험하기"를 누른 명시적 게스트에서만 `true`**. 그래서 **`user=null & isGuest=false`** 상태 — ① 미인증 초기 방문, ② 로그아웃 직후(`signOut: set(initialState)` → `isGuest:false`) — 가 #24 그물을 빠져나가 **찜 통과**(증상 1). persist는 `user===null`이라 새 쓰기는 막히지만, 이전 로그인 때 남은 `onday-favorites` blob이 `getItem`(게이팅 X)으로 읽혀 **옛 찜이 reload 후 보임**(증상 2).

## 수정 — 기준을 `user === null`로 통일
\`\`\`diff
- const isGuest = useSessionStore((s) => s.isGuest);
+ const user = useSessionStore((s) => s.user);
  ...
- if (isGuest && !isReviewer) {
+ if (user === null && !isReviewer) {   // 비로그인 차단, 심사관·로그인 면제
\`\`\`
- **게스트·미인증·로그아웃**(`user:null, !isReviewer`) → 차단 / **심사관**(`user:null, isReviewer`) → 면제 / **로그인**(`user≠null`) → 면제.
- #217 favorites persist(`user===null`)와 **동일 기준** → 찜·공유 일관.

### 보강 — in-memory 찜도 clear
`clearGuestPersisted()`(게스트 진입·로그아웃 시 호출)에 `useFavoritesStore.getState().clear()` 추가 → 이전 로그인 사용자 찜이 **reload 전까지 화면에 남는 것 방지**. clear()의 persist 쓰기는 비로그인이라 storage 게이팅에서 skip → localStorage 잔존 0. (`getItem` 게이팅은 #216 교훈대로 안 함 — init 시 로그인도 user=null이라 위험.)

## 영향 범위
- **공유(handleShare)도 같은 `useGuestGate`** (`result-view.tsx:121`, `single:539`) → 미인증 공유도 차단(의도 일치).
- **심사관 면제 유지**(`isReviewer` 면제 그대로).

## 유지(무변경)
- 심사관 찜/공유 면제, 로그인 찜/공유/persist(회귀 0), #216/#217 좌표·이전조건·찜 persist 게이팅(기준만 일치), 찜 toggle/remove 로직.

## 검증
- ✅ `tsc` 통과 / ✅ `eslint` 통과(0 errors; 잔존 9 warnings 무관) / ✅ 인코딩 깨짐 0 / ✅ 순환 import 없음

## ⚠️ 실기기/브라우저 최종 확인
- **게스트**("로그인 없이 체험하기"): 찜 → 차단 토스트 + 저장 안 됨
- **미인증 초기**(로그인·게스트 안 누르고 result 직접 접근): 찜 차단(틈 제거 확인)
- **심사관**: 찜 됨(면제), 새로고침 후 안 남음(#217)
- **로그인**: 찜 정상(회귀 0) / **로그아웃 후**: 옛 찜 안 보임(in-memory clear)
- **공유**도 동일 기준 차단/면제
> mock 모드 모드 판별: DevTools ▸ `onday-session`(sessionStorage)의 `user`/`isGuest`/`isReviewer` 값으로 확인. mock은 로그아웃 경로가 없어 한 번 mock 로그인하면 그 탭은 로그인 유지 — "게스트 테스트"는 새 탭/게스트 버튼으로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)