### PR TITLE
feat(env): 환경변수 Zod 런타임 검증 — process.env.X! 단언 교체 (#6)

### DIFF
--- a/onday-app/src/lib/db.ts
+++ b/onday-app/src/lib/db.ts
@@ -14,6 +14,8 @@
 import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
+import { getServerEnv } from "@/lib/env";
+
 // Pin the client to globalThis so Next.js dev HMR (and warm Vercel lambdas) reuse a
 // single connection pool instead of opening a new one per module reload / request.
 const globalForPrisma = globalThis as unknown as {
@@ -21,7 +23,9 @@ const globalForPrisma = globalThis as unknown as {
 };
 
 function createPrismaClient(): PrismaClient {
-  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+  // getServerEnv 가 DATABASE_URL 누락/형식오류를 명확한 에러로 조기 차단 (#6).
+  const { DATABASE_URL } = getServerEnv();
+  const adapter = new PrismaPg({ connectionString: DATABASE_URL });
   return new PrismaClient({ adapter });
 }
 

--- a/onday-app/src/lib/env.test.ts
+++ b/onday-app/src/lib/env.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getClientEnv, getServerEnv } from "./env";
+
+// 환경변수 Zod 검증 단위 테스트 (#6).
+//   ★ process.env 를 케이스별로 덮어쓰고, 누락/형식오류가 명확한 에러로 차단되는지 검증.
+
+const ORIGINAL = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL };
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL };
+});
+
+describe("getServerEnv", () => {
+  it("정상 DATABASE_URL → 통과", () => {
+    process.env.DATABASE_URL = "postgresql://postgres:pw@host:6543/postgres";
+    delete process.env.DIRECT_URL;
+    expect(getServerEnv().DATABASE_URL).toContain("postgresql://");
+  });
+
+  it("DATABASE_URL 누락 → 'Missing required env: DATABASE_URL'", () => {
+    delete process.env.DATABASE_URL;
+    expect(() => getServerEnv()).toThrow(/Missing required env: DATABASE_URL/);
+  });
+
+  it("DATABASE_URL 형식 오류(postgresql 아님) → 명확한 에러", () => {
+    process.env.DATABASE_URL = "file:./dev.db";
+    expect(() => getServerEnv()).toThrow(/DATABASE_URL.*PostgreSQL/);
+  });
+
+  it("DIRECT_URL 은 optional — 없어도 통과", () => {
+    process.env.DATABASE_URL = "postgresql://postgres:pw@host:6543/postgres";
+    delete process.env.DIRECT_URL;
+    expect(() => getServerEnv()).not.toThrow();
+  });
+
+  it("DIRECT_URL 형식 오류(있을 때만) → 차단", () => {
+    process.env.DATABASE_URL = "postgresql://postgres:pw@host:6543/postgres";
+    process.env.DIRECT_URL = "mysql://nope";
+    expect(() => getServerEnv()).toThrow(/DIRECT_URL.*PostgreSQL/);
+  });
+});
+
+describe("getClientEnv", () => {
+  it("정상 URL + publishable key → 통과", () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://ref.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "sb_publishable_abc";
+    const env = getClientEnv();
+    expect(env.NEXT_PUBLIC_SUPABASE_URL).toBe("https://ref.supabase.co");
+    expect(env.NEXT_PUBLIC_SUPABASE_KEY).toBe("sb_publishable_abc");
+  });
+
+  it("publishable 없을 때 anon 으로 fallback", () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://ref.supabase.co";
+    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "legacy_anon_key";
+    expect(getClientEnv().NEXT_PUBLIC_SUPABASE_KEY).toBe("legacy_anon_key");
+  });
+
+  it("SUPABASE_URL 누락 → 'Missing required env' (Preview 500 사고 차단)", () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "sb_publishable_abc";
+    expect(() => getClientEnv()).toThrow(/Missing required env: NEXT_PUBLIC_SUPABASE_URL/);
+  });
+
+  it("key 누락(publishable·anon 둘 다 없음) → 차단", () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://ref.supabase.co";
+    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    expect(() => getClientEnv()).toThrow(/Missing required env: NEXT_PUBLIC_SUPABASE_KEY/);
+  });
+
+  it("SUPABASE_URL 형식 오류(URL 아님) → 차단", () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "not-a-url";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "sb_publishable_abc";
+    expect(() => getClientEnv()).toThrow(/NEXT_PUBLIC_SUPABASE_URL/);
+  });
+});

