### PR TITLE
feat(logging): 상세 로그 중앙 로거 토대 (1단계, additive)

### DIFF
--- a/onday-app/src/app/api/events/route.ts
+++ b/onday-app/src/app/api/events/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { logEvent } from "@/lib/logging/log-event-server";
+
+// POST /api/events — 상세 로그 수집기 (로거 1단계 토대).
+// ★ best-effort 계약: 검증 실패·DB 실패 무관 항상 204(클라 logEvent 는 응답 안 봄).
+// ★ PII 0 — 화이트리스트 enum + .strip() 으로 미정의 키 전부 drop(주소·토큰 들어와도 버림).
+// ★ event_name 은 ✅완비 11종 enum 으로 강제(알 수 없는 이벤트·남용 차단).
+
+const EVENT_NAMES = [
+  "landing_viewed",
+  "login_entered",
+  "diagnosis_input_viewed",
+  "address_verified",
+  "diagnosis_submit_clicked",
+  "diagnosis_started",
+  "diagnosis_completed",
+  "share_link_created",
+  "share_link_clicked",
+  "saved_search_loaded",
+  "deadline_mode_activated",
+] as const;
+
+const eventSchema = z
+  .object({
+    eventName: z.enum(EVENT_NAMES),
+    mode: z.enum(["couple", "single"]).optional(),
+    method: z.enum(["kakao", "guest", "reviewer"]).optional(),
+    count: z.union([z.literal(1), z.literal(2)]).optional(),
+    daysLeft: z.number().int().optional(),
+    diagnosisId: z.string().max(64).optional(),
+    visitorId: z.string().max(64).optional(),
+  })
+  .strip();
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const parsed = eventSchema.safeParse(body);
+    if (parsed.success) {
+      await logEvent(parsed.data);
+    }
+  } catch {
+    // best-effort — 파싱·검증·insert 실패 무관. 항상 204.
+  }
+  return new NextResponse(null, { status: 204 });
+}

--- a/onday-app/src/lib/analytics/mixpanel.ts
+++ b/onday-app/src/lib/analytics/mixpanel.ts
@@ -1,4 +1,7 @@
 import mixpanel from "mixpanel-browser";
+// ★ DB raw 로거 fan-out (로거 1단계, additive). Mixpanel 전송과 독립 — ensureInit 가드 前 호출.
+//   best-effort no-op 이라 기존 track·퍼널 동작 회귀 0. 역할 분담: EVENT_LOGGER_UTM_PLAN.md §0.
+import { logEvent } from "@/lib/logging/log-event";
 
 // MON-003 v1.4 부활 (Issue #127) — REQ-NF-008 평균 탐색 완료 시간 p50 ≤ 10분 측정.
 //   diagnosis_started → diagnosis_completed funnel = Mixpanel Dashboard p50 자동 계산.
