### PR TITLE
feat(playboard): Insights 대시보드 — event_logs 퍼널·UTM 전환율 (raw 직접 집계)

### DIFF
--- a/docs/INSIGHTS_DASHBOARD_REPORT.md
+++ b/docs/INSIGHTS_DASHBOARD_REPORT.md
@@ -1,0 +1,85 @@
+# Insights 대시보드 — 결과 · 테스트 · 직접 테스트 시나리오
+
+> 대상: `/playboard/insights` (event_logs raw 직접 집계 대시보드).
+> ★ 발표 전 **유일 구현**. 크론·share_signup·distinct는 이슈 초안만(`docs/issues/`).
+> 근거: 실제 코드 + 라이브 `event_logs` 실측(48행). 작성일 2026-06-23.
+
+---
+
+## A. 결과 보고서
+
+### A-1. 구현물
+| 파일 | 역할 |
+|------|------|
+| `src/app/playboard/insights/page.tsx` | RSC 대시보드 — prod 차단·force-dynamic·robots noindex, 퍼널/전환율/UTM 렌더 |
+| `src/lib/playboard/insights.ts` | 데이터 계층 — `event_logs` 직접 집계(SELECT only), 11종 카운트·전환율 3종·UTM 채널 |
+
+### A-2. 화면 구성
+1. **헤더** — 총 이벤트 수·UTM 부착 수·적재 구간(실측 배지). prod 차단·읽기전용 안내.
+2. **전환 퍼널(11종)** — 7 funnel(Acquisition→Activation/Aha) + 4 referral/retention. 막대(단계별 색)·카운트·랜딩 대비 %.
+3. **핵심 전환율 3종** — 입력완료율·제출성공률·공유생성률(AARRR §3-2 수식 + 분자/분모 실값).
+4. **UTM 채널별 전환율** — `utm_source`별 landing→completed 표.
+5. **정직 푸터** — 이벤트 단위(비-distinct)·크론 미구현·distinct 후속 명시.
+
+### A-3. 집계 방식
+- **크론 0** — 페이지 요청 시점에 `prisma.eventLog` groupBy/count/findMany/aggregate. 인덱스(`event_name`/`timestamp`) 활용, 소량(수십~수백 행)에서 sub-second.
+- 데이터 소스 = `event_logs`(prod 적재분). dev/preview에서 열어도 같은 Supabase의 prod 행을 읽음.
+
+### A-4. 미구현 갭 (정직)
+| 항목 | 상태 |
+|------|------|
+| 가집계/최종집계 크론 | ❌ 이슈 초안만([cron-aggregation](issues/cron-aggregation.md)) |
+| `share_link_signup` | ❌ 미배선([share-link-signup](issues/share-link-signup.md)) |
+| distinct 정규화·봇 제외 | ❌ 이슈 초안만([distinct-normalization](issues/distinct-normalization.md)) |
+| 입력완료율 distinct | ⚠️ 현재 raw count(카드 인라인 주의 표기) |
+
+---
+
+## B. 테스트 보고서
+
+| 항목 | 방법 | 결과 |
+|------|------|------|
+| 타입 | `tsc --noEmit` | ✅ 통과 |
+| 린트 | `eslint`(2파일) | ✅ No warnings or errors |
+| 렌더(dev) | `GET /playboard/insights` | ✅ HTTP 200 |
+| 데이터 반영 | HTML 검증 | ✅ 총 48 이벤트·UTM 부착 9·instagram·퍼널·전환율 카드 렌더 |
+| 전환율 산출 | submitSuccess | ✅ `started 4 ÷ submit_clicked 4 = 100%` 표시 |
+| 읽기 전용 | 코드 검토(aztks) | ✅ groupBy/count/findMany/aggregate만 — write 0 |
+| prod 차단 | 코드 검토 | ✅ `getDeploymentEnv()==="production" → notFound` (logging-test 동일 패턴) |
+| 빈 상태 | 코드 검토 | ✅ `total===0` 배너 + `pct` divide-by-zero→null→"—" 가드 |
+| PII 0 | aztks 검증 | ✅ utm_source·카운트·timestamp만. route `sanitizeProps`로 utm 5종 외 차단 |
+| 기존 무변경 | additive | ✅ 신규 파일 2개만. 마이그레이션 0. Mixpanel/Sentry/퍼널/진단/로거 무변경 |
+
+**aztks-ai-peer:** VERDICT **GO** · `A:P Z:P T:P K:P S:P` · TOP_FIX(선택) = 입력완료율 카드 인라인 주의 → **적용 완료**.
+
+---
+
+## C. 사용자 직접 테스트 시나리오 (리뷰 아웃라인)
+
+> ★ Draft PR 브랜치를 로컬에서 띄워 확인. production 배포 화면에는 **안 보임**(prod 차단 — 정상).
+
+### C-1. 준비
+```bash
+git checkout feat/playboard-insights-dashboard
+cd onday-app && npm run dev   # http://localhost:3000
+```
+
+### C-2. 시나리오
+| # | 행동 | 기대 결과 |
+|---|------|-----------|
+| 1 | `/playboard/insights` 접속 | 200, 대시보드 렌더. 상단 배지에 총 이벤트·UTM·구간 표시 |
+| 2 | 퍼널 섹션 확인 | landing_viewed→…→diagnosis_completed 막대·카운트, 랜딩 대비 % |
+| 3 | 핵심 전환율 카드 | 입력완료율·제출성공률·공유생성률 + 분자/분모 실값. 분모 0이면 "—" |
+| 4 | UTM 표 확인 | `instagram` 행 + landing/completed/전환율. (없으면 안내문) |
+| 5 | `/landing?utm_source=naver&utm_medium=cpc` 진입 → 진단 1회 완료 | 잠시 후 `/playboard/insights` 새로고침 시 `naver` 채널 행 추가 |
+| 6 | 푸터 확인 | 이벤트 단위·distinct 미적용·크론 후속 주의 노출 |
+| 7 | (선택) prod 차단 검증 | `VERCEL_ENV=production` 빌드/배포 시 `/playboard/insights` → 404 |
+
+### C-3. 리뷰 체크포인트
+- [ ] 숫자가 Mixpanel 퍼널 추세와 방향성 일치하는가(절대값 아닌 구조).
+- [ ] 빈 상태(데이터 0)에서 깨지지 않는가 — 새 preview DB로 확인 가능.
+- [ ] 개인정보(주소·역명·이메일·토큰)가 화면에 **전혀** 없는가.
+- [ ] 기존 진단/공유/랜딩 흐름이 그대로인가(대시보드는 별도 경로).
+
+### C-4. 합격 기준
+A·B 전 항목 ✅ + C-2 시나리오 1~6 기대결과 일치 → 머지 후보. (머지·이슈 발행은 사용자 직접.)

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,0 +1,13 @@
+# 로깅 후속 작업 — GitHub 이슈 초안 (발행 대기)
+
+> ★ 이 폴더의 `.md`는 **이슈 초안**입니다. **GitHub 발행은 사용자가 직접** 합니다(클로드코드 자동 발행 금지).
+> 근거: `EVENT_LOGGER_UTM_PLAN.md` 로드맵 + `LOG_IMPLEMENTATION_OUTLINE.md §5 갭`.
+
+| 초안 | 우선순위 | 발표 전/후 | 상태 |
+|------|----------|-----------|------|
+| [dashboard-insights.md](dashboard-insights.md) | 🟢 높음 | **발표 전** | Draft PR 구현됨(`/playboard/insights`) |
+| [cron-aggregation.md](cron-aggregation.md) | 🟡 중 | 발표 후 | 미구현(설계만) |
+| [share-link-signup.md](share-link-signup.md) | ⚪ 낮음 | 발표 후 | 미배선(attribution 갭) |
+| [distinct-normalization.md](distinct-normalization.md) | ⚪ 낮음 | 발표 후 | 미구현 |
+
+**발행 순서 제안:** dashboard(구현 완료→PR 연결) → cron → distinct → share_signup.

