### PR TITLE
feat(playboard): 전환관리 대시보드 더미 시딩 + 확장 계획서 + 이슈 초안

### DIFF
--- a/docs/CONVERSION_DASHBOARD_PLAN.md
+++ b/docs/CONVERSION_DASHBOARD_PLAN.md
@@ -1,0 +1,131 @@
+# OnDay 전환관리 대시보드 확장 계획서 (#251 /playboard/insights 발전)
+
+> 목표: 머지된 `#251 /playboard/insights`(11종 퍼널 + 전환율 3종 + UTM)를 **전환관리 대시보드**로 확장 — **DAU/WAU/MAU** + **AARRR 퍼널 단계별 전환율** + **NSM(주간 진단 완료) + 선행 지표 3종**.
+> ★ 이 문서는 **계획서**다. 구현 0. 발표 일주일 — additive·prod 차단·읽기 전용 유지.
+> 근거(실코드): `src/lib/playboard/insights.ts`·`src/app/playboard/insights/page.tsx`·`prisma/schema.prisma`(EventLog: `visitorId` 익명·`timestamp` 인덱스). 지표 정의: `AARRR_NSM_PROPOSAL.md`·`LOG_IMPLEMENTATION_OUTLINE.md`.
+
+---
+
+## 0. 현황 → 확장 (정직)
+
+| | #251 현재 | 본 계획 확장 |
+|---|----------|--------------|
+| 지표 | 11종 퍼널 카운트 · 전환율 3종 · UTM 채널 | **+ DAU/WAU/MAU · + AARRR 단계 전환율 · + NSM 주간 추세** |
+| 데이터원 | `event_logs`(prod, 48행) 고정 | **소스 토글**(prod 실데이터 ↔ preview 더미 350행) |
+| 집계 | raw 직접(크론 0) | 동일 — raw 직접 유지 |
+| 안전 | prod 차단·읽기전용·additive | 동일 |
+
+**★ 핵심 설계 결정 — 데이터 소스 토글:** 현재 대시보드는 `prisma.eventLog`(prod)만 읽어, Step 1에서 만든 **preview 더미 350행이 화면에 안 보인다**. 발표 데모를 위해 **dev/preview 한정 소스 토글**을 둔다(아래 §4). prod 적재·운영 지표는 그대로 `event_logs`, 데모는 `preview_event_logs`.
+
+---
+
+## 1. 모니터링 지표 ① — DAU/WAU/MAU (서비스 활성)
+
+**정의 (익명 `visitorId` distinct 기준 — PII 0):**
+| 지표 | 정의 | 비고 |
+|------|------|------|
+| DAU | 해당 **일(UTC day)**에 1건 이상 이벤트를 남긴 distinct `visitorId` | 일별 추세 라인 |
+| WAU | 최근 **7일 trailing** distinct `visitorId` | rolling |
+| MAU | 최근 **30일 trailing** distinct `visitorId` | rolling |
+| Stickiness | DAU ÷ MAU × 100 | 재방문 밀도(선택) |
+
+**산출 방식 (raw 직접, 크론 0):**
+```ts
+// getActivity(): event_logs 에서 (visitorId, timestamp) 만 select → JS 집계
+//   - DAU: day → Set<visitorId>.size (최근 N일 배열)
+//   - WAU/MAU: 오늘 기준 trailing window 의 Set<visitorId>.size
+```
+- `visitorId` null(시크릿/차단) 행은 distinct 제외(분모 주의 — §6 갭).
+- 소량(수백~수천 행)이라 단일 `findMany({select:{visitorId,timestamp}})` + JS 충분.
+
+---
+
+## 2. 모니터링 지표 ② — AARRR 퍼널 단계별 전환율
+
+**11종 → AARRR 단계 매핑 (LOG_IMPLEMENTATION_OUTLINE §2 계승):**
+| 단계 | 이벤트 | 단계 전환율(예) |
+|------|--------|----------------|
+| **Acquisition** | landing_viewed · login_entered | login ÷ landing |
+| **Activation** | diagnosis_input_viewed → address_verified(2) → submit_clicked → started → **completed(Aha)** | completed ÷ input |
+| **Referral** | share_link_created · share_link_clicked | created ÷ completed · clicked ÷ created |
+| **Retention** | saved_search_loaded · deadline_mode_activated | (재방문) |
+
+- 기존 #251 퍼널 막대 위에 **단계 경계(Acquisition/Activation/Referral/Retention) 그룹 헤더 + 단계 전환율** 추가.
+- 핵심 전환율 3종(이미 구현)은 Activation/Referral의 대표 지표로 재배치.
+
+---
+
+## 3. 모니터링 지표 ③ — NSM + 선행 지표 3종
+
+- **🌟 NSM = 주간 진단 완료 수** = `COUNT(diagnosis_completed)` per ISO week. 목표선 50→200(REQ-NF-026, `AARRR_NSM_PROPOSAL §1-1`) 오버레이.
+- **주간 추세** = 최근 8~12주 라인(주별 버킷, `timestamp` group).
+- **선행 지표 3종(이미 구현, 재노출):** 주소 2건 입력 완료율 · 진단 제출 성공률 · 공유 링크 생성률(AARRR §3-2 수식).
+- NSM 추세는 distinct 아님(이벤트 카운트) — 완료는 `diagnosisId` 기준 중복 제거 권장(§6 갭).
+
+---
+
+## 4. ★ 데이터 소스 토글 설계 (preview 더미 데모)
+
+**문제:** 대시보드가 `event_logs`(prod)만 읽음 → preview 더미 350행 비가시.
+
+**설계 (dev/preview 한정, prod 영향 0):**
+- `getInsights(source: "prod" | "preview")` + 신규 `getActivity(source)` — `source==="preview"`면 `prisma.previewEventLog`, 아니면 `prisma.eventLog`.
+- 페이지는 **production 만 차단**(`getDeploymentEnv()==="production" → notFound`). ⚠️ **정직 표기: `preview` 배포는 차단 안 됨** — Vercel preview URL에서는 렌더+토글이 동작하고 `robots noindex`만 걸린다(접근 차단 아님). "운영(production) 노출 0"은 맞으나 "preview 노출 0"은 **아니다**. preview도 막으려면 차단을 `!== "development"`로 넓히는 별도 결정 필요(§6 갭).
+- UI: `?source=preview` 쿼리(또는 상단 탭) → dev/preview에서 더미로 데모, 기본은 `prod`.
+- **안전:** 읽기 전용(SELECT). preview/prod 양쪽 다 write 0. 토글은 **읽는 테이블만** 바꿈.
+
+```
+/playboard/insights            → prod event_logs (실 48행)
+/playboard/insights?source=preview → preview_event_logs (더미 350행, 데모)
+```
+
+---
+
+## 5. #251 확장 — 화면 구성(안)
+
+```mermaid
+flowchart TB
+  H["헤더 + 소스 토글(prod/preview·dev only)"]:::h
+  H --> ACT["① 활성: DAU/WAU/MAU 카드 + DAU 일별 라인"]:::a
+  ACT --> NSM["② NSM: 주간 진단완료 추세(목표 50/200) + 선행 3종"]:::n
+  NSM --> FUN["③ AARRR 퍼널: 단계 그룹 + 단계 전환율(기존 11종 막대 확장)"]:::f
+  FUN --> UTM["④ UTM 채널별 전환율(기존)"]:::u
+  classDef h fill:#EEE,stroke:#999,color:#333;
+  classDef a fill:#CDEFFD,stroke:#3FA9F5,color:#0A3055;
+  classDef n fill:#FFD166,stroke:#E8A800,color:#5A4100;
+  classDef f fill:#B4F8C8,stroke:#2EAE63,color:#0A3D24;
+  classDef u fill:#E9D5FA,stroke:#A65DD8,color:#3D1A57;
+```
+- 추가 데이터 함수: `getActivity()`(DAU/WAU/MAU), `getNsmTrend()`(주간). 기존 `getInsights()`는 `source` 인자만 추가(시그니처 확장, 호출부 기본값 유지 → 회귀 0).
+- 렌더: 기존 RSC 단일 페이지에 섹션 추가. 차트는 단순 CSS 막대/라인(외부 차트 lib 0, 의존성 추가 없음).
+
+---
+
+## 6. 미구현 갭 (정직)
+
+| 항목 | 상태 |
+|------|------|
+| distinct 정규화·봇 제외 | ⚠️ DAU/WAU/MAU는 visitorId distinct지만, 퍼널/NSM은 이벤트 카운트(완료는 diagnosisId 중복제거 권장) → [distinct-normalization](issues/distinct-normalization.md) |
+| visitorId null 처리 | ⚠️ 시크릿/차단 시 null → distinct 제외(과소 집계 가능), 화면 주석 표기 |
+| **preview 배포 노출** | ⚠️ `notFound`는 production만 차단 → **preview URL에서 대시보드 렌더됨**(noindex만). 운영(prod) 노출 0은 맞으나 preview 접근차단 아님. preview까지 막으려면 차단 조건 `!== "development"` 확장 별도 결정 |
+| NSM 완료 distinct | ⚠️ `diagnosisId` 기준 중복제거 권장이나 **nullable·FK 없음** → null 행은 dedup 누수 → null이면 행 카운트 폴백 |
+| 가집계/최종집계 크론 | ❌ 미구현 — raw 직접으로 충분한 규모 전제 → [cron-aggregation](issues/cron-aggregation.md) |
+| NSM 목표선 데이터 | 50/200은 상수(REQ-NF-026), 실측 추세와 병치 |
+| 표본 | 더미 350행/prod 48행 — 구조 검증용, 통계 신뢰는 데이터 축적 후 |
+
+---
+
+## 7. 구현 로드맵 (승인 후 — additive 단계)
+
+| 단계 | 내용 | 위험 |
+|------|------|------|
+| E1 | `getActivity()`(DAU/WAU/MAU) + 카드/라인 섹션 | 🟢 읽기전용·추가만 |
+| E2 | 소스 토글(`source` 인자 + `?source=preview`) | 🟢 dev 한정·prod 차단 안 |
+| E3 | NSM 주간 추세 + AARRR 단계 그룹 헤더 | 🟢 기존 퍼널 위 추가 |
+| (E4) | distinct 정규화 | 🟡 후속 이슈 |
+
+- 전 단계 회귀 0: 신규 함수·섹션 추가, `getInsights()` 시그니처는 기본값으로 하위호환, 마이그레이션 0, prod 차단·읽기전용 유지.
+
+---
+
+*근거: 실코드 `insights.ts`·`page.tsx`·`schema.prisma`(EventLog visitorId/timestamp). 더미 350행(preview, Step 1). 지표 정의 AARRR_NSM_PROPOSAL·LOG_IMPLEMENTATION_OUTLINE.*

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -5,9 +5,12 @@
 
 | 초안 | 우선순위 | 발표 전/후 | 상태 |
 |------|----------|-----------|------|
