### PR TITLE
test(scoring): 테스트 인프라 마무리 + scoreCandidate 단위 테스트 6케이스

### DIFF
--- a/onday-app/package.json
+++ b/onday-app/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "db:migrate:dev": "npx prisma migrate dev",
     "db:migrate:deploy": "npx prisma migrate deploy",
     "db:generate": "npx prisma generate",

--- a/onday-app/src/lib/diagnosis/scoring.test.ts
+++ b/onday-app/src/lib/diagnosis/scoring.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { getSafetyByGu } from "@/features/single/safety-index";
+
+import { scoreCandidate, type ScoreInput } from "./scoring";
+
+// OnDay 핵심 알고리즘 scoreCandidate 단위 테스트 (scoring.ts:66-101).
+//   ★ 테스트는 현재 공식을 "검증"만 한다 — 통과시키려고 scoring.ts 를 고치지 않는다.
+//   ★ 안전 가산(scoring.ts:83-86)은 무조건 적용되므로, 공식만 결정론적으로 보려면
+//     비수도권 gu("강릉시")를 써서 no_data → 안전 +0 으로 격리한다.
+//     (safety-index 는 수도권만 → "강릉시"는 항상 no_data. 수원 같은 수도권 미수집과 달리
+//      추후 데이터가 채워져도 커버리지 밖이라 테스트가 깨지지 않는다.)
+
+const NO_DATA_GU = "강릉시"; // 수도권 밖 → getSafetyByGu = no_data (안전 가산 0)
+
+// 공통 입력 빌더 — 필요한 필드만 덮어쓴다.
+function input(overrides: Partial<ScoreInput> = {}): ScoreInput {
+  return {
+    neighborhood: { gu: NO_DATA_GU, facilities: { convenience: 0, cafes: 0 } },
+    commuteA: 10,
+    commuteB: null,
+    leisureA: null,
+    leisureB: null,
+    ...overrides,
+  };
+}
+
+describe("scoreCandidate", () => {
+  it("(a) 기본 공식: 통근 패널티 + 편의 가산 합성 (안전 no_data 로 격리)", () => {
+    // 100 - min(40, 10*0.8=8)=8 → 92 (통근, :77-78)
+    //     + 0 (안전 no_data, :84)
+    //     + min(10, (100+100)/40=5)=5 → 97 (편의, :90-92)
+    const score = scoreCandidate(
+      input({
+        commuteA: 10,
+        neighborhood: { gu: NO_DATA_GU, facilities: { convenience: 100, cafes: 100 } },
+      }),
+    );
+    expect(score).toBe(97);
+  });
+
+  it("(b) 통근 패널티는 40점에서 상한 (commute 가 아무리 커도 -40 이상 안 깎임)", () => {
+    // avgCommute*0.8 = 200*0.8 = 160 이지만 min(40, …) → 40 만 차감 (:78)
+    // 100 - 40 = 60. (상한이 없다면 100-160 = -60 → 0 이 됐을 것)
+    const score = scoreCandidate(input({ commuteA: 200 }));
+    expect(score).toBe(60);
+  });
+
+  it("(c) ★ 부부 두 직장: 통근은 A·B 평균으로 패널티 (OnDay 핵심)", () => {
+    // (commuteA 20 + commuteB 60)/2 = 40 → min(40, 32)=32 차감 → 68 (:77-78)
+    const couple = scoreCandidate(input({ commuteA: 20, commuteB: 60 }));
+    expect(couple).toBe(68);
+    // 평균이 40 인 싱글(commuteA=40, commuteB=null)과 동일해야 평균 로직이 증명됨.
+    const singleSameAvg = scoreCandidate(input({ commuteA: 40, commuteB: null }));
+    expect(couple).toBe(singleSameAvg);
+  });
+
+  it("(d) 싱글 모드: commuteB=null 이면 commuteA 만 사용 (B를 0으로 치지 않음)", () => {
+    // commuteB null → avgCommute = commuteA = 30 → min(40, 24)=24 차감 → 76 (:77)
+    //   (만약 B를 0 으로 잘못 평균냈다면 avg 15 → 88 이 됐을 것)
+    const score = scoreCandidate(input({ commuteA: 30, commuteB: null }));
+    expect(score).toBe(76);
+  });
+
+  it("(e) 결과는 0~100 정수 — 상한 clamp + 반올림 (:100)", () => {
+    // 상한: 100 - 0(통근) + 0(안전) + 10(편의 saturate) + 5+5(여가 0분×2) = 120 → clamp 100
+    const over = scoreCandidate(
+      input({
+        commuteA: 0,
+        neighborhood: { gu: NO_DATA_GU, facilities: { convenience: 1000, cafes: 1000 } },
+        leisureA: 0,
+        leisureB: 0,
+      }),
+    );
+    expect(over).toBe(100);
+
+    // 반올림: 100 - 8 + (50+33)/40=2.075 = 94.075 → round → 94 (정수)
+    const rounded = scoreCandidate(
+      input({
+        commuteA: 10,
+        neighborhood: { gu: NO_DATA_GU, facilities: { convenience: 50, cafes: 33 } },
+      }),
+    );
+    expect(rounded).toBe(94);
+    expect(Number.isInteger(rounded)).toBe(true);
+  });
+
+  it("(f) 안전 통합: 수도권 동네는 getSafetyByGu 등급만큼 가산 (실데이터 결합)", () => {
+    // 강남구는 수도권 커버 → status ok. scoreCandidate 가 그 등급 보너스를 반영하는지,
+    //   동일 입력의 no_data 동네와의 차이 = 등급 보너스 인지로 검증(등급 값 하드코딩 회피).
+    const COVERED_GU = "강남구";
+    const safety = getSafetyByGu(COVERED_GU);
+    expect(safety.status).toBe("ok"); // 수도권 커버 sanity
+    if (safety.status !== "ok") return; // 타입 가드
+
+    const bonusByGrade: Record<string, number> = { A: 10, B: 5, C: 0, D: -10 };
+    const expectedBonus = bonusByGrade[safety.grade];
+
+    const base = { commuteA: 10, commuteB: null } as const;
+    const covered = scoreCandidate(
+      input({ ...base, neighborhood: { gu: COVERED_GU, facilities: { convenience: 0, cafes: 0 } } }),
+    );
+    const noData = scoreCandidate(input(base));
+    // 두 입력 차이는 오직 안전 등급 → 점수 차 = 등급 보너스(정수라 반올림 영향 없음).
+    expect(covered - noData).toBe(expectedBonus);
+  });
+});