--- a/onday-app/src/lib/env.ts
+++ b/onday-app/src/lib/env.ts
@@ -1,0 +1,91 @@
+// 환경변수 런타임 검증 (#6) — `process.env.X!` non-null 단언이 누락 시 깊은 곳에서
+// 모호하게 터지던 것을, 진입점에서 명확한 에러("Missing required env: X")로 조기 차단한다.
+// (실증: Preview env 누락 → keys.ts undefined → createServerClient throw → 미들웨어 500.)
+//
+// ★ 서버 시크릿(getServerEnv)과 클라이언트 공개값(getClientEnv, NEXT_PUBLIC_*)을 분리한다.
+//   - getServerEnv: DATABASE_URL 등 비-NEXT_PUBLIC 시크릿. 서버에서만 호출.
+//   - getClientEnv: NEXT_PUBLIC_* 공개값. 클라이언트 번들에 inline 되어도 안전한 것만.
+//
+// 점진 교체(#6): 본 라운드는 핵심 두 곳(db.ts, supabase/keys.ts)만 배선한다.
+// AI 키·카카오 키·믹스패널 등은 코드가 `?? ""` 로 부재를 우아하게 처리(선택값)하므로
+// 강제 검증 대상에서 제외 — 추측으로 required 화하지 않는다.
+
+import { z } from "zod";
+
+// ── 공통 검증 조각 ──
+const postgresUrl = z
+  .string()
+  .trim()
+  .min(1, "is required")
+  .refine(
+    (v) => v.startsWith("postgresql://") || v.startsWith("postgres://"),
+    "must be a PostgreSQL connection string (postgresql://…)",
+  );
+
+// ZodError 를 "Missing required env: X" / "X <문제>" 형태로 평탄화.
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const name = issue.path.join(".") || "env";
+      return issue.message === "is required"
+        ? `Missing required env: ${name}`
+        : `${name} ${issue.message}`;
+    })
+    .join("; ");
+}
+
+// ── 서버 전용 (시크릿) ──
+const serverEnvSchema = z.object({
+  // 런타임 쿼리에 실제 사용(db.ts). 누락/형식오류면 즉시 차단.
+  DATABASE_URL: postgresUrl,
+  // 마이그레이션(CLI) 전용 — 런타임은 안 읽으므로 optional, 있을 때만 형식 검증.
+  DIRECT_URL: postgresUrl.optional(),
+});
+
+export type ServerEnv = z.infer<typeof serverEnvSchema>;
+
+export function getServerEnv(): ServerEnv {
+  // 서버 시크릿 getter 가 클라이언트에서 호출되는 사고 방지(belt-and-suspenders —
+  // DATABASE_URL 은 NEXT_PUBLIC_ 가 아니라 애초에 클라 번들에 inline 되지 않는다).
+  if (typeof window !== "undefined") {
+    throw new Error("getServerEnv() must not be called on the client");
+  }
+
+  const parsed = serverEnvSchema.safeParse({
+    DATABASE_URL: process.env.DATABASE_URL ?? "",
+    DIRECT_URL: process.env.DIRECT_URL?.trim() || undefined,
+  });
+
+  if (!parsed.success) {
+    throw new Error(`Invalid server environment: ${formatIssues(parsed.error)}`);
+  }
+  return parsed.data;
+}
+
+// ── 클라이언트 공개값 (NEXT_PUBLIC_*) ──
+// Supabase 클라이언트가 쓰는 공개 키. publishable(최신) ?? anon(레거시) fallback 보존.
+const clientEnvSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z
+    .string()
+    .trim()
+    .min(1, "is required")
+    .pipe(z.url("must be a valid URL")),
+  NEXT_PUBLIC_SUPABASE_KEY: z.string().trim().min(1, "is required"),
+});
+
+export type ClientEnv = z.infer<typeof clientEnvSchema>;
+
+export function getClientEnv(): ClientEnv {
+  const parsed = clientEnvSchema.safeParse({
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+    NEXT_PUBLIC_SUPABASE_KEY:
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+      "",
+  });
+
+  if (!parsed.success) {
+    throw new Error(`Invalid client environment: ${formatIssues(parsed.error)}`);
+  }
+  return parsed.data;
+}

