### PR TITLE
feat(analytics): 상단 퍼널 5개 Mixpanel 이벤트 배선 (G2 해소)

### DIFF
--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -20,7 +20,12 @@ import { liftLegacyDealType } from "@/features/diagnosis/result-utils";
 import { useAddressSuggest } from "@/features/diagnosis/use-address-suggest";
 // ★ Mismatch ⑬ 정정: isWithinSeoulMetropolitan → isWithinMetroBounds (★ CMD-DIAG-001 산출물 정합, α₁ page.tsx 책임).
 import { isWithinMetroBounds } from "@/lib/diagnosis";
-import { trackDiagnosisStarted } from "@/lib/analytics/mixpanel";
+import {
+  trackDiagnosisStarted,
+  trackDiagnosisInputViewed,
+  trackAddressVerified,
+  trackDiagnosisSubmitClicked,
+} from "@/lib/analytics/mixpanel";
 import { LAST_CONFIG_KEY, useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useSessionStore } from "@/stores/session";
 import { useUIStore } from "@/stores/ui";
@@ -92,6 +97,14 @@ export default function DiagnosisPage() {
   const [queryL2, setQueryL2] = React.useState(leisureB);
   // 여가거점2 점진 공개 — 처음엔 L1만, "+ 추가"로 L2 노출. 이미 값 있으면(불러오기) 자동 노출.
   const [showL2, setShowL2] = React.useState(() => Boolean(leisureB));
+
+  // ★ 상단 퍼널 — 진단 입력 진입 1회. trackedRef = Strict Mode 2회·재마운트 중복 방지(result-view 선례).
+  const inputViewedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (inputViewedRef.current) return;
+    inputViewedRef.current = true;
+    trackDiagnosisInputViewed(mode);
+  }, [mode]);
 
   // Issue #112 — maxCommuteTime + budget 입력 영역 (★ 단방향 input → store 동기화, "이전 조건 불러오기" 시점 별도 sync).
   //   budget은 억 단위 input + 내부 만원 변환 (★ formatBudgetFilter "X-Y억" 표시 정합).
