### PR TITLE
fix(playboard): DAU/NSM 세로 막대 높이 붕괴 수정 (열 h-full)

### DIFF
--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -239,7 +239,7 @@ export default async function InsightsPage({
             <p className="text-caption-xs font-bold text-ink-3">일별 DAU (최근 {act.dau.length}일 · 데이터 있는 날)</p>
             <div className="mt-s-2 flex h-28 items-end gap-0.5">
               {act.dau.map((x) => (
-                <div key={x.date} className="flex flex-1 flex-col items-center justify-end" title={`${x.date}: ${x.visitors}명`}>
+                <div key={x.date} className="flex h-full flex-1 flex-col items-center justify-end" title={`${x.date}: ${x.visitors}명`}>
                   <span className="mb-px text-[9px] font-bold leading-none text-ink-2">{x.visitors}</span>
                   <div
                     className="w-full rounded-t-xs bg-info"
@@ -287,7 +287,7 @@ export default async function InsightsPage({
                 {nsm.weeks.map((w) => (
                   <div
                     key={w.weekStart}
-                    className="flex flex-1 flex-col items-center justify-end"
+                    className="flex h-full flex-1 flex-col items-center justify-end"
                     title={`${w.weekStart} 주: ${w.completed}건`}
                   >
                     <span className="mb-px text-caption-xs font-bold text-ink">{w.completed}</span>


### PR DESCRIPTION
## 문제
`/playboard/insights`의 DAU·NSM **세로 막대가 화면에 안 보임**.

## 원인 (진단)
막대 `<div style="height:X%">`의 부모 열(`flex flex-col`)이 **불확정 높이**(행이 `items-end` → 열 stretch 안 됨 → 열 높이 auto)라, 퍼센트 높이가 **0으로 붕괴**. 막대는 DOM엔 존재하나 0px → 안 보임.

## 수정 (CSS 표현만, 1줄급)
막대 부모 열에 **`h-full`** 추가 → 행의 확정 높이(DAU `h-28` / NSM `120px`)를 채움 → `height:%`가 정상 해석됨. DAU·NSM 동일 구조라 두 곳 모두 적용(class 동일).

## 검증 (dev 실측)
| | prod | preview |
|---|---|---|
| 열 `h-full` 적용 | 6 | 66 |
| DAU 막대 height% | 2 | 28 |
| NSM 막대 height% | 1 | 5 |
| 숫자라벨·목표선 | 유지 | 유지 |
- 퍼널(11종)·핵심 전환율·UTM 채널 **전부 intact**.
- `tsc` ✅ / `eslint` ✅

## ★ 안전 (회귀 0)
- **CSS/레이아웃 표현만** — 집계 로직·데이터·숫자 라벨·목표선·모드 토글·소스 토글 무변경.
- 퍼널·전환율·UTM(가로 width%, 원래 정상)은 미수정.
- 읽기 전용·마이그레이션 0·prod 차단 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)