### PR TITLE
feat(sentry): instrumentation.ts 추가 — 서버 에러 Sentry 전송 진입점

### DIFF
--- a/onday-app/instrumentation.ts
+++ b/onday-app/instrumentation.ts
@@ -1,0 +1,17 @@
+// Sentry 서버/엣지 init 진입점 (Next 15 + @sentry/nextjs v10).
+// ★ Next 15는 server/edge Sentry.init 을 instrumentation.ts 의 register() 로 로드한다.
+//   이 파일이 없으면 sentry.server.config 가 안 불려 서버 에러(3-sink logError ③)가 미전송된다.
+// ★ DSN 미설정 시에도 안전: sentry.server/edge.config 가 DSN 유효 URL일 때만 init → no-op 유지.
+// ★ 기존 config 3종·reportErrorToSentry·log-error.ts 무변경 — 진입점만 추가(additive).
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+  }
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config");
+  }
+}
+
+// 서버 컴포넌트·라우트의 요청 처리 에러를 Sentry 로 캡처(Next 15 onRequestError 훅).
+export { captureRequestError as onRequestError } from "@sentry/nextjs";


### PR DESCRIPTION
## 무엇을 / 왜
화요일 3-sink 로깅의 **Sentry sink가 서버 에러를 실제 전송**하도록 진입점을 추가한다. `Next 15` + `@sentry/nextjs v10`은 server/edge `Sentry.init`을 **`instrumentation.ts`의 `register()`**로 로드하는데, 이 파일이 부재해 **서버 에러(API catch의 `logError` ③ sink)가 미전송**이었다(읽기 점검 결과).

## 변경 (새 파일 1개)
`onday-app/instrumentation.ts`:
```ts
export async function register() {
  if (process.env.NEXT_RUNTIME === "nodejs") await import("./sentry.server.config");
  if (process.env.NEXT_RUNTIME === "edge") await import("./sentry.edge.config");
}
export { captureRequestError as onRequestError } from "@sentry/nextjs";
```
- 경로 = `./sentry.server.config` — config 3종이 `onday-app/` 루트에 있어 동일 위치(확인함)
- `captureRequestError`는 v10에 존재(function) 확인

## ★ 기존 무변경 (additive)
- `sentry.client/server/edge.config.ts`·`reportErrorToSentry`·`log-error.ts` **전부 무변경**
- 진입점 1개만 추가

## ★ DSN 미설정 안전 (현 환경 회귀 0)
- config가 **DSN 유효 URL일 때만 `Sentry.init`** → DSN 없으면 `register()`가 import해도 init skip = **no-op 유지**
- 검증: DSN 없는 dev에서 `/`·`/diagnosis` 200 무회귀, "Invalid Sentry Dsn"·instrumentation 에러 0

## 검증
- ✅ `tsc --noEmit` 0 / `next lint` 0
- ✅ 새 파일 1개만, 기존 무변경
- ✅ DSN 없는 현 환경 no-op 안전(dev 200, 에러 0)

## 남은 것 (사용자 별도)
- 실제 전송하려면: **DSN 설정(`NEXT_PUBLIC_SENTRY_DSN`/`SENTRY_DSN`) + Redeploy** → `/playboard/logging-test` 500 버튼 → Sentry Issues 수신 확인. 이 PR은 **진입점만**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)