--- a/onday-app/src/lib/supabase/client.ts
+++ b/onday-app/src/lib/supabase/client.ts
@@ -1,11 +1,12 @@
 "use client";
 
 import { createBrowserClient } from "@supabase/ssr";
-import { SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY } from "./keys";
+import { getSupabaseKeys } from "./keys";
 
 // 브라우저(Client Component)용 Supabase 클라이언트.
 // 세션 쿠키 동기화는 @supabase/ssr 가 담당한다. (CMD-AUTH-001 §3.5 — 단 DB-007 이
 // 미제공이라 본 W1-2 슬라이스에서 신규 구축. ssr 0.10.x.)
 export function createSupabaseBrowserClient() {
-  return createBrowserClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+  const { url, key } = getSupabaseKeys();
+  return createBrowserClient(url, key);
 }

--- a/onday-app/src/lib/supabase/keys.ts
+++ b/onday-app/src/lib/supabase/keys.ts
@@ -1,8 +1,14 @@
 // Supabase 클라이언트 공개 키 — client/server 공용 (NEXT_PUBLIC_ 만, server-only import 없음).
 // ★ 최신 Supabase = publishable key 체계(sb_publishable_...). 레거시 anon key 는 fallback.
 //   둘 다 supabase-js 의 key 슬롯에 그대로 사용 가능 (2.105.4 = publishable 네이티브 지원).
-export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+//
+// ★ #6 — 모듈 import 시점이 아니라 호출 시점에 검증한다(지연 평가). mock-auth 모드는
+//   supabase 클라이언트를 생성하지 않으므로(미들웨어 IS_MOCK_AUTH 가드), 키 없이도
+//   안전해야 한다. 실 auth 경로에서 create*Client 가 호출될 때만 getClientEnv 가
+//   누락/형식오류를 명확한 에러("Missing required env: NEXT_PUBLIC_SUPABASE_URL")로 차단한다.
+import { getClientEnv } from "@/lib/env";
 
-export const SUPABASE_PUBLISHABLE_KEY = (process.env
-  .NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)!;
+export function getSupabaseKeys(): { url: string; key: string } {
+  const { NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_KEY } = getClientEnv();
+  return { url: NEXT_PUBLIC_SUPABASE_URL, key: NEXT_PUBLIC_SUPABASE_KEY };
+}

