### PR TITLE
feat(playboard): insights 데이터 소스 토글 (E2) — ?source=preview 더미 데모

### DIFF
--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getDeploymentEnv } from "@/lib/health";
-import { getInsights, FUNNEL_STEPS, OTHER_EVENTS, type InsightsData } from "@/lib/playboard/insights";
+import { getInsights, FUNNEL_STEPS, OTHER_EVENTS, type InsightsData, type InsightsSource } from "@/lib/playboard/insights";
 
 // Insights 대시보드 — event_logs raw 직접 집계(크론 0). 운영자 도구.
 // ★ production 차단(logging-test 패턴): 운영자만 보는 도구라 prod 에선 notFound().
@@ -85,10 +85,17 @@ function RateCard({
   );
 }
 
-export default async function InsightsPage() {
+export default async function InsightsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ source?: string }>;
+}) {
   if (getDeploymentEnv() === "production") notFound();
 
-  const d: InsightsData = await getInsights();
+  // ★ 소스 토글 — ?source=preview 면 더미(preview_event_logs), 기본 prod(event_logs).
+  const sp = await searchParams;
+  const source: InsightsSource = sp.source === "preview" ? "preview" : "prod";
+  const d: InsightsData = await getInsights(source);
   const funnelCounts = FUNNEL_STEPS.map((s) => d.counts[s.key] ?? 0);
   const otherCounts = OTHER_EVENTS.map((s) => d.counts[s.key] ?? 0);
   const max = Math.max(1, ...funnelCounts, ...otherCounts);
@@ -112,6 +119,13 @@ export default async function InsightsPage() {
           <strong>production 에서 차단</strong>(404)되며 <strong>읽기 전용</strong>입니다.
         </p>
         <div className="mt-s-3 flex flex-wrap gap-s-2 text-caption-xs">
+          <span
+            className={`rounded-sm px-s-3 py-s-1 font-bold ${
+              source === "preview" ? "bg-warning-soft text-warning" : "bg-bg text-ink-3"
+            }`}
+          >
+            소스: {source === "preview" ? "preview(더미)" : "prod(실데이터)"}
+          </span>
           <span className="rounded-sm bg-success-soft px-s-3 py-s-1 font-bold text-success">총 {d.total} 이벤트</span>
           <span className="rounded-sm bg-info-soft px-s-3 py-s-1 font-bold text-info">UTM 부착 {d.utmRows}</span>
           {d.span.first ? (

--- a/onday-app/src/lib/playboard/insights.ts
+++ b/onday-app/src/lib/playboard/insights.ts
@@ -48,8 +48,15 @@ export interface InsightsData {
 const pct = (num: number, den: number): number | null =>
   den > 0 ? Math.round((num / den) * 1000) / 10 : null;
 
-export async function getInsights(): Promise<InsightsData> {
-  const grouped = await prisma.eventLog.groupBy({ by: ["eventName"], _count: { _all: true } });
+// 데이터 소스 — prod=event_logs(실), preview=preview_event_logs(더미 데모).
+// ★ 읽는 테이블만 교체(write 0). preview 는 dev/preview 에서만 의미(페이지가 prod 차단).
+export type InsightsSource = "prod" | "preview";
+
+export async function getInsights(source: InsightsSource = "prod"): Promise<InsightsData> {
+  // 두 모델은 스키마 동일(필드·인덱스) — preview 델리게이트를 eventLog 타입으로 캐스팅해 읽기만 분기.
+  const model = (source === "preview" ? prisma.previewEventLog : prisma.eventLog) as typeof prisma.eventLog;
+
+  const grouped = await model.groupBy({ by: ["eventName"], _count: { _all: true } });
   const counts: Record<string, number> = {};
   let total = 0;
   for (const g of grouped) {
@@ -57,7 +64,7 @@ export async function getInsights(): Promise<InsightsData> {
     total += g._count._all;
   }
 
-  const addressVerified2 = await prisma.eventLog.count({
+  const addressVerified2 = await model.count({
     where: { eventName: "address_verified", count: 2 },
   });
 
@@ -68,7 +75,7 @@ export async function getInsights(): Promise<InsightsData> {
   };
 
   // UTM 채널 — props(JSON)에서 utm_source 추출 후 채널별 집계.
-  const utmRowsRaw = await prisma.eventLog.findMany({
+  const utmRowsRaw = await model.findMany({
     where: { NOT: { props: null } },
     select: { eventName: true, props: true },
   });
@@ -91,7 +98,7 @@ export async function getInsights(): Promise<InsightsData> {
     .map((c) => ({ ...c, rate: pct(c.completed, c.landed) }))
     .sort((a, b) => b.total - a.total);
 
-  const agg = await prisma.eventLog.aggregate({
+  const agg = await model.aggregate({
     _min: { timestamp: true },
     _max: { timestamp: true },
   });


### PR DESCRIPTION
## 범위 (CONVERSION_DASHBOARD_PLAN §4 — E2)
`/playboard/insights`에 **데이터 소스 토글**. `?source=preview` → `preview_event_logs`(더미 350행) 읽기, 기본은 `prod`(`event_logs` 실 48행). dev/preview에서 더미 데모·분포 점검 가능.

## 변경 (2파일)
| 파일 | 내용 |
|---|---|
| `src/lib/playboard/insights.ts` | `getInsights(source: "prod"\|"preview" = "prod")` — 읽는 델리게이트만 교체(preview→eventLog 타입 캐스팅, 스키마 동일). 4개 쿼리(groupBy/count/findMany/aggregate) 동일 로직 |
| `src/app/playboard/insights/page.tsx` | `?source=preview` 수신 + 소스 표시 칩(prod 실데이터 / preview 더미) |

## 검증 (dev 실측)
| 진입 | total | 소스 칩 |
|---|---|---|
| `/playboard/insights` (기본) | **총 48** (prod, 기존 동일) | `prod(실데이터)` |
| `/playboard/insights?source=preview` | **총 350** (더미) | `preview(더미)` |
- preview에서 instagram/naver/kakao/google 채널 표시(더미 UTM).
- `tsc` ✅ / `eslint` ✅

## ★ 안전 (회귀 0)
- **읽는 테이블만 교체** — write 0, 마이그레이션 0, 집계 로직·기존 화면 무변경.
- `source` 없으면 prod 48행 = **기존 동작 동일**.
- prod 차단(`notFound`) 유지. (preview 배포 노출은 기존 한계 그대로 — 별도 이슈 `preview-access-block`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)