### PR TITLE
feat(logging): 핵심 API catch 3곳에 logError 3-sink 연결 (PR 3)

### DIFF
--- a/onday-app/src/app/api/diagnosis/[id]/route.ts
+++ b/onday-app/src/app/api/diagnosis/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import type { CandidateArea, DiagnosisFilters } from "@/lib/types";
+import { getServerUser } from "@/lib/auth/session";
+import { logError, type LogUserType } from "@/lib/logging/log-error";
 
 // GET /api/diagnosis/[id] — Fetch diagnosis result (API-02)
 export async function GET(
@@ -34,6 +36,25 @@ export async function GET(
     });
   } catch (error) {
     console.error("[API] GET /api/diagnosis/[id] error:", error);
+    // ★ 3-sink 로깅 추가(기존 유지). 서버 컨텍스트만 — visitorId/device/os=null(클라 정보).
+    let userType: LogUserType | null = null;
+    try {
+      userType = (await getServerUser()) ? "kakao" : null;
+    } catch {
+      // best-effort
+    }
+    await logError({
+      level: "error",
+      message: error instanceof Error ? error.message : String(error),
+      statusCode: 500,
+      route: "GET /api/diagnosis/[id]",
+      errorType: "api_error",
+      userType,
+      visitorId: null,
+      device: null,
+      os: null,
+      originalError: error,
+    });
     return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });
   }
 }

--- a/onday-app/src/app/api/diagnosis/route.ts
+++ b/onday-app/src/app/api/diagnosis/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { diagnosisInputSchema } from "@/lib/validators/diagnosis";
 import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
 import { prisma } from "@/lib/db";
-import { getEffectiveUserId } from "@/lib/auth/session";
+import { getEffectiveUserId, getServerUser } from "@/lib/auth/session";
+import { logError, type LogUserType } from "@/lib/logging/log-error";
 
 const IS_MOCK = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 
@@ -92,6 +93,27 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("[API] POST /api/diagnosis error:", error);
+    // ★ 3-sink 로깅 추가(기존 console.error·응답 유지). 서버가 아는 컨텍스트만 —
+    //   userType=kakao/null(게스트·심사관 구분 불가), visitorId/device/os=null(클라 정보).
+    //   logError 는 best-effort(내부 try/catch) — 실패해도 아래 응답에 영향 0.
+    let userType: LogUserType | null = null;
+    try {
+      userType = (await getServerUser()) ? "kakao" : null;
+    } catch {
+      // best-effort
+    }
+    await logError({
+      level: "error",
+      message: error instanceof Error ? error.message : String(error),
+      statusCode: 500,
+      route: "POST /api/diagnosis",
+      errorType: "api_error",
+      userType,
+      visitorId: null,
+      device: null,
+      os: null,
+      originalError: error,
+    });
     return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });
   }
 }

--- a/onday-app/src/app/api/share/route.ts
+++ b/onday-app/src/app/api/share/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { shareLinkInputSchema } from "@/lib/validators/diagnosis";
 import { prisma } from "@/lib/db";
 import { randomUUID } from "crypto";
+import { getServerUser } from "@/lib/auth/session";
+import { logError, type LogUserType } from "@/lib/logging/log-error";
 
 // DUMMY_HASH for timing attack prevention (SRS architecture pattern)
 // Production: const DUMMY_HASH = "$2b$12$..."; bcrypt.compare() to prevent password existence inference
@@ -55,6 +57,25 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("[API] POST /api/share error:", error);
+    // ★ 3-sink 로깅 추가(기존 유지). 서버 컨텍스트만 — visitorId/device/os=null(클라 정보).
+    let userType: LogUserType | null = null;
+    try {
+      userType = (await getServerUser()) ? "kakao" : null;
+    } catch {
+      // best-effort
+    }
+    await logError({
+      level: "error",
+      message: error instanceof Error ? error.message : String(error),
+      statusCode: 500,
+      route: "POST /api/share",
+      errorType: "api_error",
+      userType,
+      visitorId: null,
+      device: null,
+      os: null,
+      originalError: error,
+    });
     return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## 무엇을 / 왜
11주차 화요일 로깅 PR 3. **실제 사용자 에러가 자동으로 콘솔+DB(`error_logs`)+Sentry 3-sink에 기록**되도록, 핵심 API 라우트의 기존 `catch` 블록에 `logError()`를 연결한다. PR1(테이블·유틸)·PR2(점검 페이지)에서 만든 인프라를 실 흐름에 처음 꽂는 단계.

## 적용 범위 (3곳)
| 라우트 | catch | route 라벨 |
|---|---|---|
| `POST /api/diagnosis` | :94 | `POST /api/diagnosis` |
| `POST /api/share` | :58 | `POST /api/share` |
| `GET /api/diagnosis/[id]` | :37 | `GET /api/diagnosis/[id]` |

**제외**: `summary`(이미 `reportErrorToSentry` 호출 — 중복 방지)·`save`·`insight`.

## 기존 동작 무변경 (추가만)
- `console.error(...)` 그대로 유지
- 응답 바디·`status: 500` 그대로 유지
- 그 사이에 `await logError({...})`만 삽입

## 서버가 아는 컨텍스트만 정직 기록 ("되는 척 금지")
- `userType` = `getServerUser()` → `kakao` / `null`
  - 게스트·심사관은 **클라이언트 플래그**라 서버에서 구분 불가 → `null`로 정직 표기
- `visitorId` / `device` / `os` = `null`
  - 클라이언트 정보 — 서버는 모름. (PR4 후보: 클라 에러 바운더리에서 채움)
- `await logError`는 **best-effort**(내부 sink별 try/catch) — 실패해도 응답 영향 0

## 검증
- ✅ 성공 POST → **200 무회귀** (`diagnosisId`·`candidates` 정상 반환)
- ✅ `error_logs` 성공/404 시 **0 유지** (404는 catch 밖이라 미로깅 — 정상)
- ✅ 검증용 테스트 진단 행 정리 (`diagnoses` 352 유지, `users`/`share_links` 보존)
- ✅ `tsc --noEmit` 0 / `next lint` 0 (기존 warning 외 신규 0)

## 변경 파일
- `onday-app/src/app/api/diagnosis/route.ts`
- `onday-app/src/app/api/diagnosis/[id]/route.ts`
- `onday-app/src/app/api/share/route.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)