### PR TITLE
feat(logging): UTM 유입경로 익명 전파 (2단계/plan S3, additive)

### DIFF
--- a/onday-app/src/app/api/events/route.ts
+++ b/onday-app/src/app/api/events/route.ts
@@ -30,15 +30,32 @@ const eventSchema = z
     daysLeft: z.number().int().optional(),
     diagnosisId: z.string().max(64).optional(),
     visitorId: z.string().max(64).optional(),
+    props: z.string().max(500).optional(), // utm JSON (2단계) — 아래 sanitize 로 utm 5종만 통과
   })
   .strip();
+
+// ★ PII 0 강제 — props 에서 utm 표준 5종만 남김(클라 무관하게 외부 POST 도 차단).
+const UTM_KEYS = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"] as const;
+function sanitizeProps(props?: string): string | null {
+  if (!props) return null;
+  try {
+    const obj = JSON.parse(props) as Record<string, unknown>;
+    const clean: Record<string, string> = {};
+    for (const k of UTM_KEYS) {
+      if (typeof obj[k] === "string") clean[k] = (obj[k] as string).slice(0, 200);
+    }
+    return Object.keys(clean).length ? JSON.stringify(clean) : null;
+  } catch {
+    return null;
+  }
+}
 
 export async function POST(request: Request) {
   try {
     const body = await request.json();
     const parsed = eventSchema.safeParse(body);
     if (parsed.success) {
-      await logEvent(parsed.data);
+      await logEvent({ ...parsed.data, props: sanitizeProps(parsed.data.props) });
     }
   } catch {
     // best-effort — 파싱·검증·insert 실패 무관. 항상 204.

--- a/onday-app/src/app/landing/landing-client.tsx
+++ b/onday-app/src/app/landing/landing-client.tsx
@@ -12,6 +12,7 @@ import { Logo } from "@/components/layout/logo";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { trackLandingViewed } from "@/lib/analytics/mixpanel";
+import { captureUtm } from "@/lib/logging/utm-session";
 import { motion, MotionConfig, useScroll, useTransform, useReducedMotion, useMotionValue, animate } from "framer-motion";
 import CountUp from "react-countup";
 
@@ -805,6 +806,9 @@ export function LandingClient() {
   React.useEffect(() => {
     if (trackedRef.current) return;
     trackedRef.current = true;
+    // ★ first-touch utm 보존(쿠키 0) — 첫 이벤트부터 채널 따라가도록 trackLandingViewed 前.
+    //   useSearchParams 대신 location.search 사용: Suspense 경계 요구·CSR bailout 회피(렌더 동작 무변경).
+    captureUtm(window.location.search);
     trackLandingViewed();
   }, []);
 

--- a/onday-app/src/lib/logging/log-event.ts
+++ b/onday-app/src/lib/logging/log-event.ts
@@ -5,6 +5,7 @@
 // ★ visitorId = 익명(visitor-id.ts 재사용). UTM 부착은 3단계(본 1단계 범위 밖).
 
 import { getVisitorId } from "@/lib/logging/visitor-id";
+import { getUtm } from "@/lib/logging/utm-session";
 
 export interface EventAttrs {
   mode?: "couple" | "single";
@@ -27,6 +28,10 @@ export function logEvent(eventName: string, attrs: EventAttrs = {}): void {
 
     const visitorId = getVisitorId();
     if (visitorId) payload.visitorId = visitorId;
+
+    // ★ first-touch utm 부착(2단계). 없으면(직접 유입) 생략 — 에러 0.
+    const utm = getUtm();
+    if (utm) payload.props = JSON.stringify(utm);
 
     const body = JSON.stringify(payload);
 

--- a/onday-app/src/lib/logging/utm-session.ts
+++ b/onday-app/src/lib/logging/utm-session.ts
@@ -1,0 +1,41 @@
+// UTM 유입경로 — 익명 세션 전파 (로거 2단계 / plan S3).
+// ★ 쿠키 0 — sessionStorage 만 사용(탭 스코프, 탭 종료 시 소멸). 게스트 세션 모델과 동일 프라이버시 등급.
+// ★ first-touch — 최초 유입값 보존(이미 있으면 덮어쓰지 않음). 직접 유입(utm 없음)이면 아무것도 저장 안 함.
+// ★ PII 0 — 표준 5종(캠페인 메타)만. 전체 referrer·쿼리스트링 통째 저장 금지.
+// ★ best-effort — sessionStorage 차단·파싱 실패 시 no-op(앱·로거·track 영향 0).
+
+const KEY = "onday_utm";
+const UTM_KEYS = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"] as const;
+type UtmKey = (typeof UTM_KEYS)[number];
+export type Utm = Partial<Record<UtmKey, string>>;
+
+/** URL 쿼리에서 utm 5종을 first-touch 로 sessionStorage 에 저장. utm 없으면 no-op. */
+export function captureUtm(search: string | URLSearchParams): void {
+  if (typeof window === "undefined") return;
+  try {
+    const params = typeof search === "string" ? new URLSearchParams(search) : search;
+    const found: Utm = {};
+    for (const k of UTM_KEYS) {
+      const v = params.get(k);
+      if (v) found[k] = v.slice(0, 200); // 길이 캡(과대 입력 방지)
+    }
+    if (Object.keys(found).length === 0) return; // 직접 유입 — 저장 안 함
+    if (window.sessionStorage.getItem(KEY)) return; // ★ first-touch — 최초값 보존
+    window.sessionStorage.setItem(KEY, JSON.stringify(found));
+  } catch {
+    // best-effort
+  }
+}
+
+/** 저장된 first-touch utm 스냅샷. 없거나 실패 시 null. */
+export function getUtm(): Utm | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Utm;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 2단계 범위 (UTM 유입경로 — plan S3)

`EVENT_LOGGER_UTM_PLAN.md` **S3**. 1단계 로거(logEvent, #248 머지됨) 활용. 크론(S4~5)·대시보드는 **제외** — 후속 PR.

랜딩 utm 5종 수신 → **쿠키 0 익명 first-touch 전파** → 모든 이벤트 props 부착 → 채널별 전환율 산출 기반.

### 변경 (신규 1 + 수정 3)
| 파일 | 내용 |
|---|---|
| `src/lib/logging/utm-session.ts` (신규) | `captureUtm`(first-touch)/`getUtm` — `sessionStorage`(쿠키 0·탭 소멸), 표준 5종만 |
| `src/lib/logging/log-event.ts` (수정) | `getUtm()` → `props` JSON 부착(없으면 생략). 기존 attrs 무변경 |
| `src/app/api/events/route.ts` (수정) | `props` 옵션 필드 + `sanitizeProps`(utm 5종만 통과 — **외부 POST PII 차단**) |
| `src/app/landing/landing-client.tsx` (수정) | 기존 mount `useEffect` 에 `captureUtm(location.search)` 1줄(`trackLandingViewed` 前) |

## ★ 설계 결정 — `useSearchParams` 대신 `location.search`
`useSearchParams()` 는 Suspense 경계 요구 + CSR bailout 유발(랜딩 렌더 동작 변경 위험). 기존 client `useEffect` 안에서 `window.location.search` 를 읽어 **렌더 동작 100% 무변경**으로 회피.

## ★ 채널별 전환율 (이제 가능)
```sql
SELECT props::jsonb->>'utm_source' AS source,
       COUNT(*) FILTER (WHERE event_name='landing_viewed')      AS landed,
       COUNT(*) FILTER (WHERE event_name='diagnosis_completed') AS completed
FROM event_logs WHERE props IS NOT NULL GROUP BY 1;
```

## 검증 (실 Supabase, HTTP 통합)
- `tsc` ✅ / `eslint`(변경분) ✅ (랜딩의 기존 warning 3건은 무관·기존)
- `POST /api/events` props=utm+`address`(PII) → DB props = **utm 3종만, address DROP** ✅
- 직접 유입(utm 없음) → `props=null`, 에러 0 ✅
- 미정의 event(`evil_event`) → 204 + **insert 안 됨**(enum) ✅
- preview_event_logs 잔여 **0행**(정리 완료) ✅

## ★ 안전 (회귀 0)
- 랜딩 렌더·1단계 로거·Mixpanel·퍼널·진단 **무변경**. utm 부착만 추가.
- 마이그레이션 0(`props` 재사용). best-effort no-op(캡처 실패해도 영향 0).
- PII 0: utm=비식별 캠페인 메타, 쿠키 0·개인추적 0, sanitize 로 그 외 키 차단.

## 후속 (이 PR 아님)
- 4~5단계: 가집계/최종집계 크론(Vercel 플랜 제약 §4-3) + Admin 대시보드

🤖 Generated with [Claude Code](https://claude.com/claude-code)