### PR TITLE
feat(playboard): Phase B-2 — 화면 상세 (시각화된 기술기획서)

### DIFF
--- a/onday-app/src/app/playboard/[id]/page.tsx
+++ b/onday-app/src/app/playboard/[id]/page.tsx
@@ -1,0 +1,248 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import {
+  SCREENS,
+  USER_FLOWS,
+  TECH_ITEMS,
+  CRITICAL_AREAS,
+  type ImplStatus,
+} from "@/lib/playboard/registry";
+
+// Playboard 화면 상세 (Phase B-2) — 목업 + 기술기획 패널 = "시각화된 기술기획서".
+// ★ 격리: registry.ts(하드코딩 메타데이터)만 import — 진단·DB·API·use-diagnosis 미참조.
+//   정적 렌더 + generateStaticParams 로 9개 화면 사전 생성(DB 미접근).
+
+export function generateStaticParams() {
+  return SCREENS.map((s) => ({ id: s.id }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const screen = SCREENS.find((s) => s.id === id);
+  return {
+    title: screen ? `${screen.title} — Playboard` : "Playboard",
+    description: screen?.role,
+  };
+}
+
+function thumbUrl(screenshot: string | null): string | null {
+  if (!screenshot) return null;
+  return `/playboard/screenshots/${screenshot.split("/").pop()}`;
+}
+
+const SHORT_LABEL: Record<string, string> = {
+  landing: "랜딩",
+  login: "로그인",
+  "diagnosis-input": "진단입력",
+  "couple-result": "커플결과",
+  "single-result": "싱글결과",
+  "detail-sheet": "상세시트",
+  "deadline-input": "데드라인입력",
+  "deadline-timeline": "D-day",
+  share: "공유",
+};
+
+const STATUS_BADGE: Record<ImplStatus, { label: string; cls: string }> = {
+  implemented: { label: "구현됨", cls: "bg-success-soft text-success" },
+  partial: { label: "부분", cls: "bg-warning-soft text-warning" },
+  excluded: { label: "캡처 제외", cls: "bg-bg text-ink-3 border border-card-border" },
+  gap: { label: "갭", cls: "bg-danger-soft text-danger" },
+};
+
+const USER_TYPE_LABEL: Record<string, string> = {
+  couple: "커플",
+  single: "싱글",
+  guest: "게스트",
+  reviewer: "심사관",
+  "share-recipient": "공유수신",
+};
+
+export default async function ScreenDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const screen = SCREENS.find((s) => s.id === id);
+  if (!screen) notFound();
+
+  const thumb = thumbUrl(screen.screenshot);
+  const badge = STATUS_BADGE[screen.status];
+  const techById = new Map(TECH_ITEMS.map((t) => [t.id, t]));
+
+  // 이 화면이 행사하는 mission-critical 영역(역인덱스) + 각 영역의 기술항목.
+  const areas = CRITICAL_AREAS.filter((a) => a.exercisedOnScreens.includes(screen.id));
+
+  // 이 화면이 속한 flow + 앞/뒤 단계.
+  const flowContexts = USER_FLOWS.flatMap((f) => {
+    const idx = f.screens.indexOf(screen.id);
+    if (idx === -1) return [];
+    return [{
+      flow: f,
+      prev: idx > 0 ? f.screens[idx - 1] : null,
+      next: idx < f.screens.length - 1 ? f.screens[idx + 1] : null,
+      step: idx + 1,
+      total: f.screens.length,
+    }];
+  });
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-6xl px-s-5 py-s-8 font-sans text-ink">
+      {/* ── 브레드크럼 + 헤더 ── */}
+      <nav className="text-caption">
+        <Link href="/playboard" className="font-bold text-primary hover:underline">
+          ← Playboard
+        </Link>
+        <span className="px-s-2 text-ink-3">/</span>
+        <span className="text-ink-3">{screen.title}</span>
+      </nav>
+
+      <header className="mt-s-4 border-b border-card-border pb-s-5">
+        <div className="flex flex-wrap items-center gap-s-3">
+          <h1 className="text-h1 font-extrabold tracking-[-0.02em] text-ink">{screen.title}</h1>
+          <span className={`rounded-sm px-s-2 py-0.5 text-caption-xs font-bold ${badge.cls}`}>
+            {badge.label}
+          </span>
+          <code className="text-body-sm text-ink-3">{screen.url}</code>
+        </div>
+        <p className="mt-s-2 max-w-2xl text-body text-ink-2">{screen.role}</p>
+        <div className="mt-s-3 flex flex-wrap items-center gap-1">
+          {screen.userTypes.map((u) => (
+            <span key={u} className="rounded-chip bg-primary-soft px-s-2 py-0.5 text-caption-xs font-bold text-primary">
+              {USER_TYPE_LABEL[u] ?? u}
+            </span>
+          ))}
+        </div>
+      </header>
+
+      {/* ── 목업 ‖ 기술기획 (병치) ── */}
+      <div className="mt-s-6 grid gap-s-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        {/* 목업 */}
+        <div className="lg:sticky lg:top-s-5 lg:self-start">
+          <p className="mb-s-2 text-caption-xs font-extrabold uppercase tracking-[0.14em] text-ink-3">목업</p>
+          <div className="overflow-hidden rounded-lg border border-card-border bg-bg shadow-card">
+            {thumb ? (
+              // eslint-disable-next-line @next/next/no-img-element -- 정적 스크린샷(상황판).
+              <img src={thumb} alt={`${screen.title} 화면`} className="w-full" />
+            ) : (
+              <div className="flex aspect-[3/4] w-full flex-col items-center justify-center gap-s-2 text-ink-3">
+                <span className="text-display-2">▦</span>
+                <span className="text-body-sm">스크린샷 없음</span>
+                {screen.note ? <span className="max-w-xs px-s-5 text-center text-caption-xs">{screen.note}</span> : null}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 기술기획 패널 */}
+        <div className="flex flex-col gap-s-6">
+          {/* mission-critical 영역 & 기술항목 */}
+          <section>
+            <p className="mb-s-2 text-caption-xs font-extrabold uppercase tracking-[0.14em] text-ink-3">
+              mission-critical 기술기획
+            </p>
+            {areas.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-danger/40 bg-danger-soft p-s-4">
+                <p className="text-body font-bold text-danger">커버리지 갭 — 매핑된 mission-critical 영역 없음</p>
+                <p className="mt-1 text-body-sm text-ink-2">
+                  이 화면은 현재 6개 mission-critical 영역 중 어디에도 행사되지 않습니다(매트릭스 빈 열).
+                  화면 기능은 구현됐으나, 인증·접근제어·무결성·복구·관측성·성능 관점의 기술기획은 아직 미정 — 정직한 갭입니다.
+                </p>
+              </div>
+            ) : (
+              <ul className="flex flex-col gap-s-4">
+                {areas.map((area) => {
+                  const items = area.techItemIds
+                    .map((tid) => techById.get(tid))
+                    .filter((t): t is NonNullable<typeof t> => Boolean(t));
+                  return (
+                    <li key={area.id} className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+                      <div className="flex items-center gap-s-2">
+                        <h3 className="text-body font-bold text-ink">{area.label}</h3>
+                        <span className={`rounded-sm px-s-2 py-0.5 text-caption-xs font-bold ${STATUS_BADGE[area.status].cls}`}>
+                          {STATUS_BADGE[area.status].label}
+                        </span>
+                      </div>
+                      <ul className="mt-s-3 flex flex-col gap-s-3">
+                        {items.map((t) => (
+                          <li key={t.id} className="border-l-2 border-primary/30 pl-s-3">
+                            <p className="text-body-sm font-bold text-ink">{t.title}</p>
+                            <p className="mt-0.5 text-body-sm leading-relaxed text-ink-2">{t.point}</p>
+                            <div className="mt-1 flex flex-wrap gap-1">
+                              {t.evidence.map((e) => (
+                                <code key={e} className="rounded-xs bg-bg px-1.5 py-0.5 text-caption-xs text-ink-3">
+                                  {e}
+                                </code>
+                              ))}
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                      {/* ★ 이 영역의 갭 정직 노출 */}
+                      <p className="mt-s-3 rounded-sm bg-warning-soft px-s-3 py-s-2 text-caption-xs leading-relaxed text-ink-2">
+                        <span className="font-bold text-warning">영역 갭:</span> {area.gapNote}
+                      </p>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+
+          {/* flow 맥락 */}
+          <section>
+            <p className="mb-s-2 text-caption-xs font-extrabold uppercase tracking-[0.14em] text-ink-3">flow 맥락</p>
+            {flowContexts.length === 0 ? (
+              <p className="text-body-sm text-ink-3">연결된 사용자 flow 없음.</p>
+            ) : (
+              <ul className="flex flex-col gap-s-3">
+                {flowContexts.map(({ flow, prev, next, step, total }) => (
+                  <li key={flow.id} className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+                    <div className="flex items-baseline justify-between gap-s-2">
+                      <h3 className="text-body-sm font-bold text-ink">{flow.label}</h3>
+                      <span className="text-caption-xs text-ink-3">{step} / {total} 단계</span>
+                    </div>
+                    <div className="mt-s-2 flex items-center gap-s-2 text-caption-xs">
+                      {prev ? (
+                        <Link href={`/playboard/${prev}`} className="rounded-chip bg-bg px-s-2 py-0.5 font-bold text-ink-2 hover:text-primary">
+                          ← {SHORT_LABEL[prev] ?? prev}
+                        </Link>
+                      ) : (
+                        <span className="text-ink-3">시작</span>
+                      )}
+                      <span className="rounded-chip bg-primary px-s-3 py-0.5 font-bold text-primary-foreground">
+                        {SHORT_LABEL[screen.id] ?? screen.id}
+                      </span>
+                      {next ? (
+                        <Link href={`/playboard/${next}`} className="rounded-chip bg-bg px-s-2 py-0.5 font-bold text-ink-2 hover:text-primary">
+                          {SHORT_LABEL[next] ?? next} →
+                        </Link>
+                      ) : (
+                        <span className="text-ink-3">끝</span>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+
+      <footer className="mt-s-9 border-t border-card-border pt-s-5">
+        <Link href="/playboard" className="text-body-sm font-bold text-primary hover:underline">
+          ← Playboard 상황판으로
+        </Link>
+        <p className="mt-s-2 text-caption-xs text-ink-3">
+          SoT: <code>src/lib/playboard/registry.ts</code> · 정적 렌더(DB 미접근). 기술기획은 registry 실 데이터(file:line)만.
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/onday-app/src/app/playboard/page.tsx
+++ b/onday-app/src/app/playboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import {
   SCREENS,
@@ -95,9 +96,13 @@ function ScreenCard({ s }: { s: ScreenNode }) {
               {USER_TYPE_LABEL[u] ?? u}
             </span>
           ))}
-          <span className="ml-auto text-caption-xs text-ink-3" aria-hidden>
-            상세 B-2 →
-          </span>
+          <Link
+            href={`/playboard/${s.id}`}
+            className="ml-auto rounded-sm text-caption-xs font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            aria-label={`${s.title} 상세 보기`}
+          >
+            상세 보기 →
+          </Link>
         </div>
       </div>
     </article>


### PR DESCRIPTION
## 목표
각 화면 클릭 시 `/playboard/[id]` 상세 — **목업(스크린샷 크게) ‖ 기술기획 패널 병치** = "시각화된 기술기획서". B-1의 "상세 →" 링크를 실제 작동하게.

## 구성 (`src/app/playboard/[id]/page.tsx`, 정적 + `generateStaticParams` 9개)
1. **목업**: 화면 스크린샷 크게(public). 없으면(공유) placeholder + note.
2. **메타**: url·역할·userTypes·status 배지.
3. **★ 기술기획 패널**: 화면이 행사하는 mission-critical 영역(역인덱스) → 영역별 techItem(기술포인트 + 근거 `file:line` code chip + 영역) + **★ 영역 갭(gapNote)** 정직 노출.
4. **★ 커버리지 갭 케이스**: `deadline-input`은 매핑 영역 0 → "커버리지 갭" callout으로 정직 표기.
5. **flow 맥락**: 속한 flow의 단계(N/총) + 앞/뒤 화면 링크.
6. Playboard 복귀 링크.

## B-1 링크 살림
`page.tsx` 카드 "상세 B-2 →" span → **`<Link href="/playboard/[id]">상세 보기 →</Link>`** (브로큰 링크 해소, focus-ring 포함).

## ★ 정직성
- 기술기획 패널 = registry 실 데이터(file:line)만. 창작 0.
- 영역별 gapNote 노출(이 화면 영역의 미기획).
- `deadline-input`(영역 0)·flow 미연결은 갭으로 정직 표기.
- 공유(스크린샷 없음)는 placeholder + "별도" note.

## 검증
- ✅ **9개 상세 HTTP 200** (landing~share 전부)
- ✅ 비주얼: 리치(couple-result — 5영역 techItem + file:line + 영역갭 + flow) · **갭(deadline-input — 커버리지 갭 callout + flow 없음)**
- ✅ B-1 카드 "상세 보기 →" → 상세 이동 작동
- ✅ **격리**: `registry.ts` + `next`만 import(진단·DB·API import **0**). 정적 렌더(DB 미접근).
- ✅ **앱 로직 무변경**: `src/app/playboard/[id]/` 신규 + `page.tsx` 링크만. src/ 진단·DB·결과·registry.ts 무변경.
- ✅ `tsc`=0, `eslint`=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)