-| [dashboard-insights.md](dashboard-insights.md) | 🟢 높음 | **발표 전** | Draft PR 구현됨(`/playboard/insights`) |
+| [dashboard-insights.md](dashboard-insights.md) | 🟢 높음 | **발표 전** | Draft PR #251(`/playboard/insights`) |
+| [dashboard-conversion-extension.md](dashboard-conversion-extension.md) | 🟢 높음 | 발표 전/직후 | 계획 완료(CONVERSION_DASHBOARD_PLAN.md), 구현 대기 |
+| [preview-dummy-seeding.md](preview-dummy-seeding.md) | 🟢 높음 | 발표 전 | 구현됨(seed-preview-events.ts), Draft PR 연결 |
 | [cron-aggregation.md](cron-aggregation.md) | 🟡 중 | 발표 후 | 미구현(설계만) |
+| [preview-access-block.md](preview-access-block.md) | ⚪ 낮음 | 선택 | 미구현(결정 대기) |
 | [share-link-signup.md](share-link-signup.md) | ⚪ 낮음 | 발표 후 | 미배선(attribution 갭) |
 | [distinct-normalization.md](distinct-normalization.md) | ⚪ 낮음 | 발표 후 | 미구현 |
 
-**발행 순서 제안:** dashboard(구현 완료→PR 연결) → cron → distinct → share_signup.
+**발행 순서 제안:** dashboard-insights(#251) → preview-dummy-seeding → dashboard-conversion-extension → cron → distinct → preview-access-block → share_signup.

--- a/docs/issues/dashboard-conversion-extension.md
+++ b/docs/issues/dashboard-conversion-extension.md
@@ -1,0 +1,27 @@
+---
+title: "feat(playboard): insights → 전환관리 대시보드 확장 (DAU/WAU/MAU · AARRR 단계 · NSM)"
+labels: [enhancement, observability, playboard]
+priority: 🟢 높음 (발표 전/직후)
+status: 계획 완료 — 구현 대기 (docs/CONVERSION_DASHBOARD_PLAN.md)
+---
+
+## 배경
+머지된 `#251 /playboard/insights`는 11종 퍼널 + 전환율 3종 + UTM만 보여준다. 전환관리 대시보드로 쓰려면 **서비스 활성(DAU/WAU/MAU)** · **AARRR 단계 전환율** · **NSM(주간 진단완료) 추세**가 필요하다. 설계: `docs/CONVERSION_DASHBOARD_PLAN.md`.
+
+## 작업 (additive, raw 직접 집계 — 크론 0)
+- **E1** `getActivity()` — `event_logs`에서 익명 `visitorId` distinct로 DAU(일별 라인)·WAU(7일)·MAU(30일) + 카드 섹션.
+- **E2** 데이터 소스 토글 — `getInsights(source)` + `?source=preview` → dev/preview 더미 데모, 기본 prod. 읽는 테이블만 교체(write 0).
+- **E3** NSM 주간 추세(목표선 50→200, REQ-NF-026) + AARRR 단계 그룹 헤더/전환율.
+
+## 수용 기준 (AC)
+- [ ] DAU/WAU/MAU = distinct `visitorId`, null 제외 주석.
+- [ ] NSM = 주간 `diagnosis_completed`(diagnosisId 중복제거, null이면 행 카운트 폴백).
+- [ ] `getInsights(source?)` 기본값 prod → 기존 호출부 무변경(회귀 0).
+- [ ] 데이터 0·preview/prod 양쪽 안전. 읽기 전용. 마이그레이션 0.
+
+## ★ 안전·갭 (정직)
+- `notFound`는 **production만** 차단 — **preview 배포는 렌더됨**(noindex만). preview까지 막으려면 [preview-access-block](preview-access-block.md).
+- distinct 정규화·봇 제외는 [distinct-normalization](distinct-normalization.md).
+
+## 의존
+- 더미 데모 데이터: [preview-dummy-seeding](preview-dummy-seeding.md).

--- a/docs/issues/preview-access-block.md
+++ b/docs/issues/preview-access-block.md
@@ -1,0 +1,21 @@
+---
+title: "chore(playboard): 운영자 도구 preview 배포 접근 차단 검토 (notFound 조건 확장)"
+labels: [security, observability, playboard]
+priority: ⚪ 낮음 (선택)
+status: 미구현 — 결정 대기
+---
+
+## 배경
+`/playboard/insights`(및 `logging-test`)는 `getDeploymentEnv()==="production" → notFound`로 **production만** 차단한다. 따라서 **Vercel preview 배포 URL에서는 대시보드가 렌더된다**(`robots noindex`만, 접근 차단 아님). 운영자 전용 지표·더미 데이터가 preview URL을 아는 사람에게 노출될 수 있다.
+
+## 작업 (결정 후)
+- 차단 조건을 `getDeploymentEnv() !== "development"`로 확장(preview도 notFound) — 단, preview에서 데모해야 하면 충돌 → 트레이드오프.
+- 또는 preview는 허용하되 간단한 운영자 게이트(헤더/쿼리 토큰) 추가.
+
+## ★ 트레이드오프 (정직)
+- preview 차단 = 안전하나 preview 데모 불가. preview 허용 = 데모 가능하나 노출.
+- 발표 데모를 preview로 한다면 **차단하지 말 것**. 데모를 로컬(dev)로만 한다면 차단 권장.
+
+## 수용 기준 (AC)
+- [ ] 결정: preview 차단 여부 + 사유 문서화.
+- [ ] 선택 시 `logging-test`도 동일 정책 적용(일관성).

--- a/docs/issues/preview-dummy-seeding.md
+++ b/docs/issues/preview-dummy-seeding.md
@@ -1,0 +1,26 @@
+---
+title: "chore(playboard): preview_event_logs 더미 이벤트 시딩 스크립트 (데모/테스트)"
+labels: [tooling, observability, playboard]
+priority: 🟢 높음 (발표 전 — 데모용)
+status: 구현됨 — Draft PR 연결 예정 (scripts/seed-preview-events.ts)
+---
+
+## 배경
+전환관리 대시보드 데모/개발 테스트에 쓸 **개연성 있는 더미 이벤트**가 필요하다. prod `event_logs`(실데이터)는 절대 오염하면 안 되므로 격리 사본 `preview_event_logs`에만 적재한다.
+
+## 작업
+- `scripts/seed-preview-events.ts` — 방문자 80명, ~350행, funnel drop-off + UTM 채널 + 30일 분산.
+- **고정 시드 PRNG(mulberry32)** → 재실행 시 동일 분포(데모 재현성, `started > completed` 결정적).
+- 재실행 안전: `visitorId` 프리픽스 `seed_` 행만 삭제 후 재생성.
+
+## 수용 기준 (AC)
+- [x] `previewEventLog`에만 write — prod `event_logs` 미접근(`eventLog.count()`만 읽음).
+- [x] PII 0 — props=utm 5종만, visitorId/diagnosisId 익명 합성(`seed_*`).
+- [x] 11종 이벤트 분포·30 고유일자(DAU/WAU/MAU 산출 가능).
+- [x] 재실행 결정적(2회 동일 확인).
+
+## ★ 안전
+- 격리(preview 전용)·PII 0·재현성. 실행: `npx tsx scripts/seed-preview-events.ts`. 정리: seed_ 행 deleteMany.
+
+## 검토
+- 1차 aztks evaluate: GO (TOP_FIX=시드 PRNG 반영 완료).

--- a/onday-app/scripts/seed-preview-events.ts
+++ b/onday-app/scripts/seed-preview-events.ts
@@ -1,0 +1,172 @@
+// 개발 테스트·데모용 더미 이벤트 시딩 — preview_event_logs 전용.
+// ★★ prod event_logs 절대 미접근(격리). ★ PII 0: 익명 visitorId·utm·mode·method·count만.
+// ★ 재실행 안전: visitorId 프리픽스 "seed_" 행만 지우고 재생성(실/타 데이터 무관).
+// 실행: npx tsx scripts/seed-preview-events.ts
+//
+// 개연성: 유입→이탈→완료 funnel drop-off + UTM 채널 + 30일 분산(DAU/WAU/MAU 데모용).
+
+import { config } from "dotenv";
+config({ path: [".env.local", ".env"] });
+import { PrismaClient } from "../src/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DIRECT_URL ?? process.env.DATABASE_URL }),
+});
+
+const SEED_PREFIX = "seed_";
+const N_VISITORS = 80;
+const SPAN_DAYS = 30;
+
+// ★ 고정 시드 PRNG(mulberry32) — 재실행 시 동일 분포 재현(데모 재현성·결정적 funnel drop-off).
+//   timestamp 의 now 앵커만 실행시각에 따라가고, 모든 확률 분기는 결정적.
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const rand = mulberry32(20260623);
+
+// UTM 채널 가중(direct=utm 없음). 합 1.0.
+const UTM_CHANNELS: { source: string; medium: string; campaign: string; w: number }[] = [
+  { source: "instagram", medium: "social", campaign: "spring_launch", w: 0.22 },
+  { source: "naver", medium: "cpc", campaign: "brand_kw", w: 0.18 },
+  { source: "kakao", medium: "social", campaign: "moment", w: 0.13 },
+  { source: "google", medium: "cpc", campaign: "search_generic", w: 0.07 },
+];
+const DIRECT_RATE = 0.4; // 40% 직접 유입(utm 없음)
+
+// funnel 단계별 "직전 도달자 중 다음 도달 확률".
+const RET = {
+  login: 0.72,
+  input: 0.8,
+  addr1: 0.85,
+  addr2: 0.82, // couple 만(주소 B)
+  submit: 0.85,
+  started: 0.92,
+  completed: 0.93,
+  shareCreated: 0.3,
+  shareClicked: 0.45,
+  savedLater: 0.2, // 완료자 중 재방문 불러오기
+  deadlineLater: 0.15,
+};
+
+type Row = {
+  eventName: string;
+  timestamp: Date;
+  mode?: string | null;
+  method?: string | null;
+  count?: number | null;
+  daysLeft?: number | null;
+  diagnosisId?: string | null;
+  visitorId: string;
+  props?: string | null;
+};
+
+function hit(p: number): boolean {
+  return rand() < p;
+}
+function pickUtm(): { source: string; medium: string; campaign: string } | null {
+  if (rand() < DIRECT_RATE) return null;
+  let r = rand() * UTM_CHANNELS.reduce((s, c) => s + c.w, 0);
+  for (const c of UTM_CHANNELS) {
+    if ((r -= c.w) <= 0) return { source: c.source, medium: c.medium, campaign: c.campaign };
+  }
+  return UTM_CHANNELS[0];
+}
+
+function buildRows(): Row[] {
+  const now = Date.now();
+  const rows: Row[] = [];
+
+  for (let i = 0; i < N_VISITORS; i++) {
+    const visitorId = `${SEED_PREFIX}v_${String(i).padStart(3, "0")}`;
+    const mode = hit(0.7) ? "couple" : "single";
+    const utm = pickUtm();
+    const props = utm
+      ? JSON.stringify({ utm_source: utm.source, utm_medium: utm.medium, utm_campaign: utm.campaign })
+      : null;
+
+    // 세션 시작 시각: 최근 SPAN_DAYS 내(결정적 분포, now 앵커만 실행시각).
+    const sessionStart = now - Math.floor(rand() * SPAN_DAYS * 864e5);
+    let t = sessionStart;
+    const step = () => {
+      t += (30 + Math.floor(rand() * 270)) * 1000; // 0.5~5분 간격
+      return new Date(t);
+    };
+
+    // ① landing (전원) — utm props 부착.
+    rows.push({ eventName: "landing_viewed", timestamp: step(), visitorId, props });
+    // ② login
+    if (!hit(RET.login)) continue;
+    const method = (() => {
+      const r = rand();
+      return r < 0.5 ? "kakao" : r < 0.9 ? "guest" : "reviewer";
+    })();
+    rows.push({ eventName: "login_entered", timestamp: step(), method, visitorId, props });
+    // ③ input
+    if (!hit(RET.input)) continue;
+    rows.push({ eventName: "diagnosis_input_viewed", timestamp: step(), mode, visitorId, props });
+    // ④ address A
+    if (!hit(RET.addr1)) continue;
+    rows.push({ eventName: "address_verified", timestamp: step(), count: 1, visitorId, props });
+    // 주소 B(couple 만)
+    if (mode === "couple" && hit(RET.addr2)) {
+      rows.push({ eventName: "address_verified", timestamp: step(), count: 2, visitorId, props });
+    }
+    // ⑤ submit
+    if (!hit(RET.submit)) continue;
+    rows.push({ eventName: "diagnosis_submit_clicked", timestamp: step(), mode, visitorId, props });
+    // ⑥ started
+    if (!hit(RET.started)) continue;
+    const diagnosisId = `${SEED_PREFIX}dx_${String(i).padStart(3, "0")}`;
+    rows.push({ eventName: "diagnosis_started", timestamp: step(), diagnosisId, visitorId, props });
+    // ⑦ completed (Aha)
+    if (!hit(RET.completed)) continue;
+    rows.push({ eventName: "diagnosis_completed", timestamp: step(), diagnosisId, visitorId, props });
+
+    // Referral — couple 이 공유 동기 ↑.
+    const shareP = mode === "couple" ? RET.shareCreated : RET.shareCreated * 0.4;
+    if (hit(shareP)) {
+      rows.push({ eventName: "share_link_created", timestamp: step(), mode, diagnosisId, visitorId, props });
+      if (hit(RET.shareClicked)) {
+        rows.push({ eventName: "share_link_clicked", timestamp: step(), mode, visitorId, props });
+      }
+    }
+    // Retention — 다른 날 재방문.
+    if (hit(RET.savedLater)) {
+      const later = new Date(t + (1 + Math.floor(rand() * 13)) * 864e5);
+      rows.push({ eventName: "saved_search_loaded", timestamp: later, mode, visitorId, props });
+    }
+    if (hit(RET.deadlineLater)) {
+      const later = new Date(t + (1 + Math.floor(rand() * 20)) * 864e5);
+      rows.push({ eventName: "deadline_mode_activated", timestamp: later, daysLeft: 7 + Math.floor(rand() * 50), visitorId, props });
+    }
+  }
+  return rows;
+}
+
+async function main() {
+  // ★ 안전 가드: prod 절대 미접근. seed_ 행만 정리 후 재생성.
+  const removed = await prisma.previewEventLog.deleteMany({ where: { visitorId: { startsWith: SEED_PREFIX } } });
+  const rows = buildRows();
+  await prisma.previewEventLog.createMany({ data: rows });
+
+  const total = await prisma.previewEventLog.count();
+  const byName = await prisma.previewEventLog.groupBy({ by: ["eventName"], _count: { _all: true } });
+  console.log(`정리(seed_): ${removed.count}행 → 시딩: ${rows.length}행 | preview_event_logs 총 ${total}행`);
+  console.log("이벤트별:", JSON.stringify(byName.map((r) => ({ e: r.eventName, n: r._count._all }))));
+  console.log("prod event_logs(미접근 확인):", await prisma.eventLog.count());
+  await prisma.$disconnect();
+}
+
+main().catch(async (e) => {
+  console.error("SEED FAIL:", e?.message ?? e);
+  await prisma.$disconnect();
+  process.exit(1);
+});


