### PR TITLE
feat(playboard): insights NSM 주간 추세 + 선행지표 (E3)

### DIFF
--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -6,10 +6,12 @@ import { getDeploymentEnv } from "@/lib/health";
 import {
   getInsights,
   getActivity,
+  getNsmTrend,
   FUNNEL_STEPS,
   OTHER_EVENTS,
   type InsightsData,
   type ActivityData,
+  type NsmTrend,
   type InsightsSource,
 } from "@/lib/playboard/insights";
 
@@ -106,6 +108,8 @@ export default async function InsightsPage({
   const d: InsightsData = await getInsights(source);
   const act: ActivityData = await getActivity(source);
   const dauMax = Math.max(1, ...act.dau.map((x) => x.visitors));
+  const nsm: NsmTrend = await getNsmTrend(source);
+  const nsmMax = Math.max(1, nsm.target3mo, ...nsm.weeks.map((w) => w.completed));
   const funnelCounts = FUNNEL_STEPS.map((s) => d.counts[s.key] ?? 0);
   const otherCounts = OTHER_EVENTS.map((s) => d.counts[s.key] ?? 0);
   const max = Math.max(1, ...funnelCounts, ...otherCounts);
@@ -205,6 +209,61 @@ export default async function InsightsPage({
         {act.nullVisitorRows > 0 ? (
           <p className="mt-s-2 text-caption-xs text-warning">
             ※ visitorId 없는 {act.nullVisitorRows}행(시크릿/차단)은 distinct 제외 — 과소 집계 가능.
+          </p>
+        ) : null}
+      </section>
+
+      {/* NSM (E3) — 주간 진단 완료 추세 + 선행 지표 */}
+      <section aria-label="NSM" className="mt-s-8 border-t border-card-border pt-s-6">
+        <h2 className="text-h3 font-extrabold text-ink">🌟 NSM — 주간 진단 완료 수</h2>
+        <p className="mt-s-1 text-caption-xs text-ink-3">
+          주(월~일) 단위 <code>diagnosis_completed</code>. 목표 {nsm.target3mo}건/주(3개월) → {nsm.target6mo}건/주(6개월), REQ-NF-026.
+        </p>
+
+        {nsm.weeks.length > 0 ? (
+          <div className="mt-s-4">
+            <div className="flex items-end gap-s-2" style={{ height: "120px" }} aria-hidden>
+              {nsm.weeks.map((w) => (
+                <div key={w.weekStart} className="flex flex-1 flex-col items-center justify-end">
+                  <span className="mb-s-1 text-caption-xs font-bold text-ink">{w.completed}</span>
+                  <div
+                    className="w-full rounded-t-xs bg-warning"
+                    style={{ height: `${Math.max((w.completed / nsmMax) * 100, 4)}%` }}
+                    title={`${w.weekStart} 주: ${w.completed}건`}
+                  />
+                  <span className="mt-s-1 text-caption-xs text-ink-3">{w.weekStart.slice(5)}</span>
+                </div>
+              ))}
+            </div>
+            <p className="mt-s-2 text-caption-xs text-ink-3">
+              막대 스케일 기준 = 최대 {nsmMax} (3개월 목표선 {nsm.target3mo} 포함). 최근 주 NSM:{" "}
+              <strong className="text-ink">{nsm.latest?.completed ?? 0}</strong> / 목표 {nsm.target3mo}.
+            </p>
+          </div>
+        ) : (
+          <p className="mt-s-3 text-caption text-ink-2">아직 완료 이벤트가 없습니다.</p>
+        )}
+
+        {/* 선행 지표 3종 (getInsights.rates 재노출 — 상세는 핵심 전환율 섹션) */}
+        <p className="mt-s-5 text-caption-xs font-bold text-ink-3">선행 지표 (NSM 인과)</p>
+        <div className="mt-s-2 grid gap-s-3 sm:grid-cols-3">
+          <div className="rounded-lg border border-card-border bg-surface p-s-3">
+            <p className="text-caption-xs text-ink-3">주소 2건 입력 완료율</p>
+            <p className="mt-s-1 text-h3 font-extrabold text-ink">{fmtRate(d.rates.inputCompletion)}</p>
+          </div>
+          <div className="rounded-lg border border-card-border bg-surface p-s-3">
+            <p className="text-caption-xs text-ink-3">진단 제출 성공률</p>
+            <p className="mt-s-1 text-h3 font-extrabold text-ink">{fmtRate(d.rates.submitSuccess)}</p>
+          </div>
+          <div className="rounded-lg border border-card-border bg-surface p-s-3">
+            <p className="text-caption-xs text-ink-3">공유 링크 생성률</p>
+            <p className="mt-s-1 text-h3 font-extrabold text-ink">{fmtRate(d.rates.shareCreation)}</p>
+          </div>
+        </div>
+
+        {nsm.dedup.nullRows > 0 ? (
+          <p className="mt-s-2 text-caption-xs text-warning">
+            ※ diagnosisId 없는 {nsm.dedup.nullRows}건은 중복제거 불가 → 행 카운트 폴백(과다 집계 가능). distinct ID {nsm.dedup.distinctIds}건.
           </p>
         ) : null}
       </section>

--- a/onday-app/src/lib/playboard/insights.ts
+++ b/onday-app/src/lib/playboard/insights.ts
@@ -174,3 +174,67 @@ export async function getActivity(source: InsightsSource = "prod"): Promise<Acti
     nullVisitorRows,
   };
 }
+
+// ── NSM (E3) — 주간 진단 완료 수 추세 + 목표선. diagnosisId 중복제거(null=행 카운트 폴백). ──
+const NSM_WEEKS = 8;
+const NSM_TARGET_3MO = 50; // REQ-NF-026: 3개월 50건/주
+const NSM_TARGET_6MO = 200; // REQ-NF-026: 6개월 200건/주
+
+export interface NsmTrend {
+  weeks: { weekStart: string; completed: number }[]; // 최근 NSM_WEEKS 주(데이터 있는 주)
+  latest: { weekStart: string; completed: number } | null;
+  dedup: { distinctIds: number; nullRows: number }; // 정직 표기 — null 은 행 카운트 폴백
+  target3mo: number;
+  target6mo: number;
+}
+
+// 주(월요일) 시작일(UTC) — YYYY-MM-DD.
+function weekStartUTC(d: Date): string {
+  const dt = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = dt.getUTCDay(); // 0=일..6=토
+  dt.setUTCDate(dt.getUTCDate() + (day === 0 ? -6 : 1 - day)); // 월요일로
+  return dt.toISOString().slice(0, 10);
+}
+
+export async function getNsmTrend(source: InsightsSource = "prod"): Promise<NsmTrend> {
+  const model = (source === "preview" ? prisma.previewEventLog : prisma.eventLog) as typeof prisma.eventLog;
+  const rows = await model.findMany({
+    where: { eventName: "diagnosis_completed" },
+    select: { diagnosisId: true, timestamp: true },
+  });
+
+  const now = Date.now();
+  const perWeek = new Map<string, { ids: Set<string>; nulls: number }>();
+  const distinctIds = new Set<string>();
+  let nullRows = 0;
+
+  for (const r of rows) {
+    if (r.timestamp.getTime() > now) continue; // 미래 일자 방어(E1 패턴 계승)
+    const ws = weekStartUTC(r.timestamp);
+    let w = perWeek.get(ws);
+    if (!w) {
+      w = { ids: new Set(), nulls: 0 };
+      perWeek.set(ws, w);
+    }
+    if (r.diagnosisId) {
+      w.ids.add(r.diagnosisId); // 중복제거(같은 진단 재진입 1회로)
+      distinctIds.add(r.diagnosisId);
+    } else {
+      w.nulls += 1; // ★ diagnosisId null → dedup 불가 → 행 카운트 폴백(누수 가능, 정직 표기)
+      nullRows += 1;
+    }
+  }
+
+  const weeks = [...perWeek.entries()]
+    .map(([weekStart, w]) => ({ weekStart, completed: w.ids.size + w.nulls }))
+    .sort((a, b) => a.weekStart.localeCompare(b.weekStart))
+    .slice(-NSM_WEEKS);
+
+  return {
+    weeks,
+    latest: weeks.length ? weeks[weeks.length - 1] : null,
+    dedup: { distinctIds: distinctIds.size, nullRows },
+    target3mo: NSM_TARGET_3MO,
+    target6mo: NSM_TARGET_6MO,
+  };
+}


### PR DESCRIPTION
## 범위 (CONVERSION_DASHBOARD_PLAN §3 — E3만)
`/playboard/insights`에 **NSM(주간 진단 완료 수) 추세 + 목표선 + 선행지표 3종** 추가. ★ E3만 — 대시보드 확장 마지막 단계.

## 변경 (2파일)
| 파일 | 내용 |
|---|---|
| `src/lib/playboard/insights.ts` | `getNsmTrend(source)` — 주(월요일) 버킷 `diagnosis_completed` 추세, **diagnosisId 중복제거**(null=행 카운트 폴백), 목표 50→200(REQ-NF-026), `t>now` 방어 |
| `src/app/playboard/insights/page.tsx` | NSM 섹션 **additive**(주별 막대 + 목표 스케일 + 선행 3종 카드 + dedup 주석) |

## 검증 (dev 실측 = 독립 재계산 일치)
| 소스 | NSM 주별 | dedup |
|---|---|---|
| prod(기본) | 06-22주 = **4** | 5행 → **distinct 4**(중복 1건 제거) |
| `?source=preview` | 05-18=1·05-25=7·06-01=8·06-08=6·06-15=5 | distinct 27, null 0 |
- 선행 3종(주소 입력완료율·제출성공률·공유생성률)은 `getInsights.rates` 재노출.
- 기존 섹션 전부 intact: 서비스 활성(E1)·전환 퍼널(11종)·핵심 전환율·UTM·소스 토글.
- `tsc` ✅ / `eslint` ✅

## ★ NSM dedup 정직 표기
- 주별 NSM = **distinct diagnosisId** + (diagnosisId null인 행은 dedup 불가 → **행 카운트 폴백**, 과다 집계 가능). null>0이면 화면에 주석 노출.
- 실측: prod는 같은 diagnosisId 완료 재발화 1건을 dedup해 5→4. preview는 null 0.

## ★ 안전 (회귀 0)
- 읽기 전용(SELECT)·**마이그레이션 0**·prod 차단 유지.
- 퍼널·전환율·UTM·활성(E1)·토글 무변경 — NSM 섹션만 additive.
- 빈/소량 데이터 안전(0 가드), 미래 일자 방어(E1 패턴 계승).

🤖 Generated with [Claude Code](https://claude.com/claude-code)