--- a/docs/issues/cron-aggregation.md
+++ b/docs/issues/cron-aggregation.md
@@ -1,0 +1,27 @@
+---
+title: "feat(logging): 가집계·최종집계 크론 — metric_rollups / metric_aggregates 채우기"
+labels: [enhancement, observability, deferred]
+priority: 🟡 중 (발표 후)
+status: 미구현 — 설계만 (EVENT_LOGGER_UTM_PLAN.md §4)
+---
+
+## 배경
+3단 집계 파이프라인 중 **① raw `event_logs`만 가동**. ②가집계(`metric_rollups`)·③최종집계(`metric_aggregates`) 테이블은 생성됐으나(마이그레이션 `20260622…`) **비어 있다**. 대시보드가 raw 직접 집계로 충분한 현 규모를 넘어서면 성능 계층으로 전환.
+
+## 작업
+- `/api/cron/rollup` — `event_logs` → `metric_rollups` upsert(1h 버킷 기준선).
+- `/api/cron/aggregate` — rollups → `metric_aggregates`(H/D/W/M) upsert.
+- 멱등 upsert용 **UNIQUE 제약 추가 마이그레이션**(신규 테이블 대상 — additive): rollups `(metric_type,bucket,bucket_start)`, aggregates `(metric_type,grain,period_start)`.
+- 크론 엔드포인트 `CRON_SECRET` 보호.
+
+## ★ 위험·제약 (발표 후인 이유)
+- **Vercel 크론 플랜 제약**: Hobby = 하루 1회 상한 → 1m/10m 가집계 불가. Pro 또는 외부 스케줄러 필요. **현 플랜 미확인** → 1h/D/W/M 기준선으로 시작.
+- raw 직접 집계 대비 복잡도·실패 지점 증가 → 발표 전 도입 금지.
+
+## 수용 기준 (AC)
+- [ ] rollup/aggregate 잡 멱등(재실행 중복 0).
+- [ ] raw 무손실 → 임의 구간 backfill 가능.
+- [ ] 기존 5+6 테이블 무변경(신규 제약만 additive).
+
+## 의존
+- 대시보드([dashboard-insights](dashboard-insights.md))를 rollups/aggregates 소스로 전환(선택).

