### PR TITLE
docs: 라이브 URL 표기 정정 — onday-design-project.vercel.app 통일

### DIFF
--- a/docs/perf/baseline-2026-05.md
+++ b/docs/perf/baseline-2026-05.md
@@ -3,7 +3,7 @@ title: "Lighthouse baseline — 2026-05 (REQ-NF-002 측정 셋업 시점)"
 issue: "#126"
 task: "NFR-PERF-PAGE-LOAD"
 measurement_date: "(르르 Phase D 측정 시 갱신)"
-production_url: "(르르 Phase D 측정 시 확정 — memory `onday-design-project.vercel.app` vs `onday-prototype-claude-design.vercel.app` 정합 확인)"
+production_url: "https://onday-design-project.vercel.app"
 ---
 
 # Lighthouse baseline — 2026-05

--- a/onday-app/CLAUDE.md
+++ b/onday-app/CLAUDE.md
@@ -87,7 +87,7 @@ task-domains-overview. 한국어 통합본은 `../my-동네궁합진단기-workb
 | 13.5 | 랜딩페이지 v2 (비즈니스 브리프 전면 반영: Pain+학군+F1~F5+페르소나+시장) — 97% 달성 | 완료 | — |
 
 ## 🚀 라이브 URL
-**https://onday-prototype-claude-design.vercel.app**
+**https://onday-design-project.vercel.app**
 - `/` → `/landing` 자동 redirect (Step 13 변경: 기존 `/login` → `/landing`)
 - 랜딩페이지 CTA → `/login` → `/diagnosis` 진단 흐름
 - real 모드 — Supabase Postgres 영구 저장 (구 in-memory store 폐지, `src/lib/db.ts` = PrismaPg 어댑터)

--- a/tasks/MASTER-PLAN-REAL-API.md
+++ b/tasks/MASTER-PLAN-REAL-API.md
@@ -85,7 +85,7 @@ status: planning
 - [ ] **REST API 키 발급** → `NEXT_PUBLIC_KAKAO_REST_API_KEY` (주소 자동완성용)
 - [ ] **카카오 모빌리티 API 키 발급** → `KAKAO_MOBILITY_API_KEY` (실 통근시간용)
   - ⚠️ 카카오 모빌리티는 별도 비즈 검토 필요 (1~2주 대기 가능성). **Week 1 시작 시 즉시 신청 박힘**.
-- [ ] **Web 도메인 등록** → 카카오 디벨로퍼 콘솔에서 `https://onday-prototype-claude-design.vercel.app` + `http://localhost:3000` 박힘
+- [ ] **Web 도메인 등록** → 카카오 디벨로퍼 콘솔에서 `https://onday-design-project.vercel.app` + `http://localhost:3000` 박힘
 
 ### 3.2. 카카오/네이버 OAuth Provider 설정
 
@@ -427,7 +427,7 @@ status: planning
 ### 8.1. End-to-End 시나리오 (5분 데모)
 
 1. **랜딩 → 로그인 (실 OAuth)**
-   - `https://onday-prototype-claude-design.vercel.app` 접속
+   - `https://onday-design-project.vercel.app` 접속
    - "카카오로 1초 만에 시작" → 실 카카오 OAuth 동작 → Supabase Auth httpOnly cookie 박힘
    - 데모용 별도 계정 박힘 (개인 카카오 노출 회피)
 

--- a/tasks/NFR-PERF-PAGE-LOAD.md
+++ b/tasks/NFR-PERF-PAGE-LOAD.md
@@ -72,7 +72,7 @@ assignees: []
   - Chrome DevTools Lighthouse 탭 또는 `npx lighthouse <URL> --view`
   - 환경: 모바일 + 3G throttling + 시크릿 창
   - 대상: `/` (또는 `/landing`), `/login`, `/diagnosis` 3개 페이지
-  - Production URL = 르르 확정 (memory `onday-design-project.vercel.app` vs `onday-prototype-claude-design.vercel.app` 정합 확인)
+  - Production URL = `https://onday-design-project.vercel.app` (실 라이브 확정. 옛 `onday-prototype-claude-design`는 무관 프로토타입)
 
 - [ ] **3.5** `docs/perf/baseline-2026-05.md` 측정 결과 기록
   - Performance / Accessibility / Best Practices / SEO 점수


### PR DESCRIPTION
## 목표
추적 문서의 **틀린 라이브 URL**(`onday-prototype-claude-design.vercel.app` = 무관 옛날 프로토타입)을 실제 라이브(`onday-design-project.vercel.app`)로 통일.

## 변경 (문서/메모 4개, 코드 0)
| 파일:라인 | 전 | 후 |
|---|---|---|
| `onday-app/CLAUDE.md:90` | `https://onday-prototype-claude-design.vercel.app` | `https://onday-design-project.vercel.app` (#223 보류분) |
| `tasks/NFR-PERF-PAGE-LOAD.md:75` | "design-project vs prototype 정합 확인" 미해결 | `onday-design-project` 확정 (옛 prototype=무관 명시) |
| `docs/perf/baseline-2026-05.md:6` | "정합 확인" 플레이스홀더 | `production_url: "https://onday-design-project.vercel.app"` |
| `tasks/MASTER-PLAN-REAL-API.md:88,430` | 카카오 도메인 등록/데모 = prototype URL | `onday-design-project.vercel.app` |

## ★ 제외 (의도적 미변경)
- `src/lib/mocks/share-link/scenarios.ts` — mock 공유 URL 2건. 실제 mock 시나리오/테스트 영향 가능성으로 **이번 범위 제외**(git 미변경 확인). 별도 판단.

## 검증
- ✅ 정정 대상 파일에 라이브용 prototype URL 잔존 0 (NFR-PERF의 1건은 "옛 무관 프로토타입" 설명 맥락으로 의도적 유지)
- ✅ mock `scenarios.ts` 미변경 (git status에 없음)
- ✅ 코드 로직·실제 동작·.env 무변경 — 문서 URL 표기만
- ✅ `tsc`=0, `eslint`=0, 인코딩 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)