### PR TITLE
fix(sentry): namespace→default import — ESM captureException is not a function 해결

### DIFF
--- a/onday-app/src/app/api/sentry-test/route.ts
+++ b/onday-app/src/app/api/sentry-test/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import * as Sentry from "@sentry/nextjs";
+// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
+import Sentry from "@sentry/nextjs";
 
 // MON-001 v1.4 (Issue #73) — Sentry 캡처 검증용 라우트.
 // AC-3 "의도 에러 → Sentry Dashboard 캡처" 검증.

--- a/onday-app/src/components/auth/login-form.tsx
+++ b/onday-app/src/components/auth/login-form.tsx
@@ -2,7 +2,8 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import * as Sentry from "@sentry/nextjs";
+// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
+import Sentry from "@sentry/nextjs";
 
 import { Button } from "@/components/ui/button";
 import { OAuthButton } from "@/components/ui/oauth-button";

--- a/onday-app/src/lib/diagnosis/geocoding.ts
+++ b/onday-app/src/lib/diagnosis/geocoding.ts
@@ -10,7 +10,8 @@
 //   ★ CMD-DIAG-002~007 후행 ISSUE 시점 mapper.ts 분리 자연 도입 예상 (Wave 3 트랙 G 점진 진화 정신, ★ adaptive § Command 차원 첫 적용 정직 기록)
 // ──────────────────────────────────────────────
 
-import * as Sentry from "@sentry/nextjs";
+// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
+import Sentry from "@sentry/nextjs";
 import type { Coordinate } from "@/lib/types";
 import type { GeocodeResult, GeocodedAddress } from "./geocoding-types";
 

--- a/onday-app/src/lib/diagnosis/intersection.ts
+++ b/onday-app/src/lib/diagnosis/intersection.ts
@@ -8,7 +8,8 @@
 // ★ Coordinate ↔ KakaoCoord 변환은 toKakaoCoord 헬퍼로 transportClient 호출 직전만 (★ KakaoCoord ≠ Coordinate 분리 § 2번째 실전).
 // ──────────────────────────────────────────────
 
-import * as Sentry from "@sentry/nextjs";
+// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
+import Sentry from "@sentry/nextjs";
 import type { IKakaoTransportClient, KakaoCoord } from "@/lib/external/kakao-transport";
 import { mapKakaoResponseToCommuteInfo } from "@/lib/external/kakao-transport";
 import type { Coordinate, DiagnosisFilters, CommuteSchedule, DayOfWeek } from "@/lib/types";

--- a/onday-app/src/lib/diagnosis/use-intersection.ts
+++ b/onday-app/src/lib/diagnosis/use-intersection.ts
@@ -9,7 +9,8 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import * as Sentry from "@sentry/nextjs";
+// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
+import Sentry from "@sentry/nextjs";
 import type { IKakaoTransportClient } from "@/lib/external/kakao-transport";
 import type { Coordinate, DiagnosisFilters } from "@/lib/types";
 import { calculateIntersection, type IntersectionResult } from "./intersection";

--- a/onday-app/src/lib/helpers/sentry-error.ts
+++ b/onday-app/src/lib/helpers/sentry-error.ts
@@ -12,7 +12,10 @@
 // ★ console.error fallback (dev 환경 안전성) — production 환경에서는 Sentry 만 전송, dev/test 에서는 콘솔도 출력.
 // ──────────────────────────────────────────────
 
-import * as Sentry from '@sentry/nextjs';
+// ★ default import — namespace(`import * as`)는 @sentry/nextjs ESM 빌드(edge/browser/prod)에서
+//   captureException/Message/withScope 를 노출 안 함(default 밑에만 존재) → "is not a function".
+//   default import 는 ESM(default)·node CJS(esModuleInterop) 양쪽에서 full API 동작(실측).
+import Sentry from '@sentry/nextjs';
 import type { AppErrorDTO } from '@/lib/types/errors';
 
 /**


### PR DESCRIPTION
## 무엇을 / 왜
프로덕션(ESM 빌드)에서 발생한 **"Sentry.captureException is not a function" (Fatal)** 해결.

**원인**: `import * as Sentry from '@sentry/nextjs'`(namespace)가 `@sentry/nextjs`의 **ESM 빌드**(edge/browser/prod 서버 ESM)에서 `captureException`/`captureMessage`/`withScope`를 namespace 멤버로 노출하지 않음(API가 `.default` 밑에만 존재). exports 맵상 **`node`만 CJS**라 로컬 node-dev에선 동작 → 버그가 가려졌음.

**실측 근거**:
```
[ESM namespace] captureException: undefined   (NS.default.captureException: function)
[ESM default]   captureException: function | captureMessage: function | withScope: function
```

## 수정 = import 1줄 교체 (호출부·로직·동작 무변경)
```ts
// import * as Sentry from '@sentry/nextjs'   ← ESM 빌드에서 capture* 미노출
import Sentry from '@sentry/nextjs'           // default: ESM(.default)·CJS(esModuleInterop) 양쪽 동작
```

## 대상 6파일 (`#3 점검`으로 발견한 동일 버그 — capture*/withScope 호출)
| 파일 | API | 런타임 |
|------|-----|--------|
| ★ `sentry-error.ts` | captureException·captureMessage·withScope | **보고된 서버/edge Fatal(핵심)** |
| `login-form.tsx` | captureMessage | **클라 browser ESM Fatal** — 심사관 진입 |
| `intersection.ts`·`geocoding.ts`·`use-intersection.ts` | capture* | 진단 경로 |
| `sentry-test/route.ts` | captureException | 테스트 라우트 |

> `sentry.client/server/edge.config.ts`는 **`Sentry.init`만** 사용 → namespace에서 init은 정상 노출 → **무변경**.

## ★ 안전·정직
- import 라인만 교체, **호출부·로직 무변경**(diff 삭제 = import 라인뿐, 검증함)
- 새 동작 0 — 잠재 크래시를 원래 의도대로 복구만
- 기존 3-sink **콘솔·DB sink 무영향**
- 범위 참고: 명시 `#1`은 `sentry-error.ts`였고, 나머지 5개는 `#3 점검`에서 발견한 **동일 prod-Fatal**이라 같은 1줄 안전 픽스 적용. 일부 제외 원하면 Draft에서 조정 가능.

## 검증
- ✅ `tsc --noEmit` 0 (esModuleInterop:true → default import 타입 안전) / `next lint` 0
- ✅ 호출부 무변경(import 라인 외 삭제 0)
- ✅ **ESM 재현 테스트**: default import → `withScope + captureException + captureMessage` 호출 성공(Fatal 해소)

## 변경 (6 파일, +14/-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)