### PR TITLE
fix(landing): 루트 redirect utm 쿼리스트링 보존

### DIFF
--- a/onday-app/src/app/page.tsx
+++ b/onday-app/src/app/page.tsx
@@ -3,6 +3,19 @@ import { redirect } from "next/navigation";
 // 루트는 랜딩페이지로 즉시 이동.
 // 랜딩페이지 CTA → /login → /diagnosis 흐름.
 // 컴포넌트 시연 페이지는 /dev로 분리되어 있다.
-export default function RootPage() {
-  redirect("/landing");
+// ★ utm 등 쿼리스트링 보존 — 마케팅 링크가 루트(/?utm_source=…)를 가리킬 때 유실 방지.
+//   쿼리 없으면(직접 유입) /landing 으로만.
+export default async function RootPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === "string") qs.set(key, value);
+    else if (Array.isArray(value) && value[0] !== undefined) qs.set(key, value[0]);
+  }
+  const query = qs.toString();
+  redirect(query ? `/landing?${query}` : "/landing");
 }


### PR DESCRIPTION
## 문제
`RootPage`(`src/app/page.tsx`)의 `redirect("/landing")` 가 `searchParams` 를 버려, 마케팅 링크가 루트(`/?utm_source=…`)를 가리키면 **utm 이 유실**됨. `/landing` 의 `captureUtm(location.search)` 이 빈 쿼리만 보게 됨.
- 실측 교차 확정: 루트 진입 세션 = props 0 / `/landing?utm_*` 직접 진입 세션 = props 9(instagram 전체 퍼널).

## 수정 (1파일, 최소)
`RootPage` 가 `searchParams`(Next 15 Promise)를 받아 쿼리를 `/landing?…` 로 보존 전달.

## 검증 (dev 실측)
| 진입 | 결과 |
|---|---|
| `/?utm_source=test&utm_medium=cpc` | 307 → `location: /landing?utm_source=test&utm_medium=cpc` ✅ |
| `/` (쿼리 없음) | 307 → `/landing` ✅ (기존 동작 유지) |
| `/landing?utm_source=instagram` (직접) | 200 ✅ (영향 0, 이미 작동) |

- `tsc --noEmit` ✅ / `eslint`(page.tsx) ✅ No warnings or errors

## ★ 안전 (회귀 0)
- `page.tsx` redirect 만 수정. 랜딩 렌더·로거·UTM 캡처·진단 플로우 **무변경**.
- 루트 진입 정상 동작(랜딩 표시) 유지. 쿼리 없을 때도 안전(`/landing` 단독).

🤖 Generated with [Claude Code](https://claude.com/claude-code)