--- a/onday-app/src/lib/supabase/middleware.ts
+++ b/onday-app/src/lib/supabase/middleware.ts
@@ -1,16 +1,17 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import { SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY } from "./keys";
+import { getSupabaseKeys } from "./keys";
 
 // 미들웨어용 Supabase 클라이언트 — 요청마다 세션 쿠키를 refresh 한다.
 // ★ 본 W1-2 슬라이스는 "세션 갱신만" — 라우트 보호(미인증 redirect)는 게스트 흐름
 //   보존을 위해 #24(게스트 정리)로 이연. 여기선 getUser() 로 토큰만 갱신.
 export function createSupabaseMiddlewareClient(request: NextRequest) {
   let response = NextResponse.next({ request });
+  const { url, key } = getSupabaseKeys();
 
   const supabase = createServerClient(
-    SUPABASE_URL,
-    SUPABASE_PUBLISHABLE_KEY,
+    url,
+    key,
     {
       cookies: {
         getAll() {

--- a/onday-app/src/lib/supabase/server.ts
+++ b/onday-app/src/lib/supabase/server.ts
@@ -1,13 +1,14 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
-import { SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY } from "./keys";
+import { getSupabaseKeys } from "./keys";
 
 // 서버(Route Handler / Server Component)용 Supabase 클라이언트.
 // ★ @supabase/ssr 0.10.x 쿠키 API = getAll/setAll (구 get/set/remove 아님 — R5).
 export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
+  const { url, key } = getSupabaseKeys();
 
-  return createServerClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
+  return createServerClient(url, key, {
       cookies: {
         getAll() {
           return cookieStore.getAll();


### PR DESCRIPTION
## 목표
`process.env.X!` non-null 단언(특히 `supabase/keys.ts`)을 **Zod 런타임 검증**으로 교체. env 누락 시 깊은 곳에서 모호하게 터지는 대신 진입점에서 명확한 에러로 조기 차단.

> 실증: Preview env 누락 → `keys.ts` undefined → `createServerClient` throw → 미들웨어 500 (전 경로 다운).

## 변경

### 신설 `src/lib/env.ts`
- **`getServerEnv()`** (서버 시크릿): `DATABASE_URL`=required+`postgresql://` 형식, `DIRECT_URL`=optional(런타임 미사용, 있을 때만 형식검증). `typeof window` 가드로 클라이언트 호출 차단.
- **`getClientEnv()`** (NEXT_PUBLIC_*): `NEXT_PUBLIC_SUPABASE_URL`=required+url, key=`PUBLISHABLE ?? ANON` fallback 보존.
- 누락 시 `Missing required env: X` 명확한 메시지.

### 배선(점진 교체 — 핵심 2곳)
| 위치 | 변경 |
|---|---|
| `db.ts` | `createPrismaClient` 가 `getServerEnv().DATABASE_URL` 사용 |
| `supabase/keys.ts` | 모듈 import 시점 `process.env.X!` → **`getSupabaseKeys()` 지연 검증** |
| `supabase/{client,server,middleware}.ts` | `getSupabaseKeys()` 로 전환 |

### 남긴 곳 (의도적)
AI 키(`GOOGLE_GENERATIVE_AI_API_KEY`)·카카오·ODsay·믹스패널 키는 코드가 `?? ""` 로 부재를 우아하게 처리하는 **선택값** → 강제 required 화하면 회귀. 추측으로 검증 안 함.

## ★ 클라이언트 시크릿 누출 방지
- `getServerEnv`는 비-`NEXT_PUBLIC_` 시크릿(`DATABASE_URL`)만 다루고 `typeof window` 가드 보유 → 클라 번들 inline 불가 + 호출 자체 차단.
- `getClientEnv`는 `NEXT_PUBLIC_*` 공개값만.

## ★ mock 모드 안전성 (회귀 0)
`keys.ts`를 **모듈 로드 시점이 아닌 호출 시점**에 검증하도록 전환한 이유: `middleware.ts`가 `supabase/middleware.ts`(→keys.ts)를 무조건 import 하지만, mock-auth 모드는 `IS_MOCK_AUTH` 가드로 `create*Client`를 **호출하지 않는다**. 지연 검증이라 mock 모드는 키 없이도 안전(기존 동작 보존), 실 auth 경로에서만 검증·차단.

## 검증
- ✅ `tsc --noEmit` = 0, `eslint` = 0
- ✅ `vitest` 전체 23/23 통과 (env 10케이스 신규: 누락·형식오류·publishable/anon fallback)
- ✅ 로컬 `GET /api/health` → 200 `db:"ok"` (db.ts→getServerEnv 실 DATABASE_URL 검증 통과)
- ✅ 로컬 `GET /` → 307 redirect (실 auth 모드 middleware→getSupabaseKeys→getClientEnv 실 키 검증 통과, 500 없음)
- ✅ env 값·DB 연결·API 로직 무변경 — 검증 계층만 추가

DB_SPEC §7.4 패턴을 OnDay 실제 env(스펙에 없는 것 제외)에 적응 — 복붙 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)