### PR TITLE
feat(logging): 11주차 PR1 — DB 에러 로그 테이블 + 3-sink 로깅 유틸 (토대)

### DIFF
--- a/onday-app/prisma/migrations/20260621000000_add_error_log/migration.sql
+++ b/onday-app/prisma/migrations/20260621000000_add_error_log/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "error_logs" (
+    "id" TEXT NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "level" TEXT NOT NULL,
+    "status_code" INTEGER,
+    "route" TEXT,
+    "screen_path" TEXT,
+    "error_type" TEXT,
+    "message" TEXT NOT NULL,
+    "user_type" TEXT,
+    "visitor_id" TEXT,
+    "device" TEXT,
+    "os" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "error_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "error_logs_timestamp_idx" ON "error_logs"("timestamp");

--- a/onday-app/prisma/schema.prisma
+++ b/onday-app/prisma/schema.prisma
@@ -66,3 +66,26 @@ model SavedSearch {
 
   @@map("saved_searches")
 }
+
+// 3-sink 로깅 DB 채널 (11주차 로깅 — 콘솔+DB+Sentry 중 DB).
+// ★ 프라이버시: 개인 식별 필드 없음 — user_id 원문·이메일·이름·정확한 주소 미기록.
+//   userType(유형만)·visitorId(익명 localStorage, 개인 신원 무관)·device/os(대분류)만.
+//   message 는 호출부에서 maskPII(이메일·전화 [REDACTED]) 거친다. USER 와 FK 없음(귀속 방지).
+model ErrorLog {
+  id         String   @id @default(uuid())
+  timestamp  DateTime @default(now())
+  level      String // error | warn
+  statusCode Int?     @map("status_code")
+  route      String? // API route (예: POST /api/diagnosis)
+  screenPath String?  @map("screen_path") // 화면 경로 (예: /diagnosis/result/[id])
+  errorType  String?  @map("error_type") // AppErrorCode 등 분류
+  message    String // maskPII 거친 메시지
+  userType   String?  @map("user_type") // kakao | guest | reviewer | null
+  visitorId  String?  @map("visitor_id") // 익명 방문자 ID(localStorage, 30일) — 개인 식별 아님
+  device     String? // mobile | desktop
+  os         String? // ios | android | windows | mac | other
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@index([timestamp])
+  @@map("error_logs")
+}

--- a/onday-app/src/lib/helpers/sentry-pii-mask.ts
+++ b/onday-app/src/lib/helpers/sentry-pii-mask.ts
@@ -9,7 +9,8 @@ import type { ErrorEvent } from "@sentry/nextjs";
 const EMAIL_REGEX = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
 const PHONE_REGEX = /010-?\d{3,4}-?\d{4}/g;
 
-function maskPII(text: string): string {
+// ★ export 추가(동작 무변경) — 11주차 로깅 유틸(log-error.ts)이 메시지 마스킹에 재사용(중복 정의 X).
+export function maskPII(text: string): string {
   return text.replace(EMAIL_REGEX, "[REDACTED]").replace(PHONE_REGEX, "[REDACTED]");
 }
 

--- a/onday-app/src/lib/logging/device.ts
+++ b/onday-app/src/lib/logging/device.ts
@@ -1,0 +1,33 @@
+// 디바이스/OS 대분류 (11주차 로깅 토대).
+// ★ 프라이버시: 모바일/데스크톱 + OS 대분류만. 상세 모델·버전·해상도·fingerprint 미수집.
+//   navigator.userAgent 한 줄에서 대분류만 도출(개인 식별 불가 수준).
+
+export type DeviceKind = "mobile" | "desktop";
+export type OsKind = "ios" | "android" | "windows" | "mac" | "other";
+
+const MOBILE_UA = /iphone|ipad|ipod|android|mobile/i;
+
+export function detectDevice(ua: string): DeviceKind {
+  return MOBILE_UA.test(ua) ? "mobile" : "desktop";
+}
+
+export function detectOs(ua: string): OsKind {
+  if (/iphone|ipad|ipod/i.test(ua)) return "ios";
+  if (/android/i.test(ua)) return "android";
+  if (/windows/i.test(ua)) return "windows";
+  if (/macintosh|mac os x/i.test(ua)) return "mac";
+  return "other";
+}
+
+/** 브라우저 환경에서 device/os 대분류 도출. 서버/UA 부재 시 null(앱 안 깸). */
+export function getDeviceInfo(): { device: DeviceKind | null; os: OsKind | null } {
+  try {
+    if (typeof navigator === "undefined" || !navigator.userAgent) {
+      return { device: null, os: null };
+    }
+    const ua = navigator.userAgent;
+    return { device: detectDevice(ua), os: detectOs(ua) };
+  } catch {
+    return { device: null, os: null };
+  }
+}

--- a/onday-app/src/lib/logging/log-error.ts
+++ b/onday-app/src/lib/logging/log-error.ts
@@ -1,0 +1,77 @@
+// 통합 에러 로깅 유틸 (11주차 — 3-sink: 콘솔 + DB + Sentry). 서버측 사용 전제(prisma import).
+// ★ 기존 자산 재사용(중복 정의 X): maskPII(메시지 마스킹) · reportErrorToSentry(Sentry) · AppErrorDTO.
+// ★ best-effort — 각 sink try/catch. DB insert·로깅 실패해도 앱 절대 안 죽는다.
+// ★ 프라이버시 — message 는 maskPII(이메일·전화 [REDACTED]) 거치고, 개인 식별 필드는 받지 않는다
+//   (userType=유형만 · visitorId=익명 · device/os=대분류). USER FK 없음.
+//
+// 본 PR(토대)은 유틸 정의까지. 실제 API 라우트 적용은 다음 PR.
+
+import { prisma } from "@/lib/db";
+import { reportErrorToSentry } from "@/lib/helpers/sentry-error";
+import { maskPII } from "@/lib/helpers/sentry-pii-mask";
+import { CommonErrorCode } from "@/lib/types/errors/common";
+
+export type LogLevel = "error" | "warn";
+export type LogUserType = "kakao" | "guest" | "reviewer";
+
+export interface LogErrorPayload {
+  level: LogLevel;
+  message: string;
+  statusCode?: number | null;
+  route?: string | null; // API route (예: POST /api/diagnosis)
+  screenPath?: string | null; // 화면 경로 (예: /diagnosis/result/[id])
+  errorType?: string | null; // 분류 (AppErrorCode 등)
+  userType?: LogUserType | null; // 유형만 — 개인 식별 X
+  visitorId?: string | null; // 익명 방문자 ID
+  device?: string | null; // mobile | desktop
+  os?: string | null; // ios | android | windows | mac | other
+  /** Sentry 캡처용 원본 — DB·콘솔엔 저장 안 함. */
+  originalError?: unknown;
+}
+
+/** 3-sink 로깅. 모든 sink 는 best-effort(실패해도 throw 안 함). */
+export async function logError(p: LogErrorPayload): Promise<void> {
+  const message = maskPII(p.message); // ★ 메시지 마스킹
+
+  const meta = {
+    level: p.level,
+    statusCode: p.statusCode ?? null,
+    route: p.route ?? null,
+    screenPath: p.screenPath ?? null,
+    errorType: p.errorType ?? null,
+    message,
+    userType: p.userType ?? null,
+    visitorId: p.visitorId ?? null,
+    device: p.device ?? null,
+    os: p.os ?? null,
+  };
+
+  // ① 콘솔 — JSON 구조화 (health.ts 패턴, connection string 등 미포함).
+  try {
+    const line = JSON.stringify({ event: "app_error", ...meta });
+    if (p.level === "warn") console.warn(line);
+    else console.error(line);
+  } catch {
+    // best-effort
+  }
+
+  // ② DB — ErrorLog insert (best-effort: 테이블 미배포·연결 실패 시 조용히 실패).
+  try {
+    await prisma.errorLog.create({ data: meta });
+  } catch {
+    // 앱 흐름 차단 X
+  }
+
+  // ③ Sentry — reportErrorToSentry 재사용 (DSN 있을 때만 실제 전송, 없으면 no-op).
+  try {
+    reportErrorToSentry({
+      code: CommonErrorCode.INTERNAL_SERVER_ERROR,
+      message,
+      httpStatus: p.statusCode ?? 500,
+      sentryLevel: p.level === "warn" ? "warning" : "error",
+      originalError: p.originalError,
+    });
+  } catch {
+    // best-effort
+  }
+}

--- a/onday-app/src/lib/logging/visitor-id.ts
+++ b/onday-app/src/lib/logging/visitor-id.ts
@@ -1,0 +1,42 @@
+// 익명 방문자 ID (11주차 로깅 토대).
+// ★ 개인 식별 아님 — 기기/브라우저 단위 익명 랜덤. 재방문(같은 기기 재접속) 분석용.
+//   이름·이메일·계정과 무관. localStorage 30일 만료(생성 시각 비교, 초과 시 재발급).
+// ★ best-effort — 시크릿 모드·차단으로 localStorage 접근 실패 시 null 반환(앱 안 깸).
+
+const KEY = "onday_visitor";
+const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30일
+
+interface StoredVisitor {
+  id: string;
+  createdAt: number;
+}
+
+function randomId(): string {
+  try {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
+  } catch {
+    // crypto 미지원 — 아래 폴백
+  }
+  return `v_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e9).toString(36)}`;
+}
+
+/** 익명 방문자 ID get-or-create. localStorage 불가 시 null(앱 안 깸). */
+export function getVisitorId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as StoredVisitor;
+      if (parsed?.id && typeof parsed.createdAt === "number" && Date.now() - parsed.createdAt < TTL_MS) {
+        return parsed.id;
+      }
+      // 만료 → 재발급
+    }
+    const fresh: StoredVisitor = { id: randomId(), createdAt: Date.now() };
+    window.localStorage.setItem(KEY, JSON.stringify(fresh));
+    return fresh.id;
+  } catch {
+    // localStorage 접근 실패(시크릿/차단) — ID 없이 진행
+    return null;
+  }
+}


