### PR TITLE
docs: 문서-코드 드리프트 정리 — SQLite/in-memory 잔재 제거 + connection_limit

### DIFF
--- a/onday-app/.env.example
+++ b/onday-app/.env.example
@@ -53,9 +53,11 @@ NEXT_PUBLIC_MIXPANEL_TOKEN=
 # 로컬·프로덕션 모두 Supabase Postgres. sqlite 이원화 폐지 (db.ts 가 in-memory 였어
 # 로컬 sqlite 는 실서비스 경로가 아니었음). Prisma 7 = 드라이버 어댑터 필수.
 #
-# DATABASE_URL : 런타임 pooler 연결 (포트 6543, ?pgbouncer=true) — db.ts 의 PrismaPg 어댑터가 사용
+# DATABASE_URL : 런타임 pooler 연결 (포트 6543) — db.ts 의 PrismaPg 어댑터가 사용
+#                ?pgbouncer=true&connection_limit=1 = Vercel 서버리스 + PgBouncer 권장값
+#                (DB_SPEC §9.2 — 함수 인스턴스당 커넥션 1개로 풀 고갈 방지)
 # DIRECT_URL   : migrate/seed 전용 direct 연결 (포트 5432) — prisma.config.ts / prisma/seed.ts 가 사용
 #                (pgBouncer 6543 은 DDL/advisory lock 미지원이라 마이그레이션은 direct 필수)
 DATABASE_PROVIDER=postgresql
-DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true
+DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1
 DIRECT_URL=postgresql://postgres.[ref]:[password]@aws-0-ap-northeast-1.pooler.supabase.com:5432/postgres

--- a/onday-app/CLAUDE.md
+++ b/onday-app/CLAUDE.md
@@ -8,9 +8,15 @@
 - Tailwind CSS v3 + shadcn/ui (Pretendard 폰트)
 - react-hook-form + Zod (폼 검증)
 - Zustand (글로벌 상태) + TanStack Query v5 (서버 상태)
-- Supabase Auth (카카오/네이버 OAuth) — MVP는 Mock
-- Prisma ORM (SQLite dev / Supabase PostgreSQL prod)
+- Supabase Auth (카카오/네이버 OAuth) — 실 연동 (mock 은 `NEXT_PUBLIC_USE_MOCK_AUTH=true` 토글로만)
+- Prisma 7 ORM + Supabase PostgreSQL (로컬·프로덕션 단일 — sqlite 이원화 폐지, PrismaPg 드라이버 어댑터)
 - react-kakao-maps-sdk (MVP는 MapPlaceholder)
+
+### 데이터 (DB)
+- 실제 영구 저장 = Supabase Postgres (`src/lib/db.ts` = PrismaPg 어댑터, in-memory 아님).
+- 4 모델: `User` · `Diagnosis` · `ShareLink` · `SavedSearch` (`prisma/schema.prisma`).
+- 진단·공유링크·저장검색이 콜드스타트/세션을 넘어 유지(공유 링크 다중 세션 지속).
+- 찜(favorites)은 별개 — 클라이언트 localStorage.
 
 ## 디렉토리 구조
 - `src/app/` — Next.js App Router 라우트
@@ -48,10 +54,10 @@
 persona-domain-flows, domain-dependencies, market-size, known-follow-ups, srs-v1.6-changes,
 task-domains-overview. 한국어 통합본은 `../my-동네궁합진단기-workbase/llm-wiki.ko.md`.
 
