### PR TITLE
feat(playboard): insights 가독성·모드분리 개선 (DAU 숫자·NSM 목표선·부부/싱글·KST)

### DIFF
--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -13,6 +13,7 @@ import {
   type ActivityData,
   type NsmTrend,
   type InsightsSource,
+  type ModeFilter,
 } from "@/lib/playboard/insights";
 
 // Insights 대시보드 — event_logs raw 직접 집계(크론 0). 운영자 도구.
@@ -95,20 +96,37 @@ function RateCard({
   );
 }
 
+// UTC ISO → KST(UTC+9) "MM-DD HH:mm".
+function toKST(iso: string): string {
+  const k = new Date(new Date(iso).getTime() + 9 * 3600_000).toISOString();
+  return `${k.slice(5, 10)} ${k.slice(11, 16)}`;
+}
+
 export default async function InsightsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ source?: string }>;
+  searchParams: Promise<{ source?: string; mode?: string }>;
 }) {
   if (getDeploymentEnv() === "production") notFound();
 
   // ★ 소스 토글 — ?source=preview 면 더미(preview_event_logs), 기본 prod(event_logs).
   const sp = await searchParams;
   const source: InsightsSource = sp.source === "preview" ? "preview" : "prod";
-  const d: InsightsData = await getInsights(source);
-  const act: ActivityData = await getActivity(source);
+  // ★ 모드 필터(부부/싱글) — 없으면 전체(기존 동작). visitorId→mode 추론 기반.
+  const mode: ModeFilter | undefined = sp.mode === "couple" || sp.mode === "single" ? sp.mode : undefined;
+  // 토글 링크 — source 보존하며 mode 만 교체.
+  const modeHref = (m?: ModeFilter) => {
+    const q = new URLSearchParams();
+    if (source === "preview") q.set("source", "preview");
+    if (m) q.set("mode", m);
+    const s = q.toString();
+    return s ? `?${s}` : "/playboard/insights";
+  };
+
+  const d: InsightsData = await getInsights(source, mode);
+  const act: ActivityData = await getActivity(source, mode);
   const dauMax = Math.max(1, ...act.dau.map((x) => x.visitors));
-  const nsm: NsmTrend = await getNsmTrend(source);
+  const nsm: NsmTrend = await getNsmTrend(source, mode);
   const nsmMax = Math.max(1, nsm.target3mo, ...nsm.weeks.map((w) => w.completed));
   const funnelCounts = FUNNEL_STEPS.map((s) => d.counts[s.key] ?? 0);
   const otherCounts = OTHER_EVENTS.map((s) => d.counts[s.key] ?? 0);
@@ -144,7 +162,38 @@ export default async function InsightsPage({
           <span className="rounded-sm bg-info-soft px-s-3 py-s-1 font-bold text-info">UTM 부착 {d.utmRows}</span>
           {d.span.first ? (
             <span className="rounded-sm bg-bg px-s-3 py-s-1 text-ink-3">
-              {d.span.first.slice(0, 16).replace("T", " ")} ~ {d.span.last?.slice(11, 16)} UTC
+              {source === "preview" ? "더미 기간 " : "기간 "}
+              {toKST(d.span.first)} ~ {d.span.last ? toKST(d.span.last) : ""} KST
+            </span>
+          ) : null}
+        </div>
+
+        {/* ★ 모드 토글(부부/싱글) — 전체 = 기존 통합 뷰 */}
+        <div className="mt-s-3 flex items-center gap-s-2 text-caption-xs">
+          <span className="text-ink-3">모드:</span>
+          {(
+            [
+              { m: undefined, label: "전체" },
+              { m: "couple" as const, label: "부부" },
+              { m: "single" as const, label: "싱글" },
+            ] satisfies { m: ModeFilter | undefined; label: string }[]
+          ).map(({ m, label }) => {
+            const active = mode === m;
+            return (
+              <Link
+                key={label}
+                href={modeHref(m)}
+                className={`rounded-sm px-s-3 py-s-1 font-bold ${
+                  active ? "bg-primary text-white" : "bg-bg text-ink-2 hover:text-ink"
+                }`}
+              >
+                {label}
+              </Link>
+            );
+          })}
+          {mode ? (
+            <span className="text-ink-3">
+              · {mode === "couple" ? "부부" : "싱글"} 방문자만(mode 이벤트로 추론). landing-only 이탈자는 제외.
             </span>
           ) : null}
         </div>
@@ -188,14 +237,16 @@ export default async function InsightsPage({
         {act.dau.length > 0 ? (
           <div className="mt-s-4">
             <p className="text-caption-xs font-bold text-ink-3">일별 DAU (최근 {act.dau.length}일 · 데이터 있는 날)</p>
-            <div className="mt-s-2 flex h-24 items-end gap-0.5" aria-hidden>
+            <div className="mt-s-2 flex h-28 items-end gap-0.5">
               {act.dau.map((x) => (
-                <div
-                  key={x.date}
-                  className="flex-1 rounded-t-xs bg-info"
-                  style={{ height: `${Math.max((x.visitors / dauMax) * 100, 6)}%` }}
-                  title={`${x.date}: ${x.visitors}`}
-                />
+                <div key={x.date} className="flex flex-1 flex-col items-center justify-end" title={`${x.date}: ${x.visitors}명`}>
+                  <span className="mb-px text-[9px] font-bold leading-none text-ink-2">{x.visitors}</span>
+                  <div
+                    className="w-full rounded-t-xs bg-info"
+                    style={{ height: `${Math.max((x.visitors / dauMax) * 100, 6)}%` }}
+                    aria-hidden
+                  />
+                </div>
               ))}
             </div>
             <div className="mt-s-1 flex justify-between text-caption-xs text-ink-3">
@@ -222,21 +273,42 @@ export default async function InsightsPage({
 
         {nsm.weeks.length > 0 ? (
           <div className="mt-s-4">
-            <div className="flex items-end gap-s-2" style={{ height: "120px" }} aria-hidden>
-              {nsm.weeks.map((w) => (
-                <div key={w.weekStart} className="flex flex-1 flex-col items-center justify-end">
-                  <span className="mb-s-1 text-caption-xs font-bold text-ink">{w.completed}</span>
+            <div className="relative" style={{ height: "120px" }}>
+              {/* ★ 3개월 목표선(50/주) — 추세 대비 갭 가시화 */}
+              <div
+                className="pointer-events-none absolute inset-x-0 z-10 border-t border-dashed border-danger"
+                style={{ bottom: `${Math.min((nsm.target3mo / nsmMax) * 100, 100)}%` }}
+              >
+                <span className="absolute -top-2.5 right-0 bg-bg px-1 text-[10px] font-bold text-danger">
+                  목표 {nsm.target3mo}/주
+                </span>
+              </div>
+              <div className="flex h-full items-end gap-s-2">
+                {nsm.weeks.map((w) => (
                   <div
-                    className="w-full rounded-t-xs bg-warning"
-                    style={{ height: `${Math.max((w.completed / nsmMax) * 100, 4)}%` }}
+                    key={w.weekStart}
+                    className="flex flex-1 flex-col items-center justify-end"
                     title={`${w.weekStart} 주: ${w.completed}건`}
-                  />
-                  <span className="mt-s-1 text-caption-xs text-ink-3">{w.weekStart.slice(5)}</span>
-                </div>
+                  >
+                    <span className="mb-px text-caption-xs font-bold text-ink">{w.completed}</span>
+                    <div
+                      className="w-full rounded-t-xs bg-warning"
+                      style={{ height: `${Math.max((w.completed / nsmMax) * 100, 4)}%` }}
+                      aria-hidden
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="mt-s-1 flex gap-s-2">
+              {nsm.weeks.map((w) => (
+                <span key={w.weekStart} className="flex-1 text-center text-caption-xs text-ink-3">
+                  {w.weekStart.slice(5)}
+                </span>
               ))}
             </div>
             <p className="mt-s-2 text-caption-xs text-ink-3">
-              막대 스케일 기준 = 최대 {nsmMax} (3개월 목표선 {nsm.target3mo} 포함). 최근 주 NSM:{" "}
+              주별 추세 · 빨간 점선 = 3개월 목표({nsm.target3mo}/주), 6개월 {nsm.target6mo}/주. 최근 주 NSM:{" "}
               <strong className="text-ink">{nsm.latest?.completed ?? 0}</strong> / 목표 {nsm.target3mo}.
             </p>
           </div>

--- a/onday-app/src/lib/playboard/insights.ts
+++ b/onday-app/src/lib/playboard/insights.ts
@@ -52,11 +52,31 @@ const pct = (num: number, den: number): number | null =>
 // ★ 읽는 테이블만 교체(write 0). preview 는 dev/preview 에서만 의미(페이지가 prod 차단).
 export type InsightsSource = "prod" | "preview";
 
-export async function getInsights(source: InsightsSource = "prod"): Promise<InsightsData> {
-  // 두 모델은 스키마 동일(필드·인덱스) — preview 델리게이트를 eventLog 타입으로 캐스팅해 읽기만 분기.
-  const model = (source === "preview" ? prisma.previewEventLog : prisma.eventLog) as typeof prisma.eventLog;
+// 모드 필터(부부/싱글) — mode 컬럼은 5개 이벤트(input_viewed·submit_clicked·share_*·saved_search)만 보유.
+// ★ 그래서 방문자의 mode 를 그 이벤트로 추론(visitorId→mode)한 뒤, 그 방문자의 전 이벤트를 필터한다.
+//   → mode 이벤트가 없는 방문자(랜딩만 이탈 등)는 모드뷰에서 제외(전체뷰엔 포함). 정직 표기.
+export type ModeFilter = "couple" | "single";
 
-  const grouped = await model.groupBy({ by: ["eventName"], _count: { _all: true } });
+function delegate(source: InsightsSource) {
+  return (source === "preview" ? prisma.previewEventLog : prisma.eventLog) as typeof prisma.eventLog;
+}
+
+// 해당 모드 방문자 visitorId 목록(mode 보유 이벤트 기준 distinct).
+async function modeVisitorIds(model: typeof prisma.eventLog, mode: ModeFilter): Promise<string[]> {
+  const rows = await model.findMany({
+    where: { mode },
+    select: { visitorId: true },
+    distinct: ["visitorId"],
+  });
+  return rows.map((r) => r.visitorId).filter((v): v is string => v != null);
+}
+
+export async function getInsights(source: InsightsSource = "prod", mode?: ModeFilter): Promise<InsightsData> {
+  const model = delegate(source);
+  // mode 미지정 → modeWhere undefined → 쿼리 동일(기존 무변경). 지정 시 visitorId IN 필터.
+  const modeWhere = mode ? { visitorId: { in: await modeVisitorIds(model, mode) } } : undefined;
+
+  const grouped = await model.groupBy({ by: ["eventName"], _count: { _all: true }, where: modeWhere });
   const counts: Record<string, number> = {};
   let total = 0;
   for (const g of grouped) {
@@ -65,7 +85,7 @@ export async function getInsights(source: InsightsSource = "prod"): Promise<Insi
   }
 
   const addressVerified2 = await model.count({
-    where: { eventName: "address_verified", count: 2 },
+    where: { eventName: "address_verified", count: 2, ...(modeWhere ?? {}) },
   });
 
   const rates = {
@@ -76,7 +96,7 @@ export async function getInsights(source: InsightsSource = "prod"): Promise<Insi
 
   // UTM 채널 — props(JSON)에서 utm_source 추출 후 채널별 집계.
   const utmRowsRaw = await model.findMany({
-    where: { NOT: { props: null } },
+    where: { NOT: { props: null }, ...(modeWhere ?? {}) },
     select: { eventName: true, props: true },
   });
   const bySource = new Map<string, UtmChannel>();
@@ -101,6 +121,7 @@ export async function getInsights(source: InsightsSource = "prod"): Promise<Insi
   const agg = await model.aggregate({
     _min: { timestamp: true },
     _max: { timestamp: true },
+    where: modeWhere,
   });
 
   return {
@@ -130,9 +151,10 @@ export interface ActivityData {
   nullVisitorRows: number; // visitorId null(distinct 제외) — 과소집계 주석용
 }
 
-export async function getActivity(source: InsightsSource = "prod"): Promise<ActivityData> {
-  const model = (source === "preview" ? prisma.previewEventLog : prisma.eventLog) as typeof prisma.eventLog;
-  const rows = await model.findMany({ select: { visitorId: true, timestamp: true } });
+export async function getActivity(source: InsightsSource = "prod", mode?: ModeFilter): Promise<ActivityData> {
+  const model = delegate(source);
+  const modeWhere = mode ? { visitorId: { in: await modeVisitorIds(model, mode) } } : undefined;
+  const rows = await model.findMany({ where: modeWhere, select: { visitorId: true, timestamp: true } });
 
   const now = Date.now();
   const perDay = new Map<string, Set<string>>();
@@ -196,10 +218,11 @@ function weekStartUTC(d: Date): string {
   return dt.toISOString().slice(0, 10);
 }
 
-export async function getNsmTrend(source: InsightsSource = "prod"): Promise<NsmTrend> {
-  const model = (source === "preview" ? prisma.previewEventLog : prisma.eventLog) as typeof prisma.eventLog;
+export async function getNsmTrend(source: InsightsSource = "prod", mode?: ModeFilter): Promise<NsmTrend> {
+  const model = delegate(source);
+  const modeWhere = mode ? { visitorId: { in: await modeVisitorIds(model, mode) } } : undefined;
   const rows = await model.findMany({
-    where: { eventName: "diagnosis_completed" },
+    where: { eventName: "diagnosis_completed", ...(modeWhere ?? {}) },
     select: { diagnosisId: true, timestamp: true },
   });
 


### PR DESCRIPTION
## 범위 — 대시보드 가독성·인사이트 개선 4종 (기존 지표 로직 무변경, 표현·필터만)

| # | 개선 | 내용 |
|---|---|---|
| 1 | DAU 숫자 | 일별 DAU 막대에 값 라벨 추가(그래프+숫자) |
| 2 | NSM 목표선 | 주간 추세 막대에 **3개월 목표선(50/주) 점선 마커** + 6개월 200/주 표기 |
| 3 ★★ | 부부/싱글 분리 | `?mode=couple\|single` 토글 — 모드별 퍼널·전환율·NSM·활성 |
| 4 | 날짜 KST | 기간 표시 UTC→**KST**(혼동 방지), preview=「더미 기간」 |

## 모드 분리 설계 (정직)
- `mode` 컬럼은 5개 이벤트(input_viewed·submit_clicked·share_*·saved_search)만 보유 → **방문자 mode 를 그 이벤트로 추론**(visitorId→mode) 후 그 방문자의 전 이벤트를 `visitorId IN` 필터.
- **mode 이벤트 없는 방문자(랜딩만 이탈 등)는 모드뷰에서 제외**(전체뷰엔 포함) → 화면에 주석 표기.
- `getInsights/getActivity/getNsmTrend` 에 `mode?` 파라미터 additive. **미지정 = 기존 쿼리 동일**(modeWhere undefined → where 생략).

## 검증 (dev 실측 = DB 기대 일치)
| 뷰 | 총 이벤트 |
|---|---|
| preview 전체 | **350** (기존과 동일) |
| preview 부부 | **229** (방문자 32·완료 20) |
| preview 싱글 | **73** (방문자 12·완료 7) |
| prod 싱글 | **0** → HTTP 200 빈상태 안전 |
- 렌더 확인: KST · 목표 50/주 점선 · DAU 숫자 · 모드 주석 · 활성/NSM/퍼널/전환율/UTM 전부 intact.
- `tsc` ✅ / `eslint` ✅

## ★ 안전 (회귀 0)
- 전체뷰·집계 수식·소스 토글·퍼널·전환율·UTM·활성(E1)·NSM(E3) **무변경** — 표현·필터만 additive.
- 읽기 전용(SELECT)·**마이그레이션 0**·prod 차단 유지·`t>now`·dedup 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)