### PR DESCRIPTION
## 목표
선생님 "3-sink(콘솔+DB+Sentry)" 중 OnDay에 없던 **DB 채널 신설 + 통합 로깅 유틸**. ★ 이번 PR은 **토대(테이블+유틸)만** — 실제 API 적용·테스트 버튼은 다음 PR.

## 변경
### 1. `prisma/schema.prisma` — `ErrorLog` 모델 추가
- ★ **기존 4모델 무변경**(diff 삭제 0, 순수 추가). 마이그레이션 = `CREATE TABLE error_logs`(ALTER 0).
- ★ **개인 식별 필드 없음**: `USER` FK 없음 / `userType`(kakao·guest·reviewer·null = 유형만) / `visitorId`(익명) / `device`·`os`(대분류) / `message`(maskPII 거침). 이메일·이름·정확한 주소·user_id 원문 미기록.
- **마이그레이션 커밋만, 클라우드 미적용** — 발표 전 기존 동작 보호. error_logs 테이블 미생성 확인.

### 2. `src/lib/logging/` (신규)
- **`log-error.ts`** — `logError(payload)` 3-sink 동시: ① 콘솔(JSON 구조화, health.ts 패턴) ② DB(`prisma.errorLog.create`, best-effort) ③ Sentry(`reportErrorToSentry` 재사용). ★ `maskPII`·`reportErrorToSentry`·`AppErrorDTO` 재사용(중복 X). 각 sink try/catch → **실패해도 앱 안 죽음**.
- **`visitor-id.ts`** — 익명 방문자 ID(localStorage get-or-create, 30일 만료 재발급). ★ try/catch — 시크릿/차단 시 `null`(앱 안 깸). 개인 신원 무관 랜덤.
- **`device.ts`** — `navigator.userAgent` → mobile/desktop + OS 대분류(ios/android/windows/mac/other). ★ 상세 모델·fingerprint 미수집.

### 3. `sentry-pii-mask.ts` — `maskPII` export 추가
- 재사용(중복 정의 X) 위한 `export` 키워드 1개 + 주석만. **동작 무변경**.

## ★ 안전
- **best-effort**: DB insert·각 sink 실패해도 throw 0(try/catch 내부).
- **localStorage 폴백**: 접근 실패 시 null, 앱 정상.
- **기존 동작 무변경 — 추가만**. 기존 API·console.error·Sentry 호출 미변경(적용은 다음 PR).

## 검증
- ✅ 스키마 **삭제 0**(기존 4모델 무변경), 개인 식별 필드 0
- ✅ device/OS 판별 4케이스 정확(iOS·Android·Windows·Mac)
- ✅ **클라우드 DB 무변경** — error_logs 미생성(마이그레이션 미적용), 내 PR DB 쓰기 0
- ✅ maskPII·reportErrorToSentry·AppErrorDTO 재사용(중복 X)
- ✅ `tsc`=0, `eslint`=0

> 참고: 라이브 diagnoses가 351→352(실 사용자 트래픽) — 본 PR과 무관(DB 쓰기 0, error_logs 미생성이 증거).

🤖 Generated with [Claude Code](https://claude.com/claude-code)