@@ -178,6 +191,8 @@ export default function DiagnosisPage() {
 
   const handleSubmit = async () => {
     if (!canSubmit || !coordinateA) return;
+    // ★ 상단 퍼널 — 가드 뒤 = "유효한 제출 시도"(성공률 분모). 아래 diagnosis_started(성공 後)와 쌍.
+    trackDiagnosisSubmitClicked(mode);
     setLoading(true);
     try {
       const data = await createDiagnosis.mutateAsync({
@@ -340,6 +355,8 @@ export default function DiagnosisPage() {
               }
               setAddressA(item.title, item.coordinate);
               setQueryA(item.title);
+              // ★ 상단 퍼널 — count(1=A)만. 주소 title·coordinate·역 이름 절대 미포함(재식별 차단).
+              trackAddressVerified(1);
             }}
           />
           {isCouple && (
@@ -359,6 +376,8 @@ export default function DiagnosisPage() {
                 }
                 setAddressB(item.title, item.coordinate);
                 setQueryB(item.title);
+                // ★ 상단 퍼널 — count(2=B)만. 주소 title·coordinate·역 이름 절대 미포함(재식별 차단).
+                trackAddressVerified(2);
               }}
             />
           )}

--- a/onday-app/src/app/landing/landing-client.tsx
+++ b/onday-app/src/app/landing/landing-client.tsx
@@ -11,6 +11,7 @@ import {
 import { Logo } from "@/components/layout/logo";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { trackLandingViewed } from "@/lib/analytics/mixpanel";
 import { motion, MotionConfig, useScroll, useTransform, useReducedMotion, useMotionValue, animate } from "framer-motion";
 import CountUp from "react-countup";
 
@@ -799,6 +800,14 @@ function HeaderNav() {
 
 /* ── Main ── */
 export function LandingClient() {
+  // ★ 상단 퍼널 시작점 — 랜딩 진입 1회. trackedRef = Strict Mode 2회·재마운트 중복 방지(result-view 선례).
+  const trackedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (trackedRef.current) return;
+    trackedRef.current = true;
+    trackLandingViewed();
+  }, []);
+
   return (
     <MotionConfig reducedMotion="user">
     <div className="relative min-h-screen bg-bg">

--- a/onday-app/src/components/auth/login-form.tsx
+++ b/onday-app/src/components/auth/login-form.tsx
@@ -13,6 +13,7 @@ import { useSessionStore } from "@/stores/session";
 import { clearGuestPersisted } from "@/lib/auth/clear-guest-persisted";
 import { useUIStore } from "@/stores/ui";
 import { cn } from "@/lib/utils";
+import { trackLoginEntered } from "@/lib/analytics/mixpanel";
 
 // 패턴 A — controlled props 유지
 //   OAuthButton / Button은 props만 받고, store 연결은 본 LoginForm에서만
@@ -36,6 +37,8 @@ export function LoginForm() {
 
   const handleKakao = async () => {
     setInFlight("kakao");
+    // ★ 상단 퍼널 — 카카오 redirect(아래 signInWithOAuth) 前 발화해야 유실 안 됨.
+    trackLoginEntered("kakao");
     try {
       if (IS_MOCK_AUTH) {
         await new Promise((resolve) => setTimeout(resolve, MOCK_LATENCY_MS));
@@ -75,6 +78,7 @@ export function LoginForm() {
 
   const handleGuest = () => {
     setInFlight("guest");
+    trackLoginEntered("guest");
     enterGuestMode();
     // 게스트는 회원 정보 미저장 — 이전 로그인 사용자가 남긴 좌표·이전조건·찜 제거(물려받기 방지).
     clearGuestPersisted();
@@ -84,6 +88,7 @@ export function LoginForm() {
   // ★ #24 심사관(채용 담당자) 데모 모드 — 로그인 없이 풀 기능(저장/공유 차단 면제).
   //   세션 내(in-memory + favorites localStorage) 동작, 회원 정보에는 귀속되지 않음.
   const handleReviewer = () => {
+    trackLoginEntered("reviewer");
     enterReviewerMode();
     // 심사관도 회원 정보 미저장 — 이전 로그인 사용자가 남긴 좌표·이전조건·찜 제거.
     clearGuestPersisted();

--- a/onday-app/src/lib/analytics/mixpanel.ts
+++ b/onday-app/src/lib/analytics/mixpanel.ts
@@ -43,3 +43,35 @@ export function trackDiagnosisCompleted(diagnosisId: string): void {
     timestamp: Date.now(),
   });
 }
+
+// ── 상단 퍼널 5종 (11주차 수요 — AARRR_NSM_PROPOSAL.md G2 해소: 진단 제출 前 이탈 가시화) ──
+//   ★ 기존 패턴 동일: ensureInit(token no-op·ip:false) + 비식별 속성만.
+//   ★ PII 0 — 주소·좌표·역 이름·이메일 절대 미포함. 유형/카운트/모드 같은 카테고리만.
+
+export function trackLandingViewed(): void {
+  if (!ensureInit()) return;
+  mixpanel.track("landing_viewed", { timestamp: Date.now() });
+}
+
+export function trackLoginEntered(method: "kakao" | "guest" | "reviewer"): void {
+  if (!ensureInit()) return;
+  mixpanel.track("login_entered", { method, timestamp: Date.now() });
+}
+
+export function trackDiagnosisInputViewed(mode: "couple" | "single"): void {
+  if (!ensureInit()) return;
+  mixpanel.track("diagnosis_input_viewed", { mode, timestamp: Date.now() });
+}
+
+// ★ count = 확정된 주소 순번(1=A, 2=B). 주소 title·coordinate·역 이름은 절대 담지 않는다(재식별 차단).
+export function trackAddressVerified(count: 1 | 2): void {
+  if (!ensureInit()) return;
+  mixpanel.track("address_verified", { count, timestamp: Date.now() });
+}
+
+// ★ mode 만 — /diagnosis 입력 화면엔 deadline 입력이 없다(deadline 은 별도 /deadline 라우트).
+//   설계의 has_deadline 은 deadline 발 제출 지점이 생기면 그때 추가(없는 값 만들지 않음).
+export function trackDiagnosisSubmitClicked(mode: "couple" | "single"): void {
+  if (!ensureInit()) return;
+  mixpanel.track("diagnosis_submit_clicked", { mode, timestamp: Date.now() });
+}


### PR DESCRIPTION
## 무엇을 / 왜
`AARRR_NSM_PROPOSAL.md`(#240)가 설계한 **상단 퍼널 5개 이벤트**를 Mixpanel에 배선한다. 현재 추적은 `diagnosis_started`·`diagnosis_completed` 2개뿐(제출 *이후*)이라 그 앞 단계가 깜깜이(**G2**) → 진단 제출 前 이탈 드롭오프를 가시화한다.

## 배선 5개 (file:line)
| 이벤트 | 지점 | 속성 | 가드 |
|--------|------|------|------|
| `landing_viewed` | `landing-client.tsx` LandingClient useEffect | `timestamp` | trackedRef(마운트) |
| `login_entered` | `login-form.tsx` handleKakao(redirect 前)·handleGuest·handleReviewer | `method`(kakao/guest/reviewer) | — |
| `diagnosis_input_viewed` | `diagnosis/page.tsx` 마운트 useEffect | `mode`(couple/single) | trackedRef(마운트) |
| `address_verified` | `page.tsx` 주소 A onSelect(count=1)·B onSelect(count=2) | **`count`(1/2)만** | — |
| `diagnosis_submit_clicked` | `page.tsx` handleSubmit `canSubmit` 가드 後 | `mode` | — |

## ★ PII 0 (재확인)
- 7개 `mixpanel.track` 전부 속성 = `timestamp`/`method`/`mode`/`count`만. **주소·좌표·역 이름·이메일·lat/lng 0**.
- `address_verified`는 **count(1/2)만** — 주소 `title`·`coordinate` 절대 미포함(재식별 차단).
- 기존 패턴 그대로: `ensureInit()` token 미설정 시 no-op, `ip:false` 익명화.

## ★ 기존 동작 무변경 (추가만)
- 기존 track 2개(`diagnosis_started`·`diagnosis_completed`) **무변경**(diff에 `-`줄 0).
- 마운트 2개(`landing`·`input`)는 `trackedRef` 가드로 Strict Mode 2회·재마운트 중복 방지(result-view 선례).
- `diagnosis_submit_clicked`는 `canSubmit` 가드 *뒤* = "유효한 제출 시도" → 기존 `diagnosis_started`(성공 後)와 **쌍**으로 제출 성공률(분자/분모) 계산.

## 정직성 노트
- **`has_deadline` 속성 미포함** — `/diagnosis` 입력 화면엔 deadline 입력이 없다(`DiagnosisFilters`에 필드 없음, deadline은 별도 `/deadline` 라우트). 설계의 `has_deadline`은 deadline 발 제출 지점이 생기면 추가 — **없는 값을 만들지 않음**.

## 검증
- ✅ `tsc --noEmit` 0 / `next lint` 0(신규 — 기존 unused import warning 외)
- ✅ `/landing`·`/login`·`/diagnosis` 200 무회귀, 런타임 에러 0(새 useEffect 무해)
- ✅ token 미설정 시 전부 no-op(런타임 안전)

## 변경 파일 (4, +66/-1)
- `onday-app/src/lib/analytics/mixpanel.ts` (5 함수 추가)
- `onday-app/src/app/landing/landing-client.tsx`
- `onday-app/src/components/auth/login-form.tsx`
- `onday-app/src/app/diagnosis/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)