### PR TITLE
feat(playboard): insights DAU/WAU/MAU 활성 지표 (E1)

### DIFF
--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -3,7 +3,15 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getDeploymentEnv } from "@/lib/health";
-import { getInsights, FUNNEL_STEPS, OTHER_EVENTS, type InsightsData, type InsightsSource } from "@/lib/playboard/insights";
+import {
+  getInsights,
+  getActivity,
+  FUNNEL_STEPS,
+  OTHER_EVENTS,
+  type InsightsData,
+  type ActivityData,
+  type InsightsSource,
+} from "@/lib/playboard/insights";
 
 // Insights 대시보드 — event_logs raw 직접 집계(크론 0). 운영자 도구.
 // ★ production 차단(logging-test 패턴): 운영자만 보는 도구라 prod 에선 notFound().
@@ -96,6 +104,8 @@ export default async function InsightsPage({
   const sp = await searchParams;
   const source: InsightsSource = sp.source === "preview" ? "preview" : "prod";
   const d: InsightsData = await getInsights(source);
+  const act: ActivityData = await getActivity(source);
+  const dauMax = Math.max(1, ...act.dau.map((x) => x.visitors));
   const funnelCounts = FUNNEL_STEPS.map((s) => d.counts[s.key] ?? 0);
   const otherCounts = OTHER_EVENTS.map((s) => d.counts[s.key] ?? 0);
   const max = Math.max(1, ...funnelCounts, ...otherCounts);
@@ -145,8 +155,62 @@ export default async function InsightsPage({
         </section>
       ) : null}
 
+      {/* 활성 지표 (E1) — DAU/WAU/MAU */}
+      <section aria-label="활성 지표" className="mt-s-6">
+        <h2 className="text-h3 font-extrabold text-ink">서비스 활성 (DAU/WAU/MAU)</h2>
+        <p className="mt-s-1 text-caption-xs text-ink-3">
+          익명 <code>visitorId</code> distinct 기준. WAU=최근 7일·MAU=최근 30일 trailing.
+        </p>
+        <div className="mt-s-4 grid gap-s-3 sm:grid-cols-3">
+          <div className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+            <p className="text-caption-xs font-bold text-ink-3">
+              DAU{act.latestDau ? ` · ${act.latestDau.date}` : " (최근 활동일)"}
+            </p>
+            <p className="mt-s-1 text-h2 font-extrabold text-ink">{act.latestDau?.visitors ?? 0}</p>
+            <p className="mt-s-1 text-caption-xs text-ink-3">최근 활동일 distinct 방문자</p>
+          </div>
+          <div className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+            <p className="text-caption-xs font-bold text-ink-3">WAU (7일)</p>
+            <p className="mt-s-1 text-h2 font-extrabold text-ink">{act.wau}</p>
+            <p className="mt-s-1 text-caption-xs text-ink-3">최근 7일 distinct 방문자</p>
+          </div>
+          <div className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+            <p className="text-caption-xs font-bold text-ink-3">MAU (30일)</p>
+            <p className="mt-s-1 text-h2 font-extrabold text-ink">{act.mau}</p>
+            <p className="mt-s-1 text-caption-xs text-ink-3">최근 30일 distinct 방문자</p>
+          </div>
+        </div>
+
+        {act.dau.length > 0 ? (
+          <div className="mt-s-4">
+            <p className="text-caption-xs font-bold text-ink-3">일별 DAU (최근 {act.dau.length}일 · 데이터 있는 날)</p>
+            <div className="mt-s-2 flex h-24 items-end gap-0.5" aria-hidden>
+              {act.dau.map((x) => (
+                <div
+                  key={x.date}
+                  className="flex-1 rounded-t-xs bg-info"
+                  style={{ height: `${Math.max((x.visitors / dauMax) * 100, 6)}%` }}
+                  title={`${x.date}: ${x.visitors}`}
+                />
+              ))}
+            </div>
+            <div className="mt-s-1 flex justify-between text-caption-xs text-ink-3">
+              <span>{act.dau[0].date}</span>
+              <span>최대 {dauMax}명/일</span>
+              <span>{act.dau[act.dau.length - 1].date}</span>
+            </div>
+          </div>
+        ) : null}
+
+        {act.nullVisitorRows > 0 ? (
+          <p className="mt-s-2 text-caption-xs text-warning">
+            ※ visitorId 없는 {act.nullVisitorRows}행(시크릿/차단)은 distinct 제외 — 과소 집계 가능.
+          </p>
+        ) : null}
+      </section>
+
       {/* 11종 퍼널 */}
-      <section aria-label="퍼널" className="mt-s-6">
+      <section aria-label="퍼널" className="mt-s-8 border-t border-card-border pt-s-6">
         <h2 className="text-h3 font-extrabold text-ink">전환 퍼널 (11종)</h2>
         <p className="mt-s-1 text-caption-xs text-ink-3">% = 랜딩 노출 대비. 막대 색 = AARRR 단계.</p>
         <div className="mt-s-4 space-y-s-2">

--- a/onday-app/src/lib/playboard/insights.ts
+++ b/onday-app/src/lib/playboard/insights.ts
@@ -116,3 +116,61 @@ export async function getInsights(source: InsightsSource = "prod"): Promise<Insi
     },
   };
 }
