### PR TITLE
feat(logging): 11주차 PR2 — 로깅 점검 페이지 + 400/500 테스트 (prod 차단)

### DIFF
--- a/onday-app/src/app/api/dev/log-test/route.ts
+++ b/onday-app/src/app/api/dev/log-test/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+
+import { getDeploymentEnv } from "@/lib/health";
+import { logError, type LogUserType } from "@/lib/logging/log-error";
+import { prisma } from "@/lib/db";
+
+// 로깅 점검(운영자 테스트) — 의도적 400/500 에러로 3-sink(콘솔·DB·Sentry) 기록 검증.
+// ★ production 차단: 운영 도구라 production 에선 404. 개발·프리뷰에서만 동작.
+// ★ 의도적 테스트임을 errorType("test_400"/"test_500")로 명확히.
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface LogTestBody {
+  status?: 400 | 500;
+  visitorId?: string | null;
+  device?: string | null;
+  os?: string | null;
+  userType?: LogUserType | null;
+}
+
+export async function POST(request: Request) {
+  // ★ production 차단 (관리자 인증 대체 — 환경 기반).
+  if (getDeploymentEnv() === "production") {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as LogTestBody;
+  const status = body.status === 400 ? 400 : 500;
+  const errorType = status === 400 ? "test_400" : "test_500";
+
+  await logError({
+    level: "error",
+    message: `[로깅 점검] 의도적 ${status} 테스트 에러 (운영자 트리거)`,
+    statusCode: status,
+    route: "POST /api/dev/log-test",
+    errorType,
+    userType: body.userType ?? null,
+    visitorId: body.visitorId ?? null,
+    device: body.device ?? null,
+    os: body.os ?? null,
+  });
+
+  // ★ DB sink 실제 동작 여부 정직 보고 — error_logs 테이블 존재 확인(미적용이면 false).
+  let dbAvailable = false;
+  try {
+    await prisma.errorLog.count();
+    dbAvailable = true;
+  } catch {
+    dbAvailable = false;
+  }
+
+  const sentryConfigured = Boolean(
+    process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+  );
+
+  return NextResponse.json(
+    {
+      ok: true,
+      status,
+      errorType,
+      sinks: {
+        console: true, // JSON 구조화 로그 — 항상 동작
+        db: dbAvailable, // error_logs 테이블 적용 시 true (미적용이면 best-effort 실패)
+        sentry: sentryConfigured, // DSN 설정 시 전송, 없으면 no-op
+      },
+    },
+    { status },
+  );
+}

--- a/onday-app/src/app/playboard/logging-test/logging-test-client.tsx
+++ b/onday-app/src/app/playboard/logging-test/logging-test-client.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { getVisitorId } from "@/lib/logging/visitor-id";
+import { getDeviceInfo } from "@/lib/logging/device";
+import { useSessionStore } from "@/stores/session";
+import type { LogUserType } from "@/lib/logging/log-error";
+
+// 로깅 점검 클라이언트 — 400/500 의도적 에러 트리거 + 3-sink 기록 결과 표시.
+// ★ visitorId·device/os·userType 를 클라에서 수집해 API 로 전달(로그에 포함).
+
+type SinkResult = {
+  status: number;
+  errorType: string;
+  sinks: { console: boolean; db: boolean; sentry: boolean };
+  sent: { visitorId: string | null; device: string | null; os: string | null; userType: LogUserType | null };
+};
+
+function YesNo({ on, label }: { on: boolean; label: string }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-sm px-s-2 py-0.5 text-caption-xs font-bold ${
+        on ? "bg-success-soft text-success" : "bg-bg text-ink-3 border border-card-border"
+      }`}
+    >
+      {label} {on ? "기록됨" : "미동작"}
+    </span>
+  );
+}
+
+export function LoggingTestClient() {
+  const user = useSessionStore((s) => s.user);
+  const isGuest = useSessionStore((s) => s.isGuest);
+  const isReviewer = useSessionStore((s) => s.isReviewer);
+  const [loading, setLoading] = React.useState<400 | 500 | null>(null);
+  const [result, setResult] = React.useState<SinkResult | null>(null);
+  const [err, setErr] = React.useState<string | null>(null);
+
+  const userType: LogUserType | null = isReviewer
+    ? "reviewer"
+    : isGuest
+      ? "guest"
+      : user?.provider === "kakao"
+        ? "kakao"
+        : null;
+
+  async function trigger(status: 400 | 500) {
+    setLoading(status);
+    setErr(null);
+    const { device, os } = getDeviceInfo();
+    const visitorId = getVisitorId();
+    const sent = { visitorId, device, os, userType };
+    try {
+      const res = await fetch("/api/dev/log-test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status, ...sent }),
+      });
+      const body = (await res.json().catch(() => ({}))) as Omit<SinkResult, "sent">;
+      setResult({ ...body, status: res.status, sent });
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-3xl px-s-5 py-s-8 font-sans text-ink">
+      <nav className="text-caption">
+        <Link href="/playboard" className="font-bold text-primary hover:underline">
+          ← Playboard
+        </Link>
+        <span className="px-s-2 text-ink-3">/</span>
+        <span className="text-ink-3">로깅 점검</span>
+      </nav>
+
+      <header className="mt-s-4 border-b border-card-border pb-s-5">
+        <p className="text-caption-xs font-extrabold uppercase tracking-[0.16em] text-primary">운영자 도구 · dev 전용</p>
+        <h1 className="mt-s-2 text-h1 font-extrabold tracking-[-0.02em] text-ink">로깅 점검 (운영자 테스트)</h1>
+        <p className="mt-s-2 text-body text-ink-2">
+          버튼을 누르면 의도적으로 400/500 에러를 발생시켜 <strong>3-sink(콘솔·ErrorLog DB·Sentry)</strong> 기록을 검증합니다.
+          이 페이지·API는 <strong>production 에서 차단</strong>(404)됩니다.
+        </p>
+      </header>
+
+      {/* 트리거 버튼 */}
+      <section aria-label="에러 트리거" className="mt-s-6 flex flex-wrap gap-s-3">
+        <button
+          type="button"
+          onClick={() => trigger(400)}
+          disabled={loading !== null}
+          className="rounded-lg bg-warning px-s-5 py-s-3 text-body font-bold text-white shadow-card transition hover:brightness-95 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-warning focus-visible:ring-offset-2"
+        >
+          {loading === 400 ? "발생 중…" : "400 에러 발생"}
+        </button>
+        <button
+          type="button"
+          onClick={() => trigger(500)}
+          disabled={loading !== null}
+          className="rounded-lg bg-danger px-s-5 py-s-3 text-body font-bold text-white shadow-card transition hover:brightness-95 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger focus-visible:ring-offset-2"
+        >
+          {loading === 500 ? "발생 중…" : "500 에러 발생"}
+        </button>
+      </section>
+
+      {/* 결과 */}
+      {err ? (
+        <p className="mt-s-5 rounded-lg border border-danger/40 bg-danger-soft p-s-4 text-body-sm text-danger">
+          요청 실패: {err}
+        </p>
+      ) : null}
+
+      {result ? (
+        <section aria-label="기록 결과" className="mt-s-5 rounded-lg border border-card-border bg-surface p-s-5 shadow-card">
+          <div className="flex flex-wrap items-center gap-s-2">
+            <h2 className="text-h3 font-extrabold text-ink">응답 {result.status}</h2>
+            <code className="rounded-xs bg-bg px-1.5 py-0.5 text-caption-xs text-ink-3">{result.errorType}</code>
+          </div>
+
+          <p className="mt-s-3 text-caption-xs font-bold text-ink-3">3-sink 기록</p>
+          <div className="mt-s-2 flex flex-wrap gap-s-2">
+            <YesNo on={result.sinks?.console} label="① 콘솔" />
+            <YesNo on={result.sinks?.db} label="② DB(ErrorLog)" />
+            <YesNo on={result.sinks?.sentry} label="③ Sentry" />
+          </div>
+          {!result.sinks?.db ? (
+            <p className="mt-s-2 rounded-sm bg-warning-soft px-s-3 py-s-2 text-caption-xs leading-relaxed text-ink-2">
+              ★ DB sink 미동작 = <code>error_logs</code> 테이블 미적용(best-effort 실패). 마이그레이션 적용 시 기록됩니다(아래 안내). 콘솔·Sentry는 정상.
+            </p>
+          ) : null}
+          {!result.sinks?.sentry ? (
+            <p className="mt-s-2 text-caption-xs text-ink-3">※ Sentry 미동작 = DSN 미설정(no-op). DSN 설정 시 전송.</p>
+          ) : null}
+
+          <p className="mt-s-4 text-caption-xs font-bold text-ink-3">로그에 포함된 컨텍스트(개인 식별 X)</p>
+          <ul className="mt-s-2 grid gap-1 text-caption-xs text-ink-2 sm:grid-cols-2">
+            <li>userType: <code className="text-ink">{result.sent.userType ?? "null"}</code></li>
+            <li>visitorId: <code className="text-ink">{result.sent.visitorId ?? "null(차단/시크릿)"}</code></li>
+            <li>device: <code className="text-ink">{result.sent.device ?? "null"}</code></li>
+            <li>os: <code className="text-ink">{result.sent.os ?? "null"}</code></li>
+          </ul>
+        </section>
+      ) : null}
+
+      <footer className="mt-s-9 border-t border-card-border pt-s-5 text-caption-xs leading-relaxed text-ink-3">
+        DB sink 활성화: 마이그레이션 <code>20260621000000_add_error_log</code> 를 클라우드에 적용해야 함 —
+        <code className="ml-1">DATABASE_URL=$DIRECT_URL_PROD DIRECT_URL=$DIRECT_URL_PROD npm run db:migrate:deploy</code>
+        (새 테이블 CREATE만, 기존 데이터 영향 0). 적용 전엔 DB sink 가 best-effort 로 조용히 실패합니다.
+      </footer>
+    </main>
+  );
+}

--- a/onday-app/src/app/playboard/logging-test/page.tsx
+++ b/onday-app/src/app/playboard/logging-test/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { getDeploymentEnv } from "@/lib/health";
+import { LoggingTestClient } from "./logging-test-client";
+
+// 로깅 점검(운영자 테스트) 페이지 — Playboard 안의 dev 전용 도구.
+// ★ production 차단: 운영자(나)만 보는 도구라 production 에선 notFound(). 개발·프리뷰에서만 노출.
+//   force-dynamic 으로 요청 시점 env 평가(빌드 시점 고정 방지).
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "로깅 점검 — Playboard",
+  robots: { index: false, follow: false },
+};
+
+export default function LoggingTestPage() {
+  if (getDeploymentEnv() === "production") notFound();
+  return <LoggingTestClient />;
+}


### PR DESCRIPTION
## 목표
PR1의 3-sink 유틸(`logError`·`visitorId`·`device`)을 검증하는 **운영자 로깅 점검 도구**. OnDay엔 관리자가 없으니 Playboard 안에 + **production 차단**(관리자 인증 대체 = 환경 기반).

## 구성
### 1. `/playboard/logging-test` (page + client)
- "로깅 점검(운영자 테스트)" + **400/500 에러 발생 버튼** 2개.
- ★ **production 차단**: `getDeploymentEnv()==="production"` → `notFound()`. 개발·프리뷰에서만 노출. `robots: noindex`.
- ★ **visitorId(익명)·device/os(대분류)·userType(세션 유형)** 를 클라에서 수집 → API 전달.
- **결과 패널**: ① 콘솔 ② DB(ErrorLog) ③ Sentry 각 sink 동작 여부 + 컨텍스트 표시(개인 식별 X).

### 2. `POST /api/dev/log-test`
- 400/500 의도적 응답 + `logError` 호출(`errorType: test_400`/`test_500`).
- ★ production 차단(404). **DB sink 동작 여부**(`error_logs` 테이블 존재) 정직 보고.

## ★ 마이그레이션 (사용자 확인 후 적용)
- **현재 미적용** → DB sink = `false`(best-effort 조용히 실패). 콘솔·Sentry는 정상.
- 적용: `DATABASE_URL=$DIRECT_URL_PROD DIRECT_URL=$DIRECT_URL_PROD npm run db:migrate:deploy`
- 새 테이블 `CREATE`만 — 기존 데이터(User·Diagnosis 등) 영향 **0**. 페이지·footer에 안내.

## ★ 안전
- 기존 코드·API·Playboard(B-1~Phase C) **무변경** — 신규 페이지 + dev 라우트만.
- **production 노출 0** — 페이지·API 둘 다 prod 404.

## 검증
- ✅ 페이지 200(dev), 400/500 버튼 → API 응답
- ✅ **① 콘솔 sink** JSON 로그 확인 — `{event:"app_error", userType, visitorId, device, os, errorType...}` (PII 0, 익명 컨텍스트만)
- ✅ ② DB / ③ Sentry sink = false 정직 표기(테이블 미적용·DSN 미설정)
- ✅ visitorId 실제 익명 UUID 생성·전달, device/os 대분류
- ✅ production 게이트 로직 검증(VERCEL_ENV=production → 404)
- ✅ 기존 무변경·prod 노출 0, `tsc`=0/`eslint`=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)