--- a/onday-app/vitest.config.ts
+++ b/onday-app/vitest.config.ts
@@ -1,0 +1,17 @@
+import { resolve } from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+// 테스트 인프라 (#135 vitest 설치 후 마무리).
+//   - resolve.alias: 앱 코드가 쓰는 "@/" (tsconfig paths) 를 vitest 가 알 수 있게 수동 매핑
+//     (vite-tsconfig-paths 미설치 → @ → src 로 직접).
+//   - environment node: 점수 로직 등 순수 함수 단위 테스트라 DOM 불필요.
+//   - JSON import(safety-index.json 등)는 vitest 기본 동작으로 처리.
+export default defineConfig({
+  resolve: {
+    alias: { "@": resolve(__dirname, "src") },
+  },
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## 목표
테스트 인프라 마무리(#135가 vitest 설치·`__tests__` 골격까지 했으나 config·스크립트·테스트가 비어 있었음) + **OnDay 핵심 알고리즘 `scoreCandidate`(동네 점수)** 단위 테스트 1파일. PM 포트폴리오용 — "제품의 점수 알고리즘"을 테스트로 명세화.

## 변경 (3개 — 앱 코드 무변경)
1. **`vitest.config.ts`(신설):** `resolve.alias` `@`→`src`(앱이 쓰는 `@/` path alias를 vitest가 알도록 — `vite-tsconfig-paths` 미설치라 수동 매핑) · `environment: "node"`(순수 함수, DOM 불요). JSON import는 vitest 기본 동작.
2. **`package.json`:** `"test": "vitest run"` + `"test:watch": "vitest"`.
3. **`src/lib/diagnosis/scoring.test.ts`(신설, 공동 배치):** `scoreCandidate` 6케이스. (#135 `__tests__` 골격은 무변경.)

## 테스트 케이스 ↔ 실제 공식(`scoring.ts`) 근거
> 안전 가산(`:83-86`)은 무조건 적용되므로, 공식만 결정론적으로 보려면 **비수도권 gu `"강릉시"`**로 `no_data`(안전 +0) 격리. (safety-index는 수도권만 → 추후 데이터가 채워져도 커버리지 밖이라 테스트 안 깨짐.)

| 케이스 | 검증 | 공식 근거 | 기대값 |
|---|---|---|---|
| **(a)** 기본 공식 합성 | 통근 패널티 + 편의 가산 | `:77-78`,`:90-92` | `100−8+5 = 97` |
| **(b)** 통근 40 상한 | `min(40, …)` | `:78` | `100−40 = 60` (상한 없으면 0) |
| **(c) ★ 부부 두 직장 평균** | (A+B)/2로 패널티 | `:77` | `couple(20,60)=68` 且 `=single(40)` |
| **(d)** 싱글 `commuteB=null` | commuteA만(B를 0 취급 안 함) | `:77` | `100−24 = 76` |
| **(e)** 0~100 clamp+반올림 | 상한 clamp·`round` | `:100` | 초과→`100`, `94.075`→`94`(정수) |
| **(f)** 안전 통합(실데이터) | `getSafetyByGu` 등급 보너스 반영 | `:83-86` | `score(강남구)−score(강릉시) = 등급보너스` |

> (f)는 등급 값을 하드코딩하지 않고 **`getSafetyByGu`를 oracle로** 써서 "scoreCandidate가 안전 모듈이 보고한 등급 보너스를 반영하는지"만 검증 → 데이터 갱신에 강건.

## ★ 원칙 — scoring.ts 무변경
테스트는 **현재 동작을 검증만** 하며, 통과시키려고 `scoring.ts`를 고치지 않았습니다(거꾸로 금지). 단언은 `scoring.ts:74-100` 실제 공식 손계산. `git diff scoring.ts` = **무변경**.

## 검증
- ✅ `npm test` → **Test Files 1 passed · Tests 6 passed** (vitest 4.1.6, 185ms)
- ✅ `tsc --noEmit` 통과 (exit 0) · `eslint` 통과 (0 errors; 잔존 9 warnings 무관)
- ✅ `@/` alias 동작((f)가 `@/features/single/safety-index` import해 통과로 입증)
- ✅ scoring.ts·앱 코드 무변경(변경 = config·테스트·package.json scripts 3개만) · 인코딩 깨짐 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)