### PR DESCRIPTION
## 범위 (#251 머지 후속 — 계획·도구·이슈)
머지된 `#251 /playboard/insights`를 **전환관리 대시보드**로 확장하기 위한 **더미 시딩 도구 + 확장 계획서 + 후속 이슈 초안**. ★ 발표 전 실제 구현은 #251(대시보드)까지였고, 본 PR은 **확장 계획·데모 도구·이슈 초안만**(대시보드 확장 코드는 미구현 — 이슈로 발행 대기).

## 변경 (6파일, +382)
| 파일 | 내용 |
|---|---|
| `onday-app/scripts/seed-preview-events.ts` | **preview_event_logs 전용** 더미(80명·~350행), 고정 시드 PRNG(재현성), PII 0, **prod `event_logs` 미접근** |
| `docs/CONVERSION_DASHBOARD_PLAN.md` | DAU/WAU/MAU + AARRR 단계 전환율 + NSM + 데이터 소스 토글 설계(raw 직접·크론 0) |
| `docs/issues/*` | 신규 초안 3종(대시보드 확장·더미 시딩·preview 차단) + README 갱신 |

## 안전 (회귀 0)
- 더미는 **preview만** — prod `event_logs`(실 48행) 무변경. 시딩 스크립트는 `previewEventLog`만 write, `eventLog`는 count만 read.
- 읽기/도구 위주, **마이그레이션 0**. Mixpanel/Sentry/#251/로거/진단 무변경.
- PII 0: props=utm 5종, visitorId/diagnosisId 익명 합성(`seed_*`).

## 검토 (aztks-agent EVALUATE 2회)
- 더미 데이터: **GO** — TOP_FIX(시드 PRNG로 재현성·`started>completed`) 반영.
- 확장 계획서: **GO** — TOP_FIX(`notFound`는 production만 차단 → **preview 배포는 렌더됨**, noindex만) 정직 표기 반영 + NSM diagnosisId null 폴백 갭 추가.

## 미구현 갭 (정직)
- 대시보드 확장(DAU/WAU/MAU·NSM·AARRR 단계)·크론·distinct·preview 차단·share_signup = **이슈 초안만**, 구현 X.

> 발행·머지는 사용자 직접. `docs/issues/` 7종 발행 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)