+
+// ── 활성 지표 (E1) — DAU/WAU/MAU. 익명 visitorId distinct 기준(PII 0), raw 직접(크론 0). ──
+const DAU_WINDOW_DAYS = 30;
+const DAY_MS = 86_400_000;
+
+export interface ActivityData {
+  dau: { date: string; visitors: number }[]; // 최근 DAU_WINDOW_DAYS 일(데이터 있는 날)
+  latestDau: { date: string; visitors: number } | null; // 최근 활동일 DAU
+  wau: number; // 최근 7일 trailing distinct
+  mau: number; // 최근 30일 trailing distinct
+  totalVisitors: number; // 전체 distinct(참고)
+  nullVisitorRows: number; // visitorId null(distinct 제외) — 과소집계 주석용
+}
+
+export async function getActivity(source: InsightsSource = "prod"): Promise<ActivityData> {
+  const model = (source === "preview" ? prisma.previewEventLog : prisma.eventLog) as typeof prisma.eventLog;
+  const rows = await model.findMany({ select: { visitorId: true, timestamp: true } });
+
+  const now = Date.now();
+  const perDay = new Map<string, Set<string>>();
+  const wauSet = new Set<string>();
+  const mauSet = new Set<string>();
+  const allSet = new Set<string>();
+  let nullVisitorRows = 0;
+
+  for (const r of rows) {
+    if (!r.visitorId) {
+      nullVisitorRows += 1; // distinct 불가 → 제외(과소집계 가능)
+      continue;
+    }
+    const t = r.timestamp.getTime();
+    if (t > now) continue; // 미래 타임스탬프(더미 아티팩트 등) 방어 — 활성 집계서 제외
+    const day = r.timestamp.toISOString().slice(0, 10);
+    let set = perDay.get(day);
+    if (!set) {
+      set = new Set();
+      perDay.set(day, set);
+    }
+    set.add(r.visitorId);
+    allSet.add(r.visitorId);
+    if (now - t <= 7 * DAY_MS) wauSet.add(r.visitorId);
+    if (now - t <= 30 * DAY_MS) mauSet.add(r.visitorId);
+  }
+
+  const dau = [...perDay.entries()]
+    .map(([date, set]) => ({ date, visitors: set.size }))
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .slice(-DAU_WINDOW_DAYS);
+
+  return {
+    dau,
+    latestDau: dau.length ? dau[dau.length - 1] : null,
+    wau: wauSet.size,
+    mau: mauSet.size,
+    totalVisitors: allSet.size,
+    nullVisitorRows,
+  };
+}


### PR DESCRIPTION
## 범위 (CONVERSION_DASHBOARD_PLAN §1 — E1만)
`/playboard/insights`에 **서비스 활성 지표(DAU/WAU/MAU)** 추가. ★ E1만 — E3(NSM)는 별도.

## 변경 (2파일)
| 파일 | 내용 |
|---|---|
| `src/lib/playboard/insights.ts` | `getActivity(source)` — 익명 `visitorId` distinct 기준 DAU(일별·최근 30일)·WAU(7일)·MAU(30일). raw 직접(크론 0). `t>now` 방어 + null 제외 |
| `src/app/playboard/insights/page.tsx` | 활성 지표 섹션 **additive**(카드 3 + 일별 DAU 막대). 소스 토글 연동 |

## 검증 (dev 실측 = 독립 재계산 일치)
| 소스 | DAU(최근일) | WAU(7일) | MAU(30일) | 비고 |
|---|---|---|---|---|
| prod(기본) | 1 | **5** | **5** | 실데이터(48행)·소량서 안전 |
| `?source=preview` | 3 | **20** | **79** | 더미 27 활동일·의미 있는 값 |
- 렌더 숫자 = DB 독립 재계산과 정확히 일치(visitorId distinct 검증).
- 기존 섹션 전부 intact: 전환 퍼널(11종)·핵심 전환율·UTM 채널·소스 토글.
- `tsc` ✅ / `eslint` ✅

## ★ 안전 (회귀 0)
- 읽기 전용(SELECT)·**마이그레이션 0**·prod 차단(`notFound`) 유지.
- 기존 퍼널·전환율·UTM·토글 무변경 — **활성 섹션만 additive**.
- 빈 데이터(prod 소량)에서도 안전(0/null 가드). 미래 타임스탬프 방어.

## 알려진 갭 (정직)
- 더미 시드가 retention 이벤트를 미래 일자로 생성하는 아티팩트 존재 → E1은 `t>now` 가드로 방어(집계 정확). 시드 자체 클램프는 별도(seed PR/이슈).
- distinct 정규화·봇 제외는 후속 이슈(distinct-normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)