### PR TITLE
feat(health): /api/health DB 연결 검증 + env/region (#10)

### DIFF
--- a/onday-app/src/app/api/health/route.ts
+++ b/onday-app/src/app/api/health/route.ts
@@ -1,18 +1,18 @@
 import { NextResponse } from "next/server";
 
-// MON-001 v1.4 (Issue #73) — REQ-NF-011 Uptime 핑 엔드포인트.
-// Sentry Uptime Monitor 5분 주기 핑 대상 (Sentry Dashboard 설정 = 르르 영역).
-// mock 모드 + Vercel 서버리스 = DB ping 환경 부적합 → 단순 200 OK 사수.
-// 차후 Production DB(PostgreSQL) 연결 시점 Prisma $queryRaw SELECT 1 확장 답습.
+import { checkHealth } from "@/lib/health";
+
+// MON-001 v1.4 (Issue #73) Uptime 핑 + #10 DB 연결 검증.
+// 기존 단순 200 → prisma.$queryRaw`SELECT 1` 로 실제 DB 연결을 확인한다:
+//   연결 OK = 200 db:"ok" / 실패 = 503 db:"error" (DATABASE_URL 깨짐·P1001 등을 즉시 가시화).
+// ★ pg 드라이버 어댑터는 Node 런타임 필수 → prisma 는 지연 import (헬스 외 경로 영향 0).
+// ★ 로그(db_connect_ok/db_connect_fail)에 connection string 미포함 (DB_SPEC §19).
 
 export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
-export function GET() {
-  return NextResponse.json(
-    {
-      status: "ok",
-      timestamp: new Date().toISOString(),
-    },
-    { status: 200 },
-  );
+export async function GET() {
+  const { prisma } = await import("@/lib/db");
+  const result = await checkHealth(prisma, new Date().toISOString());
+  return NextResponse.json(result.body, { status: result.status });
 }

--- a/onday-app/src/lib/health.test.ts
+++ b/onday-app/src/lib/health.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { checkHealth, getDeploymentEnv, getDeploymentRegion } from "./health";
+
+// /api/health DB ping 로직 단위 테스트 (#10).
+//   ★ 가짜 $queryRaw 주입으로 실 DB 없이 ok/error 분기를 결정론적으로 검증한다.
+
+const NOW = "2026-06-20T00:00:00.000Z";
+
+describe("checkHealth", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("DB 연결 성공 → 200 + db:ok + status:ok + timestamp 보존", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const db = { $queryRaw: async () => [{ value: 1 }] };
+
+    const result = await checkHealth(db, NOW);
+
+    expect(result.status).toBe(200);
+    expect(result.body.db).toBe("ok");
+    expect(result.body.status).toBe("ok");
+    expect(result.body.timestamp).toBe(NOW);
+  });
+
+  it("DB 연결 실패 → 503 + db:error + status:error", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const db = {
+      $queryRaw: async () => {
+        throw new Error("P1001: Can't reach database server");
+      },
+    };
+
+    const result = await checkHealth(db, NOW);
+
+    expect(result.status).toBe(503);
+    expect(result.body.db).toBe("error");
+    expect(result.body.status).toBe("error");
+  });
+
+  it("★ 실패 로그에 connection string 미포함 (DB_SPEC §19)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // 에러 메시지에 실제 URL 이 섞여 들어온 상황을 가정.
+    const secret = "postgresql://postgres:supersecret@aws-1.pooler.supabase.com:6543/postgres";
+    const db = {
+      $queryRaw: async () => {
+        throw new Error(secret);
+      },
+    };
+
+    await checkHealth(db, NOW);
+
+    const logged = errorSpy.mock.calls.flat().join(" ");
+    expect(logged).toContain("db_connect_fail");
+    expect(logged).not.toContain("supersecret");
+    expect(logged).not.toContain("postgresql://");
+  });
+});
+
+describe("getDeploymentEnv / getDeploymentRegion", () => {
+  const original = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it("VERCEL_ENV=preview → preview", () => {
+    process.env.VERCEL_ENV = "preview";
+    expect(getDeploymentEnv()).toBe("preview");
+  });
+
+  it("VERCEL_ENV=production → production", () => {
+    process.env.VERCEL_ENV = "production";
+    expect(getDeploymentEnv()).toBe("production");
+  });
+
+  it("VERCEL_REGION 없으면 local", () => {
+    delete process.env.VERCEL_REGION;
+    expect(getDeploymentRegion()).toBe("local");
+  });
+
+  it("VERCEL_REGION 있으면 그대로", () => {
+    process.env.VERCEL_REGION = "icn1";
+    expect(getDeploymentRegion()).toBe("icn1");
+  });
+});

