### PR TITLE
docs(playboard): Phase D — SoT 운영 규칙 정립 (CLAUDE.md + PRD 참조)

### DIFF
--- a/docs/00_PRD_v1.1-rev.4.md
+++ b/docs/00_PRD_v1.1-rev.4.md
@@ -8,6 +8,8 @@
   - rev.3 (2026-04-18): SRS Rev 1.5 MVP 축소 반영 — F5 간이 저장·불러오기로 축소, Story 3-5 AC 축소, §5-3 AES-256·ISMS-P 제거, §7-2 Out-of-Scope 3건 추가, §7-3 R4 완화 전략 수정
   - rev.4 (2026-04-21): SRS Rev 1.6 + Task List v1.2 정합성 반영 — Supabase Auth 전환 (§5-3), 결제 도메인 MVP 제외 (§7-2 Out-of-Scope 추가), 북극성 KPI → 진단 완료 수 (§1-4), 보조1 → WTP 설문 응답률, §5-4 모니터링 도구 갱신, §7-5 PG사 의존성 제거 (+ ERD SAVED_SEARCH 3필드 단순화, /api/v1/search/replay 제거)
 
+> **운영 현황·구현 상태는 Playboard 참조 (역할 분담).** 본 PRD는 **비전·요구사항·근거(why·what)**의 SoT이고, **화면별 구현 상태·기술기획(요구사항/게이트/데이터계약/예외/NFR)·mission-critical 제어의 4-상태(구현/이연/미구현/미기획)·갭 현황**은 **Playboard**(`/playboard`, SoT = `onday-app/src/lib/playboard/registry.ts`)가 운영 SoT다. 요구사항 변경 시 본 PRD와 Playboard registry를 함께 갱신한다.
+
 ---
 
 ## 1. 개요·목표

--- a/onday-app/CLAUDE.md
+++ b/onday-app/CLAUDE.md
@@ -128,3 +128,26 @@ task-domains-overview. 한국어 통합본은 `../my-동네궁합진단기-workb
 lsof -ti:3000 | xargs kill -9 2>/dev/null; rm -rf .next && npm run dev
 ```
 **예방**: Step 단위 큰 변경(신규 페이지 + middleware/store) 후 dev 재시작 권장
+
+## Playboard — 운영 SoT (★ 동시 갱신 규칙)
+
+OnDay는 화면·기능·기술기획의 **운영 현황을 Playboard**로 단일 관리한다.
+
+- **SoT**: `src/lib/playboard/registry.ts` (화면 9 · 사용자 flow 5 · 기술기획 항목 · mission-critical 6영역 · `SCREEN_SPECS`[화면별 5종: 요구사항·게이트·데이터계약·예외·NFR] · `AREA_SPECS`[영역별 제어 스펙] · `CONVERGENCE`[갭 후속]).
+- **상황판**: `/playboard`(인덱스·커버리지 매트릭스·흐름) → `/playboard/[id]`(화면 상세) → `/playboard/flow/[type]`(흐름). 정적 렌더, registry만 참조(진단·DB import 0).
+
+### ★ 동시 갱신 규칙 (앞으로 이렇게 운영한다)
+다음 변경 시 **`registry.ts`를 같은 PR에서 함께 갱신**한다:
+- **요구사항 변경/추가** → 해당 화면 `SCREEN_SPECS[*].requirements` 또는 `AREA_SPECS` 갱신.
+- **화면/라우트 신설·제거** → `SCREENS`(+ 스크린샷)·`USER_FLOWS` 갱신.
+- **구현 완료/이연/범위변경** → 해당 항목 `status` 갱신(`implemented`/`deferred`/`unimplemented`/`unplanned` 또는 `SpecStatus`).
+- **갭의 이슈화/해소** → `CONVERGENCE` 항목 `status`·`link` 갱신.
+
+### ★ 4-상태 분류 의미 (정직성 핵심)
+`AREA_SPECS` 제어와 매트릭스 표기는 "갭"을 뭉뚱그리지 않는다:
+- **implemented** — 코드 `file:line` 또는 플랫폼 기본(Vercel·Supabase).
+- **deferred** — SRS/CON이 **GA 이후·v1.5+로 명시 결정**(예: AES-256 = CON-16, 관측성 SLO = CON-17). **★ 미기획 아님**.
+- **unimplemented** — REQ-NF 요구는 문서화 / 코드 없음(예: WAF REQ-NF-022).
+- **unplanned** — SRS/PRD에도 없음(순수 미기획, 예: DB 자동 롤백). 현재 1건.
+
+> 모든 항목은 `evidence`(SRS/PRD/CON ID 또는 코드 `file:line`)를 둔다 — 추측·창작 금지. 근거 없으면 `unplanned`로 정직 표기.

