### PR TITLE
feat(logging): 나머지 API catch에 logError 확장 — save·insight·summary (PR 3b)

### DIFF
--- a/onday-app/src/app/api/insight/route.ts
+++ b/onday-app/src/app/api/insight/route.ts
@@ -8,6 +8,8 @@ import {
   sanitizeStory,
   storySchema,
 } from "@/lib/insight/story";
+import { getServerUser } from "@/lib/auth/session";
+import { logError, type LogUserType } from "@/lib/logging/log-error";
 
 // 동네 하루 미리보기 — Gemini 시간대별 스토리 (SRS CON-13/14: Vercel AI SDK + Gemini, env 모델 교체).
 // ★ Phase 3 = DayPreviewData(Phase 2 extractDayData 출력) 주입 → 구조화 JSON 스토리. UI 는 Phase 4.
@@ -77,6 +79,26 @@ export async function POST(request: Request) {
   } catch (error) {
     // Gemini 실패/타임아웃/쿼터/스키마 불일치 → graceful 502 (크래시 X).
     console.error("[API] POST /api/insight error:", error);
+    // ★ 3-sink 로깅 추가(기존 502 응답 유지). statusCode=502(실제 응답값 그대로).
+    //   서버 컨텍스트만 — visitorId/device/os=null(클라 정보).
+    let userType: LogUserType | null = null;
+    try {
+      userType = (await getServerUser()) ? "kakao" : null;
+    } catch {
+      // best-effort
+    }
+    await logError({
+      level: "error",
+      message: error instanceof Error ? error.message : String(error),
+      statusCode: 502,
+      route: "POST /api/insight",
+      errorType: "ai_error",
+      userType,
+      visitorId: null,
+      device: null,
+      os: null,
+      originalError: error,
+    });
     return NextResponse.json(
       { error: "인사이트 생성에 실패했습니다" },
       { status: 502 },

--- a/onday-app/src/app/api/save/route.ts
+++ b/onday-app/src/app/api/save/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { getEffectiveUserId } from "@/lib/auth/session";
+import { getEffectiveUserId, getServerUser } from "@/lib/auth/session";
+import { logError, type LogUserType } from "@/lib/logging/log-error";
 import { z } from "zod";
 
 const saveSearchSchema = z.object({
@@ -38,6 +39,25 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("[API] POST /api/save error:", error);
+    // ★ 3-sink 로깅 추가(기존 유지). 서버 컨텍스트만 — visitorId/device/os=null(클라 정보).
+    let userType: LogUserType | null = null;
+    try {
+      userType = (await getServerUser()) ? "kakao" : null;
+    } catch {
+      // best-effort
+    }
+    await logError({
+      level: "error",
+      message: error instanceof Error ? error.message : String(error),
+      statusCode: 500,
+      route: "POST /api/save",
+      errorType: "api_error",
+      userType,
+      visitorId: null,
+      device: null,
+      os: null,
+      originalError: error,
+    });
     return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });
   }
 }
@@ -62,6 +82,25 @@ export async function GET() {
     });
   } catch (error) {
     console.error("[API] GET /api/save error:", error);
+    // ★ 3-sink 로깅 추가(기존 유지). 서버 컨텍스트만 — visitorId/device/os=null(클라 정보).
+    let userType: LogUserType | null = null;
+    try {
+      userType = (await getServerUser()) ? "kakao" : null;
+    } catch {
+      // best-effort
+    }
+    await logError({
+      level: "error",
+      message: error instanceof Error ? error.message : String(error),
+      statusCode: 500,
+      route: "GET /api/save",
+      errorType: "api_error",
+      userType,
+      visitorId: null,
+      device: null,
+      os: null,
+      originalError: error,
+    });
     return NextResponse.json({ error: "서버 오류가 발생했습니다" }, { status: 500 });
   }
 }

--- a/onday-app/src/app/api/summary/route.ts
+++ b/onday-app/src/app/api/summary/route.ts
@@ -8,9 +8,8 @@ import {
   rationaleSchema,
   sanitizeRationale,
 } from "@/lib/summary/rationale";
-import { createAppError } from "@/lib/helpers/app-error";
-import { reportErrorToSentry } from "@/lib/helpers/sentry-error";
-import { CommonErrorCode } from "@/lib/types/errors";
+import { getServerUser } from "@/lib/auth/session";
+import { logError, type LogUserType } from "@/lib/logging/log-error";
 
 // 30분 요약 — Gemini "이 동네 추천 이유" 한 줄 (UI-011/QRY-DL-002 Phase 1).
 //   /api/insight(하루 미리보기) 패턴 복제 — createGoogleGenerativeAI + generateObject + thinkingBudget=0.