-## Mock 모드
-- `NEXT_PUBLIC_USE_MOCK=true`로 모든 외부 의존성 Mock
-- SQLite 로컬 DB (DATABASE_PROVIDER=sqlite)
-- Prisma 7 + better-sqlite3 adapter
+## 실행 모드
+- **기본 = real 모드** (`NEXT_PUBLIC_USE_MOCK=false`, `NEXT_PUBLIC_USE_MOCK_AUTH=false`) — Supabase Postgres + 실 외부 API.
+- `NEXT_PUBLIC_USE_MOCK=true` = 외부 의존성 Mock (개발용 선택 토글). DB 는 항상 Postgres — sqlite/in-memory 경로 없음.
+- env 검증: `src/lib/env.ts` 의 `getServerEnv`/`getClientEnv` (Zod) 가 누락/형식오류를 진입점에서 차단(#6).
 
 ## 현재 진행 상황
 
@@ -84,7 +90,7 @@ task-domains-overview. 한국어 통합본은 `../my-동네궁합진단기-workb
 **https://onday-prototype-claude-design.vercel.app**
 - `/` → `/landing` 자동 redirect (Step 13 변경: 기존 `/login` → `/landing`)
 - 랜딩페이지 CTA → `/login` → `/diagnosis` 진단 흐름
-- mock 모드 (`NEXT_PUBLIC_USE_MOCK=true`), in-memory store
+- real 모드 — Supabase Postgres 영구 저장 (구 in-memory store 폐지, `src/lib/db.ts` = PrismaPg 어댑터)
 - 베타 테스트 가능 수준
 
 ## 다음 시작 지점
@@ -94,9 +100,9 @@ task-domains-overview. 한국어 통합본은 `../my-동네궁합진단기-workb
 - Tier 2~5 강화는 9~12주차 일정에 맞춰
 
 ### Step 13 후보 (운영 안정화 — 베타 피드백 후 우선순위 조정)
-- Supabase Postgres 연결 (in-memory → 영구 저장, share link 다중 세션 유지)
-  · `src/lib/db.ts` 인터페이스 그대로 두고 driver adapter로 교체
-  · `prisma/seed.ts`는 보존되어 있음 (Step 12에서 tsconfig exclude만 추가)
+- ✅ (완료) Supabase Postgres 연결 — `src/lib/db.ts` 가 PrismaPg 드라이버 어댑터로 교체됨,
+  in-memory → 영구 저장 전환 완료(진단·공유링크·저장검색, share link 다중 세션 유지).
+  추가로 `/api/health` DB ping(#10) + `lib/env.ts` Zod env 검증(#6) 도입.
 - Lighthouse 측정 + 모바일 viewport(375px) 실기 검증
 - Sentry 연결 (`NEXT_PUBLIC_SENTRY_DSN`)
 - Kakao Map SDK 연결 (현재는 `MapPlaceholder`)
@@ -104,13 +110,13 @@ task-domains-overview. 한국어 통합본은 `../my-동네궁합진단기-workb
 ## Step 12 잔여 cleanup (Step 13+)
 - 잔존 `key={i}` (low-risk): `dev/page.tsx`, `map-placeholder.tsx`
 - 잔존 hsl 인라인: `button.tsx` / `mode-selector.tsx`의 disabled `hsl(220 30% 84%)` — 별도 token 검토
-- `better-sqlite3` / `@prisma/adapter-better-sqlite3` 미사용 dep 정리 (Postgres 전환과 함께)
+- ✅ (완료) `better-sqlite3` / `@prisma/adapter-better-sqlite3` 제거 — `@prisma/adapter-pg` + `pg` 로 전환됨
 
 ## 주의사항
 - 한글 인코딩: Write 후 반드시 `grep -rn $'\xef\xbf\xbd'` 로 검증
 - Prisma 7: `@/generated/prisma/client` 경로 사용 (index.ts 없음)
 - shadcn v4: `@base-ui/react` 사용 (Radix 아님), oklch 덮어쓰기 주의
-- **in-memory store는 `globalThis` 핀 필수** — Next.js dev HMR 시 모듈 재로딩으로 Map 초기화됨 (`src/lib/db.ts` 참고). Vercel warm 람다에서도 같은 인스턴스 재사용에 도움.
+- **PrismaClient는 `globalThis` 핀 필수** — Next.js dev HMR 시 모듈 재로딩으로 커넥션 풀이 새로 열리는 누수 방지 (`src/lib/db.ts` 의 `__ondayPrisma`). Vercel warm 람다에서도 같은 풀 재사용. (구 in-memory Map 방식은 폐지 — 이제 Supabase Postgres 영구 저장.)
 - **`src/generated/prisma/`는 `.gitignore`** — 의존하는 파일은 `tsconfig exclude`로 빼야 Vercel 빌드 통과 (`prisma/seed.ts` 사례).
 - **React 19 ESLint 규칙**: `react-hooks/set-state-in-effect`가 useEffect → setState 패턴을 차단. localStorage 같은 외부 store는 `useSyncExternalStore`로 (`deadline-banner.tsx` 참고).
 


### PR DESCRIPTION
## 목표
갭 분석에서 나온 **문서-코드 드리프트** 정리. 실제는 Postgres real 모드인데 문서·템플릿에 낡은 "in-memory / SQLite / mock 기본" 흔적이 헷갈리게 남아 있었음. **문서·템플릿만 변경, 로직 무변경.**

## 변경 (커밋 대상 2개 파일)

### 1. `.env.example` — `connection_limit=1` 추가 (DB_SPEC §9.2)
`DATABASE_URL` 이 `?pgbouncer=true` 단독 → `?pgbouncer=true&connection_limit=1`.
Vercel 서버리스 + PgBouncer 권장값(함수 인스턴스당 커넥션 1개 → 풀 고갈 방지). 주석으로 설명 추가.
> SQLite 잔재는 `.env.example` 엔 이미 없었음(이전 커밋에서 정리됨) — 본 PR은 누락된 `connection_limit` 만 보완.

### 2. `CLAUDE.md` — 낡은 기술 → 실제 코드 상태
모두 코드로 검증한 사실만 반영(추측 없음):
| 위치 | 전 (드리프트) | 후 (실제) |
|---|---|---|
| Tech Stack | `Prisma ORM (SQLite dev / PostgreSQL prod)` | `Prisma 7 + Supabase Postgres 단일 (PrismaPg 어댑터)` |
| Tech Stack | `Supabase Auth — MVP는 Mock` | `실 연동 (mock 은 USE_MOCK_AUTH 토글)` |
| (신설) | — | **데이터(DB) 섹션**: 4모델 `User·Diagnosis·ShareLink·SavedSearch` + 영구저장 |
| Mock 모드 | `SQLite 로컬 DB / better-sqlite3 adapter` | **실행 모드**: 기본 real(`USE_MOCK=false`), DB 항상 Postgres + `lib/env.ts`(#6) |
| 라이브 URL | `mock 모드, in-memory store` | `real 모드 — Supabase Postgres 영구 저장` |
| 주의사항 | `in-memory store globalThis 핀 (Map 초기화)` | `PrismaClient globalThis 핀 (커넥션 풀 누수 방지)` |
| Step 13/cleanup | Postgres 연결·better-sqlite3 제거 = 후보 | ✅ **완료** 표기 (이미 반영됨) |

검증 근거: `schema.prisma`(4모델), `package.json`(better-sqlite3 없음, adapter-pg 사용), `db.ts`(PrismaPg, Map 없음), `.env.local`(USE_MOCK=false).

## ★ 안전성
- **실제 `.env.local`(동작 중) 무변경** — 로컬 `.env` 의 죽은 sqlite 줄은 별도로 정리했으나 gitignore 라 PR 미포함(자세히는 아래).
- **시크릿 미커밋** — `.env.example` 은 `[ref]`/`[password]` 플레이스홀더만, diff 시크릿 스캔 통과.
- DB·코드 로직 무변경 (`tsc`=0, `eslint`=0 / 경고 9건은 무관 파일 기존분).

## 로컬 `.env` 참고 (PR 미포함)
로컬 `.env` 의 `DATABASE_URL="file:./dev.db"`(죽은 sqlite 잔재) 도 정리했으나 `.env` 는 gitignore 라 커밋되지 않음. `.env.local`(Postgres)이 런타임에서 우선하므로 그 sqlite 값은 이미 미사용이었고, #6 의 `lib/env.ts` 가 `.env.local` 부재 시 "Missing required env" 로 명확히 차단함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)