--- a/docs/issues/dashboard-insights.md
+++ b/docs/issues/dashboard-insights.md
@@ -1,0 +1,32 @@
+---
+title: "feat(playboard): Insights 대시보드 — event_logs 퍼널·UTM 전환율 (raw 직접 집계)"
+labels: [enhancement, observability, playboard]
+priority: 🟢 높음 (발표 전)
+status: 구현됨 — Draft PR 연결 예정
+---
+
+## 배경
+로깅 구현(#248·#249·#250)으로 `event_logs`에 11종 이벤트가 적재되나, 이를 보는 **운영자 화면이 없다**(AARRR G4). Mixpanel 퍼널과 같은 구조를 **자체 DB(raw)** 로 시각화한다.
+
+## 작업
+- `/playboard/insights` RSC 페이지 신설 (`logging-test` prod-차단 패턴 답습).
+- `event_logs` **요청 시점 직접 집계**(크론 0): 11종 퍼널 + 핵심 전환율 3종 + UTM 채널별 전환율.
+- 데이터 소스 = `prisma.eventLog` groupBy/count/findMany/aggregate (**SELECT only**).
+
+## 수용 기준 (AC)
+- [x] 11종 퍼널(7 funnel + 4 referral/retention) 카운트·막대 표시.
+- [x] 핵심 전환율 3종(입력완료율·제출성공률·공유생성률, AARRR §3-2 수식).
+- [x] UTM 채널별 landing→completed 전환율 표.
+- [x] `event_logs` 0행이어도 안전(빈 상태 메시지).
+- [x] production 차단(`getDeploymentEnv()==="production" → notFound`), `robots: noindex`.
+
+## 안전
+- additive(신규 파일 2개), 읽기 전용, 마이그레이션 0, 기존 동작 무변경.
+
+## 미해결/후속
+- distinct(세션·방문자) 정규화·봇 제외 → [distinct-normalization](distinct-normalization.md).
+- 대규모 시 raw 직접 집계 → 가집계 크론 전환 → [cron-aggregation](cron-aggregation.md).
+
+## 구현
+- 파일: `src/app/playboard/insights/page.tsx`, `src/lib/playboard/insights.ts`.
+- **Draft PR**(이 이슈가 닫음) — 발행 시 `Closes #<번호>` 연결.

--- a/docs/issues/distinct-normalization.md
+++ b/docs/issues/distinct-normalization.md
@@ -1,0 +1,23 @@
+---
+title: "chore(logging): 전환율 distinct 정규화 + 봇·내부 트래픽 제외"
+labels: [enhancement, observability, data-quality]
+priority: ⚪ 낮음 (발표 후)
+status: 미구현
+---
+
+## 배경
+현재 전환율은 **이벤트 단위 카운트**(세션·방문자 distinct 미적용)라, 소표본에서 `login_entered(13) > landing_viewed(8)` 같은 분모<분자 역전이 보인다(다회 발화). 신뢰 가능한 비율을 위해 정규화 필요(`AARRR_NSM_PROPOSAL.md §3-2 공통 관리방침`, `LOG_IMPLEMENTATION_OUTLINE.md §3 주의`).
+
+## 작업
+- distinct 기준: 로그인 유저=`user_id`, 게스트=익명 `visitor_id`(이미 적재 중).
+- 봇·내부 트래픽 제외(내부 IP·UA 필터 — 단 IP는 미수집이라 UA/패턴 기반).
+- 전환율 분모/분자를 distinct 기준으로 재정의 → 대시보드 반영.
+
+## 수용 기준 (AC)
+- [ ] 입력완료율·제출성공률 등 distinct 기준 산출.
+- [ ] 분모<분자 역전 해소.
+- [ ] PII 0 유지(IP 미수집 원칙 — distinct는 익명 visitor_id 기준).
+
+## 의존
+- 대시보드([dashboard-insights](dashboard-insights.md)) 집계 로직 확장.
+- 데이터 축적(현 48행/17분은 표본 부족).

--- a/docs/issues/share-link-signup.md
+++ b/docs/issues/share-link-signup.md
@@ -1,0 +1,25 @@
+---
+title: "feat(logging): share_link_signup — 공유 경유 2nd 유저 가입 attribution"
+labels: [enhancement, observability, deferred]
+priority: ⚪ 낮음 (발표 후)
+status: 미배선 — attribution 연결 없음 (G3)
+---
+
+## 배경
+Referral 퍼널의 마지막 단계 `share_link_signup`(공유 링크 경유 → 2nd 유저 가입)이 **유일한 미배선 이벤트**. `/share/[uuid]` → `/login` CTA에 **attribution 연결이 없어** 측정 불가(`AARRR_NSM_PROPOSAL.md:174`, `LOG_IMPLEMENTATION_OUTLINE.md §1·§5`). REQ-NF-029(2nd 유저 전환율 ≥15%) 충족용.
+
+## 작업 (설계 후보)
+- 공유 링크에 attribution 식별자 전파(쿠키 없이 — sessionStorage `via_share` 또는 `/login?via=share` 쿼리).
+- `login_entered` 발화 시 `via_share` 여부를 `method` 외 속성으로 기록(PII 0 유지).
+- 또는 별도 `share_link_signup` 이벤트 신설.
+
+## ★ 미해결 (창작 금지)
+- 현재 share→login 경로에 식별자 전파 코드가 **없음**. UTM(first-touch)과 유사 패턴으로 설계 필요하나, 공유 토큰(uniqueUrl)을 식별자로 쓰면 PII 위험 → 익명 플래그만.
+
+## 수용 기준 (AC)
+- [ ] 공유 경유 가입을 익명으로 식별(공유 토큰·개인정보 미노출).
+- [ ] `share_link_clicked → signup` 전환율 산출 가능.
+- [ ] 직접 가입(비공유)과 구분.
+
+## 의존
+- UTM first-touch 패턴([utm-session.ts]) 재사용 검토.

--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -1,0 +1,214 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { getDeploymentEnv } from "@/lib/health";
+import { getInsights, FUNNEL_STEPS, OTHER_EVENTS, type InsightsData } from "@/lib/playboard/insights";
+
+// Insights 대시보드 — event_logs raw 직접 집계(크론 0). 운영자 도구.
+// ★ production 차단(logging-test 패턴): 운영자만 보는 도구라 prod 에선 notFound().
+//   force-dynamic 으로 요청 시점 env·데이터 평가.
+// ★ 읽기 전용(SELECT만) · 기존 동작 무변경 · 데이터 0이어도 안전.
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Insights — Playboard",
+  description: "event_logs 기반 퍼널 + UTM 채널 전환율 (raw 직접 집계).",
+  robots: { index: false, follow: false },
+};
+
+const STAGE_BAR: Record<string, string> = {
+  Acquisition: "bg-info",
+  Activation: "bg-success",
+  Referral: "bg-primary",
+  Retention: "bg-warning",
+};
+
+function fmtRate(r: number | null): string {
+  return r === null ? "—" : `${r}%`;
+}
+
+function Bar({ count, max, stage }: { count: number; max: number; stage: string }) {
+  const width = max > 0 ? Math.max((count / max) * 100, count > 0 ? 4 : 0) : 0;
+  return (
+    <div className="h-6 w-full overflow-hidden rounded-sm bg-bg" aria-hidden>
+      <div className={`h-full rounded-sm ${STAGE_BAR[stage] ?? "bg-ink-3"}`} style={{ width: `${width}%` }} />
+    </div>
+  );
+}
+
+function FunnelRow({
+  label,
+  stage,
+  count,
+  max,
+  topCount,
+}: {
+  label: string;
+  stage: string;
+  count: number;
+  max: number;
+  topCount: number;
+}) {
+  const ofTop = topCount > 0 ? Math.round((count / topCount) * 1000) / 10 : null;
+  return (
+    <div className="grid grid-cols-[10rem_1fr_5rem] items-center gap-s-3">
+      <span className="text-caption text-ink-2">{label}</span>
+      <Bar count={count} max={max} stage={stage} />
+      <span className="text-right text-caption-xs text-ink-3">
+        <strong className="text-ink">{count}</strong>
+        {ofTop !== null ? <span className="ml-1 text-ink-3">({ofTop}%)</span> : null}
+      </span>
+    </div>
+  );
+}
+
+function RateCard({
+  title,
+  rate,
+  formula,
+  note,
+}: {
+  title: string;
+  rate: number | null;
+  formula: string;
+  note?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+      <p className="text-caption-xs font-bold text-ink-3">{title}</p>
+      <p className="mt-s-1 text-h2 font-extrabold text-ink">{fmtRate(rate)}</p>
+      <p className="mt-s-1 text-caption-xs leading-relaxed text-ink-3">{formula}</p>
+      {note ? <p className="mt-s-2 text-caption-xs leading-relaxed text-warning">{note}</p> : null}
+    </div>
+  );
+}
+
+export default async function InsightsPage() {
+  if (getDeploymentEnv() === "production") notFound();
+
+  const d: InsightsData = await getInsights();
+  const funnelCounts = FUNNEL_STEPS.map((s) => d.counts[s.key] ?? 0);
+  const otherCounts = OTHER_EVENTS.map((s) => d.counts[s.key] ?? 0);
+  const max = Math.max(1, ...funnelCounts, ...otherCounts);
+  const topCount = d.counts["landing_viewed"] ?? 0;
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-4xl px-s-5 py-s-8 font-sans text-ink">
+      <nav className="text-caption">
+        <Link href="/playboard" className="font-bold text-primary hover:underline">
+          ← Playboard
+        </Link>
+        <span className="px-s-2 text-ink-3">/</span>
+        <span className="text-ink-3">Insights</span>
+      </nav>
+
+      <header className="mt-s-4 border-b border-card-border pb-s-5">
+        <p className="text-caption-xs font-extrabold uppercase tracking-[0.16em] text-primary">운영자 도구 · dev 전용</p>
+        <h1 className="mt-s-2 text-h1 font-extrabold tracking-[-0.02em] text-ink">Insights — 퍼널 · UTM 전환율</h1>
+        <p className="mt-s-2 text-body text-ink-2">
+          <code>event_logs</code> 를 <strong>요청 시점에 직접 집계</strong>(크론 없음). 이 페이지는{" "}
+          <strong>production 에서 차단</strong>(404)되며 <strong>읽기 전용</strong>입니다.
+        </p>
+        <div className="mt-s-3 flex flex-wrap gap-s-2 text-caption-xs">
+          <span className="rounded-sm bg-success-soft px-s-3 py-s-1 font-bold text-success">총 {d.total} 이벤트</span>
+          <span className="rounded-sm bg-info-soft px-s-3 py-s-1 font-bold text-info">UTM 부착 {d.utmRows}</span>
+          {d.span.first ? (
+            <span className="rounded-sm bg-bg px-s-3 py-s-1 text-ink-3">
+              {d.span.first.slice(0, 16).replace("T", " ")} ~ {d.span.last?.slice(11, 16)} UTC
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      {d.total === 0 ? (
+        <section className="mt-s-6 rounded-lg border border-card-border bg-surface p-s-6 text-center shadow-card">
+          <p className="text-body font-bold text-ink">아직 적재된 이벤트가 없습니다.</p>
+          <p className="mt-s-2 text-caption text-ink-2">
+            라이브에서 진단 흐름을 한 번 돌면 <code>event_logs</code> 에 쌓이고, 이 화면에 즉시 반영됩니다.
+          </p>
+        </section>
+      ) : null}
+
+      {/* 11종 퍼널 */}
+      <section aria-label="퍼널" className="mt-s-6">
+        <h2 className="text-h3 font-extrabold text-ink">전환 퍼널 (11종)</h2>
+        <p className="mt-s-1 text-caption-xs text-ink-3">% = 랜딩 노출 대비. 막대 색 = AARRR 단계.</p>
+        <div className="mt-s-4 space-y-s-2">
+          {FUNNEL_STEPS.map((s, i) => (
+            <FunnelRow key={s.key} label={s.label} stage={s.stage} count={funnelCounts[i]} max={max} topCount={topCount} />
+          ))}
+        </div>
+        <p className="mt-s-5 text-caption-xs font-bold text-ink-3">Referral · Retention</p>
+        <div className="mt-s-2 space-y-s-2">
+          {OTHER_EVENTS.map((s, i) => (
+            <FunnelRow key={s.key} label={s.label} stage={s.stage} count={otherCounts[i]} max={max} topCount={topCount} />
+          ))}
+        </div>
+      </section>
+
+      {/* 핵심 전환율 3종 */}
+      <section aria-label="핵심 전환율" className="mt-s-8">
+        <h2 className="text-h3 font-extrabold text-ink">핵심 전환율 (NSM 선행 지표)</h2>
+        <div className="mt-s-4 grid gap-s-3 sm:grid-cols-3">
+          <RateCard
+            title="주소 2건 입력 완료율"
+            rate={d.rates.inputCompletion}
+            formula={`address_verified(2) ${d.addressVerified2} ÷ input_viewed ${d.counts["diagnosis_input_viewed"] ?? 0}`}
+            note="※ 분모(input_viewed) 다회 발화로 왜곡 가능 — distinct 정규화는 후속."
+          />
+          <RateCard
+            title="진단 제출 성공률"
+            rate={d.rates.submitSuccess}
+            formula={`started ${d.counts["diagnosis_started"] ?? 0} ÷ submit_clicked ${d.counts["diagnosis_submit_clicked"] ?? 0}`}
+          />
+          <RateCard
+            title="공유 링크 생성률"
+            rate={d.rates.shareCreation}
+            formula={`share_created ${d.counts["share_link_created"] ?? 0} ÷ completed ${d.counts["diagnosis_completed"] ?? 0}`}
+          />
+        </div>
+      </section>
+
+      {/* UTM 채널별 */}
+      <section aria-label="UTM 채널" className="mt-s-8">
+        <h2 className="text-h3 font-extrabold text-ink">UTM 채널별 전환율</h2>
+        {d.utm.length === 0 ? (
+          <p className="mt-s-3 rounded-lg border border-card-border bg-surface p-s-4 text-caption text-ink-2">
+            UTM 부착 이벤트가 없습니다. <code>?utm_source=…</code> 로 유입된 진단이 있어야 채널이 표시됩니다.
+          </p>
+        ) : (
+          <div className="mt-s-4 overflow-hidden rounded-lg border border-card-border">
+            <table className="w-full text-left text-caption">
+              <thead className="bg-bg text-caption-xs text-ink-3">
+                <tr>
+                  <th className="px-s-4 py-s-2 font-bold">utm_source</th>
+                  <th className="px-s-4 py-s-2 text-right font-bold">landing_viewed</th>
+                  <th className="px-s-4 py-s-2 text-right font-bold">diagnosis_completed</th>
+                  <th className="px-s-4 py-s-2 text-right font-bold">전환율</th>
+                </tr>
+              </thead>
+              <tbody>
+                {d.utm.map((c) => (
+                  <tr key={c.source} className="border-t border-card-border">
+                    <td className="px-s-4 py-s-2 font-bold text-ink">{c.source}</td>
+                    <td className="px-s-4 py-s-2 text-right text-ink-2">{c.landed}</td>
+                    <td className="px-s-4 py-s-2 text-right text-ink-2">{c.completed}</td>
+                    <td className="px-s-4 py-s-2 text-right font-bold text-ink">{fmtRate(c.rate)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <footer className="mt-s-9 border-t border-card-border pt-s-5 text-caption-xs leading-relaxed text-ink-3">
+        ★ 수치는 <strong>이벤트 단위</strong>(세션·방문자 distinct 미적용) — 소표본에선 <code>login_entered</code> 가{" "}
+        <code>landing_viewed</code> 보다 클 수 있음(다회 발화). 정규 전환율(distinct·봇 제외)·가집계/최종집계 크론은{" "}
+        <strong>후속 이슈</strong>(미구현). 본 화면은 raw 직접 집계로 소량 데이터에 충분.
+      </footer>
+    </main>
+  );
+}

--- a/onday-app/src/lib/playboard/insights.ts
+++ b/onday-app/src/lib/playboard/insights.ts
@@ -1,0 +1,111 @@
+// Playboard Insights — event_logs raw 직접 집계 (크론 0, 읽기 전용 SELECT만).
+// ★ event_logs(prod 적재분)를 조회. 발표 전 대시보드의 데이터 계층.
+// ★ 기존 무변경: write 0(groupBy/count/findMany/aggregate = SELECT). 마이그레이션 0.
+// ★ 데이터 0이어도 안전(전부 0/빈 배열 반환).
+
+import { prisma } from "@/lib/db";
+
+// 11종 = 퍼널 7 + Referral·Retention 4 (LOG_IMPLEMENTATION_OUTLINE.md §1·§2 순서).
+export const FUNNEL_STEPS = [
+  { key: "landing_viewed", label: "랜딩 노출", stage: "Acquisition" },
+  { key: "login_entered", label: "로그인 진입", stage: "Acquisition" },
+  { key: "diagnosis_input_viewed", label: "입력 화면", stage: "Activation" },
+  { key: "address_verified", label: "주소 검증", stage: "Activation" },
+  { key: "diagnosis_submit_clicked", label: "제출 클릭", stage: "Activation" },
+  { key: "diagnosis_started", label: "제출 성공", stage: "Activation" },
+  { key: "diagnosis_completed", label: "진단 완료 (Aha · NSM)", stage: "Activation" },
+] as const;
+
+export const OTHER_EVENTS = [
+  { key: "share_link_created", label: "공유 생성", stage: "Referral" },
+  { key: "share_link_clicked", label: "공유 클릭", stage: "Referral" },
+  { key: "saved_search_loaded", label: "조건 불러오기", stage: "Retention" },
+  { key: "deadline_mode_activated", label: "데드라인 활성", stage: "Retention" },
+] as const;
+
+export interface UtmChannel {
+  source: string;
+  landed: number; // landing_viewed
+  completed: number; // diagnosis_completed
+  total: number; // utm 부착 전체 이벤트
+  rate: number | null; // completed/landed %
+}
+
+export interface InsightsData {
+  total: number;
+  counts: Record<string, number>;
+  addressVerified2: number; // count=2 (입력완료율 분자)
+  rates: {
+    inputCompletion: number | null; // address_verified(2) / diagnosis_input_viewed
+    submitSuccess: number | null; // diagnosis_started / diagnosis_submit_clicked
+    shareCreation: number | null; // share_link_created / diagnosis_completed
+  };
+  utm: UtmChannel[];
+  utmRows: number;
+  span: { first: string | null; last: string | null };
+}
+
+const pct = (num: number, den: number): number | null =>
+  den > 0 ? Math.round((num / den) * 1000) / 10 : null;
+
+export async function getInsights(): Promise<InsightsData> {
+  const grouped = await prisma.eventLog.groupBy({ by: ["eventName"], _count: { _all: true } });
+  const counts: Record<string, number> = {};
+  let total = 0;
+  for (const g of grouped) {
+    counts[g.eventName] = g._count._all;
+    total += g._count._all;
+  }
+
+  const addressVerified2 = await prisma.eventLog.count({
+    where: { eventName: "address_verified", count: 2 },
+  });
+
+  const rates = {
+    inputCompletion: pct(addressVerified2, counts["diagnosis_input_viewed"] ?? 0),
+    submitSuccess: pct(counts["diagnosis_started"] ?? 0, counts["diagnosis_submit_clicked"] ?? 0),
+    shareCreation: pct(counts["share_link_created"] ?? 0, counts["diagnosis_completed"] ?? 0),
+  };
+
+  // UTM 채널 — props(JSON)에서 utm_source 추출 후 채널별 집계.
+  const utmRowsRaw = await prisma.eventLog.findMany({
+    where: { NOT: { props: null } },
+    select: { eventName: true, props: true },
+  });
+  const bySource = new Map<string, UtmChannel>();
+  for (const r of utmRowsRaw) {
+    let source = "(unknown)";
+    try {
+      const o = JSON.parse(r.props as string) as { utm_source?: unknown };
+      if (typeof o.utm_source === "string") source = o.utm_source;
+    } catch {
+      // best-effort — 파싱 실패 시 unknown
+    }
+    const ch = bySource.get(source) ?? { source, landed: 0, completed: 0, total: 0, rate: null };
+    ch.total += 1;
+    if (r.eventName === "landing_viewed") ch.landed += 1;
+    if (r.eventName === "diagnosis_completed") ch.completed += 1;
+    bySource.set(source, ch);
+  }
+  const utm = [...bySource.values()]
+    .map((c) => ({ ...c, rate: pct(c.completed, c.landed) }))
+    .sort((a, b) => b.total - a.total);
+
+  const agg = await prisma.eventLog.aggregate({
+    _min: { timestamp: true },
+    _max: { timestamp: true },
+  });
+
+  return {
+    total,
+    counts,
+    addressVerified2,
+    rates,
+    utm,
+    utmRows: utmRowsRaw.length,
+    span: {
+      first: agg._min.timestamp?.toISOString() ?? null,
+      last: agg._max.timestamp?.toISOString() ?? null,
+    },
+  };
+}


### PR DESCRIPTION
## 범위 (발표 전 유일 구현)
`event_logs`(#248·#249·#250로 적재) 를 보는 **운영자 대시보드** `/playboard/insights`. raw 직접 집계(**크론 0**), prod 차단, 읽기 전용.
> 크론·share_link_signup·distinct 정규화는 **이슈 초안만**(`docs/issues/`, 발행은 사용자) — 본 PR 범위 밖.

## 구현 (신규 2파일)
| 파일 | 내용 |
|---|---|
| `src/app/playboard/insights/page.tsx` | RSC — prod 차단(`notFound`)·`force-dynamic`·`robots noindex`, 퍼널/전환율/UTM 렌더, 빈 상태 처리 |
| `src/lib/playboard/insights.ts` | `event_logs` 직접 집계(groupBy/count/findMany/aggregate = **SELECT only**) |

## 화면
1. 헤더(총 이벤트·UTM 부착·구간 배지) 2. **11종 퍼널**(7 funnel + 4 referral/retention, 단계색 막대) 3. **핵심 전환율 3종**(AARRR §3-2) 4. **UTM 채널별 전환율 표** 5. 정직 푸터(이벤트단위·distinct 후속)

## 검증
- `tsc` ✅ / `eslint` ✅
- dev `GET /playboard/insights` → **HTTP 200**, 라이브 48행 렌더(총 48·UTM 9·instagram·전환율 카드)
- 읽기 전용·prod 차단·빈 상태·PII 0 — 코드 검토 확인
- **aztks-ai-peer: GO** (`A:P Z:P T:P K:P S:P`), TOP_FIX(입력완료율 카드 distinct 주의) **반영**

## ★ 안전 (회귀 0)
additive(신규 파일만)·마이그레이션 0·읽기 전용. Mixpanel/Sentry/퍼널/진단/로거 **무변경**. PII 0(utm_source·카운트·timestamp만).

## 문서
- `docs/issues/` 후속 이슈 초안 4종(발행 대기) + `docs/INSIGHTS_DASHBOARD_REPORT.md`(결과·테스트·직접 테스트 시나리오)

🤖 Generated with [Claude Code](https://claude.com/claude-code)