@@ -81,10 +80,28 @@ export async function POST(request: Request) {
     const rationale = sanitizeRationale(object.rationale, facts);
     return NextResponse.json({ rationale, source: "ai" });
   } catch (error) {
-    // Gemini 실패/타임아웃/쿼터/스키마 불일치/미화 차단 → Sentry 기록 후 룰 fallback (빈 카드 0).
-    reportErrorToSentry(
-      createAppError(CommonErrorCode.INTERNAL_SERVER_ERROR, error),
-    );
+    // Gemini 실패/타임아웃/쿼터/스키마 불일치/미화 차단 → 룰 fallback (빈 카드 0).
+    // ★ 기존 reportErrorToSentry 를 logError 로 교체 — logError 가 콘솔+DB+Sentry 상위집합이라
+    //   Sentry 보고는 logError 내부 reportErrorToSentry 로 그대로 유지(중복 X, 단일화).
+    //   ★ statusCode=200 — 에러지만 사용자엔 fallback 200 응답(실제 응답값). errorType 으로 구분.
+    let userType: LogUserType | null = null;
+    try {
+      userType = (await getServerUser()) ? "kakao" : null;
+    } catch {
+      // best-effort
+    }
+    await logError({
+      level: "error",
+      message: error instanceof Error ? error.message : String(error),
+      statusCode: 200,
+      route: "POST /api/summary",
+      errorType: "ai_fallback",
+      userType,
+      visitorId: null,
+      device: null,
+      os: null,
+      originalError: error,
+    });
     return NextResponse.json({
       rationale: generateFallbackRationale(facts),
       source: "fallback",


### PR DESCRIPTION
## 무엇을 / 왜
11주차 화요일 로깅 PR 3b. PR 3a(핵심 3개 `diagnosis`/`share`/`diagnosis/[id]`, #238 머지)에 이어 **나머지 API 라우트의 catch에 `logError()` 3-sink를 확장**한다. 각 라우트의 응답 의미를 `statusCode`에 정직하게 반영하는 것이 핵심.

## 적용 범위 (3 파일 / 4 catch)
| 라우트 | catch | statusCode | errorType | 비고 |
|---|---|---|---|---|
| `POST /api/save` | :39 | 500 | `api_error` | 3a DB 패턴 동일 |
| `GET /api/save` | :63 | 500 | `api_error` | 3a DB 패턴 동일 |
| `POST /api/insight` | :77 | **502** | `ai_error` | ★ 실제 응답값 502 그대로 |
| `POST /api/summary` | :83 | **200** | `ai_fallback` | ★ 에러지만 사용자엔 fallback 200 |

## 각 라우트 특이점
- **insight** — Gemini 실패 시 graceful **502**. 로그 `statusCode=502`로 실제 응답값 그대로 기록.
- **summary** — Gemini 실패 시 **200 fallback**(빈 카드 방지). 에러지만 사용자에겐 200이라 `statusCode=200` + `errorType="ai_fallback"`로 구분.
  - ★ **기존 `reportErrorToSentry` → `logError` 교체**. `logError`가 콘솔+DB+Sentry **상위집합**이라 Sentry 보고는 내부 `reportErrorToSentry`로 **그대로 유지**(중복 없이 단일화). 안 쓰게 된 `createAppError`/`CommonErrorCode` import 정리.

## 안전 원칙 (3a 동일)
- `save`·`insight` — 기존 `console.error`·응답 바디·`status` **무변경**(추가만).
- `summary` — Sentry 보고 **동작 보존**하며 교체(응답 바디·`source` 무변경).
- `await logError`는 **best-effort**(내부 sink별 try/catch) — 실패해도 응답 영향 0.
- 서버가 아는 컨텍스트만: `userType`=`getServerUser()`→`kakao`/`null`, `visitorId`/`device`/`os`=`null`(클라 정보 — 되는 척 금지).

## 검증 (가짜 AI 키로 catch 강제 진입)
- ✅ `insight` POST → **502** 응답 무변경 (`{error:"인사이트 생성에 실패했습니다"}`)
- ✅ `summary` POST → **200 / source=fallback / rationale 존재** 응답 무변경
- ✅ `error_logs` 2행 정확 기록:
  - `POST /api/insight` · statusCode **502** · errorType `ai_error` · level error · 컨텍스트 null
  - `POST /api/summary` · statusCode **200** · errorType `ai_fallback` · level error · 컨텍스트 null
- ✅ **PII 0** (message=Gemini 원문 "API key not valid…", 이메일·전화 없음)
- ✅ 테스트 행 정리 (`error_logs` 0 복귀, `diagnoses` 352 / `users` 2 / `share_links` 9 / `saved_searches` 0 보존)
- ✅ `tsc --noEmit` 0 / `next lint` 0

> 참고: `save`는 DB 500 강제가 비현실적이라 런타임 미실측이나, 코드가 #238에서 검증·머지된 `diagnosis`/`share` catch와 **동일 패턴**(statusCode 500, api_error). Sentry는 로컬 DSN 미설정이라 no-op(전송 미실측) — 단 `logError` 내부 `reportErrorToSentry` 경로는 summary 기존 코드와 동일.

## 변경 파일
- `onday-app/src/app/api/save/route.ts`
- `onday-app/src/app/api/insight/route.ts`
- `onday-app/src/app/api/summary/route.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)