### PR TITLE
feat(analytics): Referral·Retention 4개 이벤트 배선 (보완 10개 완료)

### DIFF
--- a/onday-app/src/app/deadline/page.tsx
+++ b/onday-app/src/app/deadline/page.tsx
@@ -22,6 +22,7 @@ import {
   formatTargetDate,
 } from "@/features/deadline/timeline-builder";
 import { markerLabel } from "@/features/diagnosis/result-utils";
+import { trackDeadlineModeActivated } from "@/lib/analytics/mixpanel";
 import { latLngToPixel } from "@/lib/coordinate-transform";
 import {
   buildNaverMobileMapUrl,
@@ -145,6 +146,8 @@ export default function DeadlinePage() {
     const target = new Date(`${draft}T00:00:00`);
     setDeadlineDate(target.toISOString());
     setInlineError(null);
+    // ★ Retention 퍼널 — 데드라인 저장(활성화) 성공. days_left(숫자)만(ISO 날짜 미포함, PII 0).
+    trackDeadlineModeActivated(daysFromNow(target.toISOString()));
     pushToast({ variant: "ok", message: "데드라인을 저장했어요" });
   };
 

--- a/onday-app/src/app/diagnosis/page.tsx
+++ b/onday-app/src/app/diagnosis/page.tsx
@@ -25,6 +25,7 @@ import {
   trackDiagnosisInputViewed,
   trackAddressVerified,
   trackDiagnosisSubmitClicked,
+  trackSavedSearchLoaded,
 } from "@/lib/analytics/mixpanel";
 import { LAST_CONFIG_KEY, useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useSessionStore } from "@/stores/session";
@@ -288,6 +289,8 @@ export default function DiagnosisPage() {
       );
       setMonthlyMaxInput(nextIsWolse && nextBudget ? String(nextBudget.max) : "");
       setDealType(nextDealType);
+      // ★ Retention 퍼널 — 불러오기 성공. mode 만(불러온 config 의 주소는 미포함, PII 0).
+      trackSavedSearchLoaded(config.mode === "single" ? "single" : "couple");
       pushToast({ variant: "default", message: "이전 조건을 불러왔습니다 ✨" });
     } catch {
       pushToast({ variant: "default", message: "이전 조건 불러오기 실패" });

--- a/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
@@ -22,7 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { runMockDiagnosis } from "@/features/diagnosis/mock-calculator";
 import { liftLegacyDealType } from "@/features/diagnosis/result-utils";
 import { useDiagnosis } from "@/features/diagnosis/use-diagnosis";
-import { trackDiagnosisCompleted } from "@/lib/analytics/mixpanel";
+import { trackDiagnosisCompleted, trackShareLinkCreated } from "@/lib/analytics/mixpanel";
 import { generateRelaxationSuggestions } from "@/lib/diagnosis/generate-suggestions";
 import type { DiagnosisFilters } from "@/lib/types";
 import { copyToClipboard } from "@/lib/utils/clipboard";
@@ -131,6 +131,8 @@ export function ResultView({ id }: ResultViewProps) {
         throw new Error(err.error ?? "공유 링크 생성에 실패했습니다");
       }
       const data: { shareUrl: string } = await res.json();
+      // ★ Referral 퍼널 — 생성 성공. diagnosis_id·mode 만(공유 토큰 shareUrl 미포함, PII 0).
+      trackShareLinkCreated(id, mode);
       const absolute = `${window.location.origin}${data.shareUrl}`;
       await copyToClipboard(absolute);
       pushToast({

--- a/onday-app/src/app/share/[uuid]/share-report-view.tsx
+++ b/onday-app/src/app/share/[uuid]/share-report-view.tsx
@@ -9,6 +9,7 @@ import { ReportCard } from "@/components/share/report-card";
 import { ShareHero } from "@/components/share/share-hero";
 import { Button } from "@/components/ui/button";
 import { buildReportStats } from "@/features/share/preview-stats";
+import { trackShareLinkClicked } from "@/lib/analytics/mixpanel";
 import type { CandidateArea } from "@/lib/types";
 
 // ★ W2: production = 대중교통 ODsay + 자차 카카오 모빌리티(둘 다 브라우저 직접) / mock = Haversine 추정.
@@ -59,6 +60,15 @@ function expiryChipText(expiresAt: string): string {
 export function ShareReportView({ data }: ShareReportViewProps) {
   const { preview, locked, total } = data;
   const lockedCount = locked.length;
+
+  // ★ Referral 퍼널 — 수신자 진입 1회(클라뷰). trackedRef = Strict Mode 2회·재마운트 중복 방지(landing 선례).
+  //   ★★ mode 만 — uniqueUrl·addressA/B 절대 미포함(share data 에 섞여있음, 재식별 차단).
+  const clickedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (clickedRef.current) return;
+    clickedRef.current = true;
+    trackShareLinkClicked(data.mode);
+  }, [data.mode]);
 
   return (
     <main className="flex min-h-screen flex-col bg-bg pb-[120px]">

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -65,6 +65,7 @@ import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import { useFavoritesStore, toFavoriteSnapshot } from "@/stores/favorites";
 import { useUIStore } from "@/stores/ui";
 import { useGuestGate } from "@/features/auth/use-guest-gate";
+import { trackShareLinkCreated } from "@/lib/analytics/mixpanel";
 
 import { LayerToggle, type SingleLayer } from "./layer-toggle";
 
@@ -549,6 +550,8 @@ export function SingleResultView({ id }: SingleResultViewProps) {
         throw new Error(err.error ?? "공유 링크 생성에 실패했습니다");
       }
       const data: { shareUrl: string } = await res.json();
+      // ★ Referral 퍼널 — 생성 성공. 싱글뷰라 mode="single" 리터럴(공유 토큰 미포함, PII 0).
+      trackShareLinkCreated(id, "single");
       await copyToClipboard(`${window.location.origin}${data.shareUrl}`);
       pushToast({ variant: "ok", message: "공유 링크가 복사되었습니다" });
     } catch (err) {

--- a/onday-app/src/lib/analytics/mixpanel.ts
+++ b/onday-app/src/lib/analytics/mixpanel.ts
@@ -75,3 +75,31 @@ export function trackDiagnosisSubmitClicked(mode: "couple" | "single"): void {
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_submit_clicked", { mode, timestamp: Date.now() });
 }
+
+// ── Referral·Retention 4종 (11주차 수요 — AARRR_NSM_PROPOSAL.md 보완 10개의 나머지) ──
+//   ★ 기존 패턴 동일 + PII 0. ★★ 공유 토큰(shareUrl/uniqueUrl)·주소(addressA/B)·역 이름 절대 미포함.
+//   share_link_signup 은 제외 — share→login CTA 에 attribution 연결이 없어 측정 불가(억지 창작 금지, 후속 과제).
+
+// ★ diagnosis_id = 내부 uuid(기존 diagnosis_started 패턴). 공유 토큰(uniqueUrl)은 담지 않는다.
+export function trackShareLinkCreated(diagnosisId: string, mode: "couple" | "single"): void {
+  if (!ensureInit()) return;
+  mixpanel.track("share_link_created", { diagnosis_id: diagnosisId, mode, timestamp: Date.now() });
+}
+
+// ★ mode 만 — share 페이지 data 의 uniqueUrl·addressA/B 는 절대 담지 않는다(재식별 차단).
+export function trackShareLinkClicked(mode: "couple" | "single"): void {
+  if (!ensureInit()) return;
+  mixpanel.track("share_link_clicked", { mode, timestamp: Date.now() });
+}
+
+// ★ mode 만 — 불러온 config 의 주소는 절대 담지 않는다.
+export function trackSavedSearchLoaded(mode: "couple" | "single"): void {
+  if (!ensureInit()) return;
+  mixpanel.track("saved_search_loaded", { mode, timestamp: Date.now() });
+}
+
+// ★ days_left(숫자)만 — ISO 날짜 대신 D-day 로 환원(식별성 0).
+export function trackDeadlineModeActivated(daysLeft: number): void {
+  if (!ensureInit()) return;
+  mixpanel.track("deadline_mode_activated", { days_left: daysLeft, timestamp: Date.now() });
+}


### PR DESCRIPTION
## 무엇을 / 왜
`AARRR_NSM_PROPOSAL.md` "보완 10개" 중 **남은 5개에서 4개를 배선**한다(#241 상단 퍼널 5개에 이어). Referral·Retention 단계를 가시화해 부부 합의(공유)·재방문 가치를 측정한다. 기존 track 7개 무변경 — 추가만.

## 배선 4개 (file:line)
| 이벤트 | 지점 | 속성 | 가드 |
|--------|------|------|------|
| `share_link_created` | `result-view.tsx` handleShare(부부)·`single-result-view.tsx` handleShare(싱글) — `/api/share` 성공 後 | `diagnosis_id`·`mode` | — |
| `share_link_clicked` | `share-report-view.tsx` 마운트 useEffect(클라뷰) | `mode` | trackedRef |
| `saved_search_loaded` | `diagnosis/page.tsx` handleLoadLast 성공 분기 | `mode` | — |
| `deadline_mode_activated` | `deadline/page.tsx` handleSave 後(저장 성공) | `days_left`(숫자) | — |

## ★★ PII 0 (재확인)
- 11개 `mixpanel.track` 전부 속성 = `timestamp`/`method`/`mode`/`count`/`diagnosis_id`/`days_left`만.
- ★★ **공유 토큰(`shareUrl`/`uniqueUrl`)·주소(`addressA/B`)·역 이름 절대 미포함** — share 페이지 data·불러오기 config에 섞여있어 속성 선별. 호출부도 `id`/`mode`/`days_left`만 전달(grep 확인).
- `share_link_created`는 `diagnosis_id`(내부 uuid, 기존 패턴)만 — 공유 토큰 `uniqueUrl`은 안 담음.
- `deadline_mode_activated`는 ISO 날짜 대신 `days_left`(D-day 숫자)로 환원.

## ★ share_link_signup — 제외(갭, 정직 표기)
- **배선 안 함.** 공유 수신 CTA(`share-report-view.tsx` `<Link href="/login">`)에 attribution이 없어 share→login→가입을 잇는 연결고리가 없다 → 측정 불가.
- 억지 창작 금지. **attribution 플러밍(예: share 진입 시 플래그 저장 → 로그인 시 읽기) 선행이 필요한 후속 과제.**

## ★ 기존 동작 무변경 (추가만)
- 기존 track 7개(`diagnosis_started`·`diagnosis_completed` + 상단 퍼널 5) **무변경**(diff 삭제 라인 0, import 교체 1줄 제외).
- `share_link_clicked`만 마운트형이라 `trackedRef` 가드(Strict Mode 2회·재마운트 중복 방지, landing 선례). 나머지 3개는 핸들러형이라 가드 불필요.
- 게스트는 `handleShare`의 `guestGate("share")`로 차단 → `share_link_created`는 로그인·심사관만 발화(자연스러움).

## 검증
- ✅ `tsc --noEmit` 0 / `next lint` 0
- ✅ `/diagnosis`·`/deadline`·`/landing` 200 무회귀, 런타임 에러 0
- ✅ token 미설정 시 no-op

## 변경 파일 (6, +50/-1)
- `onday-app/src/lib/analytics/mixpanel.ts` (4 함수 추가)
- `result-view.tsx` · `single-result-view.tsx` · `share-report-view.tsx` · `diagnosis/page.tsx` · `deadline/page.tsx`

## 진행 현황 (보완 10개)
- ✅ 상단 퍼널 5 (#241) + ✅ Referral·Retention 4 (본 PR) = **9/10 배선 완료**
- ⚠️ `share_link_signup` 1개 = attribution 갭(후속 과제)

🤖 Generated with [Claude Code](https://claude.com/claude-code)