--- a/onday-app/src/lib/health.ts
+++ b/onday-app/src/lib/health.ts
@@ -1,0 +1,53 @@
+// /api/health DB 연결 검증 로직 — route 에서 분리해 단위 테스트 가능하게.
+// DB_SPEC §13 checkHealth 패턴을 OnDay 구조(Prisma 7 어댑터, Vercel 시스템 변수)에 적응.
+// ★ 보안(DB_SPEC §19): 구조화 로그에 connection string 절대 미포함 — 이벤트명 + env/region 메타만.
+
+export type DeploymentEnv = "development" | "preview" | "production";
+
+export type HealthResponseBody = {
+  // status/timestamp 는 기존 Uptime 핑(MON-001 #73) 응답 계약 유지용 (추가 필드만 신설).
+  status: "ok" | "error";
+  db: "ok" | "error";
+  env: DeploymentEnv;
+  region: string;
+  timestamp: string;
+};
+
+export type HealthResult = {
+  status: number;
+  body: HealthResponseBody;
+};
+
+// $queryRaw 태그드 템플릿만 의존 — 테스트에서 가짜 객체를 주입할 수 있다 (실 prisma 불필요).
+export type HealthDatabase = {
+  $queryRaw: (query: TemplateStringsArray, ...values: unknown[]) => Promise<unknown>;
+};
+
+export function getDeploymentEnv(): DeploymentEnv {
+  if (process.env.VERCEL_ENV === "production" || process.env.VERCEL_ENV === "preview") {
+    return process.env.VERCEL_ENV;
+  }
+  return process.env.NODE_ENV === "production" ? "production" : "development";
+}
+
+export function getDeploymentRegion(): string {
+  return process.env.VERCEL_REGION?.trim() || "local";
+}
+
+export async function checkHealth(
+  database: HealthDatabase,
+  timestamp: string,
+): Promise<HealthResult> {
+  const env = getDeploymentEnv();
+  const region = getDeploymentRegion();
+
+  try {
+    await database.$queryRaw`SELECT 1`;
+    console.info(JSON.stringify({ event: "db_connect_ok", env, region }));
+    return { status: 200, body: { status: "ok", db: "ok", env, region, timestamp } };
+  } catch {
+    // 에러 객체에 URL 이 섞일 수 있으므로 메시지를 로그에 싣지 않는다 (DB_SPEC §19).
+    console.error(JSON.stringify({ event: "db_connect_fail", env, region, reason: "db_unavailable" }));
+    return { status: 503, body: { status: "error", db: "error", env, region, timestamp } };
+  }
+}


### PR DESCRIPTION
## 목표
`/api/health` 가 정적 `{status:"ok"}` 만 반환하던 것을 **실제 DB 연결 검증**으로 전환. `DATABASE_URL` 깨짐(P1001) 같은 상황을 헬스체크로 즉시 가시화.

## 변경
- `prisma.$queryRaw\`SELECT 1\`` 성공 → `200 db:"ok"` / 실패 → `503 db:"error"`
- 응답에 `env`(development/preview/production, `VERCEL_ENV`) + `region`(`VERCEL_REGION` ?? "local") 추가
- 기존 `status`/`timestamp` 필드 보존 → MON-001(#73) Sentry Uptime 핑 계약 무파손
- 로직을 `src/lib/health.ts` 로 분리 → 단위 테스트 가능
- `route.ts`: `runtime="nodejs"` 명시(pg 어댑터), `prisma` 지연 import (헬스 외 경로 영향 0)

## 보안 (DB_SPEC §19)
- 구조화 로그 `db_connect_ok`/`db_connect_fail` 에 **connection string 절대 미포함** — 이벤트명 + env/region 메타만
- 실패 시 에러 메시지도 로그에 싣지 않음(URL 혼입 방지)
- 전용 단위 테스트로 URL 미노출 검증

## 검증
- ✅ `tsc --noEmit` = 0, `eslint` = 0
- ✅ `vitest health.test.ts` 7/7 통과 (ok/error 분기 + env/region + 로그 보안)
- ✅ 로컬 `GET /api/health` → `{"status":"ok","db":"ok","env":"development","region":"local",...}` HTTP 200 (실 Supabase DB)
- ✅ dev 로그에 connection string 미노출 확인
- 503/`db:"error"` 경로 = 단위 테스트로 코드 레벨 검증

## 범위
`/api/health` 만 변경. 다른 API·`db.ts` 싱글턴 무변경(읽기만).

DB_SPEC_DEFINITION.md §13 헬스체크 패턴을 OnDay 현 구조(npm/Next 15/Prisma 7 어댑터)에 적응 — 스펙 복붙 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)