--- a/onday-app/src/lib/playboard/registry.ts
+++ b/onday-app/src/lib/playboard/registry.ts
@@ -412,8 +412,41 @@ export interface ConvergenceRef {
   link?: string; // PR/이슈 URL 등
 }
 
-/** 현재 비움 — Phase B+ 수렴 시 append. 빈 배열 = 아직 수렴 항목 없음(정직). */
-export const CONVERGENCE: ConvergenceRef[] = [];
+/** Phase D — AREA_SPECS·SCREEN_SPECS 에서 식별된 실제 갭의 후속 수렴 항목.
+ *  ★ 정직: 아직 GitHub 이슈로 발행되지 않은 식별된 갭은 status="planned", link 없음.
+ *  ★ deferred(GA 이후·v1.5+ 의도적 결정)는 후속 to-do 가 아니므로 여기 넣지 않는다. */
+export const CONVERGENCE: ConvergenceRef[] = [
+  {
+    kind: "gap-followup",
+    targetId: "couple-result",
+    title: "REQ-FUNC-007 — 교통 API 자동 재시도 1회 구현 (현재 catch→토스트만)",
+    status: "planned",
+  },
+  {
+    kind: "gap-followup",
+    targetId: "access-control",
+    title: "REQ-NF-022 — 악성 트래픽 차단 WAF + Rate Limiter(IP 60req/분)",
+    status: "planned",
+  },
+  {
+    kind: "gap-followup",
+    targetId: "access-control",
+    title: "REQ-NF-021 — 비인가 공유 링크 접근 침투 테스트",
+    status: "planned",
+  },
+  {
+    kind: "gap-followup",
+    targetId: "performance",
+    title: "REQ-NF-002 — Lighthouse CI 게이트 (baseline 측정은 #126 완료)",
+    status: "planned",
+  },
+  {
+    kind: "gap-followup",
+    targetId: "resilience",
+    title: "DB 마이그레이션 자동 롤백/게이트형 워크플로우 (★ 순수 미기획 — SRS/PRD 부재)",
+    status: "planned",
+  },
+];
 
 // ──────────────────────────────────────────────────────────────────────────
 // 7. 화면별 기술스펙 5종 (요구사항·게이트·데이터계약·예외·NFR)


### PR DESCRIPTION
## 목표
Playboard를 "살아있는 운영 SoT"로 정립. 문서·메타만(앱 로직 무변경).

## 변경 (문서 3개)
### 1. `onday-app/CLAUDE.md` — "Playboard — 운영 SoT" 섹션 추가 (기존 보존)
- **★ 동시 갱신 규칙**: 요구사항 변경·화면 신설/제거·구현완료/이연/범위변경·갭 이슈화 시 **`registry.ts`를 같은 PR에서 함께 갱신**.
- Playboard 구조(registry=SoT, `/playboard`=상황판) + **4-상태 분류 의미**(implemented/deferred/unimplemented/unplanned, ★ 이연≠미기획).

### 2. `docs/00_PRD_v1.1-rev.4.md` — Playboard 참조 안내 추가 (본문 보존)
- **역할 분담 명시**: PRD = 비전·요구사항·근거(why·what) SoT / Playboard = 구현상태·기술기획·갭 4-상태·운영 SoT.
- 메타 블록 직후 한 줄 추가, §1~§9 본문 무변경.

### 3. `registry.ts` `CONVERGENCE` — 식별된 갭 5건 연결
| target | 갭 | status |
|---|---|---|
| couple-result | REQ-FUNC-007 재시도 미구현 | planned |
| access-control | REQ-NF-022 WAF/Rate Limiter | planned |
| access-control | REQ-NF-021 침투 테스트 | planned |
| performance | REQ-NF-002 Lighthouse CI 게이트 | planned |
| resilience | DB 자동 롤백(순수 미기획) | planned |
> ★ 정직: 아직 GitHub 이슈 미발행 → `link` 없음, `status:"planned"`. **deferred(GA 이후 의도적 결정)는 to-do가 아니라 제외**.

## ★ 정직성
- 규칙은 "앞으로 이렇게 운영한다"는 약속 — 과장 없음.
- PRD/CLAUDE.md 기존 내용 **보존**(추가만, 덮어쓰기 X). 검증: webpack 섹션·PRD §1 그대로.

## 검증
- ✅ **앱 로직·코드 무변경** — 변경 = `CLAUDE.md` + PRD + `registry.ts`(CONVERGENCE 데이터)만
- ✅ registry **import 0** 격리 유지
- ✅ 기존 섹션 보존, 인코딩 clean
- ✅ CONVERGENCE 5건 targetId 무결성 OK
- ✅ `tsc`=0, `eslint`=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)