@@ -29,6 +32,7 @@ function ensureInit(): boolean {
 }
 
 export function trackDiagnosisStarted(diagnosisId: string): void {
+  logEvent("diagnosis_started", { diagnosisId });
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_started", {
     diagnosis_id: diagnosisId,
@@ -37,6 +41,7 @@ export function trackDiagnosisStarted(diagnosisId: string): void {
 }
 
 export function trackDiagnosisCompleted(diagnosisId: string): void {
+  logEvent("diagnosis_completed", { diagnosisId });
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_completed", {
     diagnosis_id: diagnosisId,
@@ -49,22 +54,26 @@ export function trackDiagnosisCompleted(diagnosisId: string): void {
 //   ★ PII 0 — 주소·좌표·역 이름·이메일 절대 미포함. 유형/카운트/모드 같은 카테고리만.
 
 export function trackLandingViewed(): void {
+  logEvent("landing_viewed");
   if (!ensureInit()) return;
   mixpanel.track("landing_viewed", { timestamp: Date.now() });
 }
 
 export function trackLoginEntered(method: "kakao" | "guest" | "reviewer"): void {
+  logEvent("login_entered", { method });
   if (!ensureInit()) return;
   mixpanel.track("login_entered", { method, timestamp: Date.now() });
 }
 
 export function trackDiagnosisInputViewed(mode: "couple" | "single"): void {
+  logEvent("diagnosis_input_viewed", { mode });
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_input_viewed", { mode, timestamp: Date.now() });
 }
 
 // ★ count = 확정된 주소 순번(1=A, 2=B). 주소 title·coordinate·역 이름은 절대 담지 않는다(재식별 차단).
 export function trackAddressVerified(count: 1 | 2): void {
+  logEvent("address_verified", { count });
   if (!ensureInit()) return;
   mixpanel.track("address_verified", { count, timestamp: Date.now() });
 }
@@ -72,6 +81,7 @@ export function trackAddressVerified(count: 1 | 2): void {
 // ★ mode 만 — /diagnosis 입력 화면엔 deadline 입력이 없다(deadline 은 별도 /deadline 라우트).
 //   설계의 has_deadline 은 deadline 발 제출 지점이 생기면 그때 추가(없는 값 만들지 않음).
 export function trackDiagnosisSubmitClicked(mode: "couple" | "single"): void {
+  logEvent("diagnosis_submit_clicked", { mode });
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_submit_clicked", { mode, timestamp: Date.now() });
 }
@@ -82,24 +92,28 @@ export function trackDiagnosisSubmitClicked(mode: "couple" | "single"): void {
 
 // ★ diagnosis_id = 내부 uuid(기존 diagnosis_started 패턴). 공유 토큰(uniqueUrl)은 담지 않는다.
 export function trackShareLinkCreated(diagnosisId: string, mode: "couple" | "single"): void {
+  logEvent("share_link_created", { diagnosisId, mode });
   if (!ensureInit()) return;
   mixpanel.track("share_link_created", { diagnosis_id: diagnosisId, mode, timestamp: Date.now() });
 }
 
 // ★ mode 만 — share 페이지 data 의 uniqueUrl·addressA/B 는 절대 담지 않는다(재식별 차단).
 export function trackShareLinkClicked(mode: "couple" | "single"): void {
+  logEvent("share_link_clicked", { mode });
   if (!ensureInit()) return;
   mixpanel.track("share_link_clicked", { mode, timestamp: Date.now() });
 }
 
 // ★ mode 만 — 불러온 config 의 주소는 절대 담지 않는다.
 export function trackSavedSearchLoaded(mode: "couple" | "single"): void {
+  logEvent("saved_search_loaded", { mode });
   if (!ensureInit()) return;
   mixpanel.track("saved_search_loaded", { mode, timestamp: Date.now() });
 }
 
 // ★ days_left(숫자)만 — ISO 날짜 대신 D-day 로 환원(식별성 0).
 export function trackDeadlineModeActivated(daysLeft: number): void {
+  logEvent("deadline_mode_activated", { daysLeft });
   if (!ensureInit()) return;
   mixpanel.track("deadline_mode_activated", { days_left: daysLeft, timestamp: Date.now() });
 }

--- a/onday-app/src/lib/logging/log-event-server.ts
+++ b/onday-app/src/lib/logging/log-event-server.ts
@@ -1,0 +1,42 @@
+// 상세 로그 적재 — 서버측 insert (로거 1단계 토대).
+// ★ log-error.ts best-effort 패턴 계승: DB insert 실패해도 조용히 삼킴(앱 흐름 차단 X).
+// ★ prod → event_logs / preview·dev → preview_event_logs (prod raw 청결 유지, 환경 격리).
+// ★ USER FK 없음 · PII 0 — 비식별 속성만(ErrorLog 답습).
+
+import { prisma } from "@/lib/db";
+import { getDeploymentEnv } from "@/lib/health";
+
+export interface EventLogInput {
+  eventName: string;
+  mode?: string | null;
+  method?: string | null;
+  count?: number | null;
+  daysLeft?: number | null;
+  diagnosisId?: string | null;
+  visitorId?: string | null;
+  props?: string | null;
+}
+
+/** event_logs(prod) / preview_event_logs(preview·dev) 에 1행 insert. best-effort. */
+export async function logEvent(input: EventLogInput): Promise<void> {
+  const data = {
+    eventName: input.eventName,
+    mode: input.mode ?? null,
+    method: input.method ?? null,
+    count: input.count ?? null,
+    daysLeft: input.daysLeft ?? null,
+    diagnosisId: input.diagnosisId ?? null,
+    visitorId: input.visitorId ?? null,
+    props: input.props ?? null,
+  };
+
+  try {
+    if (getDeploymentEnv() === "production") {
+      await prisma.eventLog.create({ data });
+    } else {
+      await prisma.previewEventLog.create({ data });
+    }
+  } catch {
+    // best-effort — 테이블 미배포·연결 실패 시 조용히 실패. 앱·기존 동작 영향 0.
+  }
+}

--- a/onday-app/src/lib/logging/log-event.ts
+++ b/onday-app/src/lib/logging/log-event.ts
@@ -1,0 +1,48 @@
+// 상세 로그 적재 — 클라이언트 emitter (로거 1단계 토대).
+// ★ Mixpanel 대체 아님 — 원본 raw 보관용 DB 적재(역할 분담, EVENT_LOGGER_UTM_PLAN.md §0).
+// ★ best-effort — sendBeacon fire-and-forget. 실패·미지원·서버 부재 시 no-op(앱·기존 track 영향 0).
+// ★ PII 0 — 타입 화이트리스트(mode/method/count/daysLeft/diagnosisId)만. 주소·토큰·역명은 인자에 없음.
+// ★ visitorId = 익명(visitor-id.ts 재사용). UTM 부착은 3단계(본 1단계 범위 밖).
+
+import { getVisitorId } from "@/lib/logging/visitor-id";
+
+export interface EventAttrs {
+  mode?: "couple" | "single";
+  method?: "kakao" | "guest" | "reviewer";
+  count?: 1 | 2;
+  daysLeft?: number;
+  diagnosisId?: string;
+}
+
+/** 이벤트 1건을 /api/events 로 비차단 전송. 실패해도 절대 throw 안 함. */
+export function logEvent(eventName: string, attrs: EventAttrs = {}): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: Record<string, unknown> = { eventName };
+    if (attrs.mode !== undefined) payload.mode = attrs.mode;
+    if (attrs.method !== undefined) payload.method = attrs.method;
+    if (attrs.count !== undefined) payload.count = attrs.count;
+    if (attrs.daysLeft !== undefined) payload.daysLeft = attrs.daysLeft;
+    if (attrs.diagnosisId !== undefined) payload.diagnosisId = attrs.diagnosisId;
+
+    const visitorId = getVisitorId();
+    if (visitorId) payload.visitorId = visitorId;
+
+    const body = JSON.stringify(payload);
+
+    // sendBeacon — 페이지 언로드 중에도 안전, UI 블로킹 0.
+    if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+      navigator.sendBeacon("/api/events", new Blob([body], { type: "application/json" }));
+      return;
+    }
+    // 폴백 — sendBeacon 미지원 환경.
+    void fetch("/api/events", {
+      method: "POST",
+      body,
+      keepalive: true,
+      headers: { "Content-Type": "application/json" },
+    }).catch(() => {});
+  } catch {
+    // best-effort — 절대 throw 안 함.
+  }
+}


### PR DESCRIPTION
## 1단계 범위 (로거 토대 — additive only)

`docs/EVENT_LOGGER_UTM_PLAN.md` 로드맵 **🟢 1단계(배관) + 2단계(mixpanel fan-out)**. UTM(3단계)·크론(4~5단계)은 **제외** — 후속 PR.

11종 ✅완비 이벤트를 `event_logs` 에 적재하는 중앙 로거. **Mixpanel 대체 아님** — 역할 분담(운영측정=Mixpanel / 원본 raw 보관=DB, 플랜 §0).

### 변경 (신규 3 + 수정 1)
| 파일 | 내용 |
|---|---|
| `src/lib/logging/log-event.ts` (신규) | 클라 emitter — `sendBeacon('/api/events')`, best-effort, PII 화이트리스트, 익명 `visitorId` 재사용 |
| `src/lib/logging/log-event-server.ts` (신규) | 서버 insert — prod→`event_logs` / preview·dev→`preview_event_logs`, best-effort(log-error.ts 패턴) |
| `src/app/api/events/route.ts` (신규) | `POST` 수집기 — Zod enum 11종 + `.strip()` 미정의 키 drop, 항상 `204` |
| `src/lib/analytics/mixpanel.ts` (수정) | 11개 `trackXxx` 에 `logEvent()` 1줄 fan-out — **`ensureInit` 가드 前** 호출(Mixpanel 토큰과 독립) |

## ★ 기존 무변경 (회귀 0)
- 11개 `track*()` 호출 지점 **zero-touch**(mixpanel.ts 단일 fan-out).
- `mixpanel.track`·`ensureInit`·퍼널 대시보드·Sentry·진단 플로우 **그대로**(추가만).
- `logEvent` best-effort no-op — token/DSN 부재처럼 실패해도 track·UI 영향 0.

## 검증
- `tsc --noEmit` ✅ / `eslint` ✅ (No warnings or errors)
- DB 스모크: `preview_event_logs` insert→readback→delete ✅, 잔여 0행(정리 완료).
- count 정합: `logEvent` 11 / `mixpanel.track` 11 / `ensureInit` 가드 11.

## 후속 (이 PR 아님)
- 3단계: UTM 캡처(랜딩 sessionStorage first-touch) → event_logs 부착
- 4~5단계: 가집계/최종집계 크론(Vercel 플랜 제약 §4-3) + Admin 대시보드

🤖 Generated with [Claude Code](https://claude.com/claude-code)