### PR TITLE
fix(playboard): DAU 막대 트랙 인라인 높이 — h-28 JIT 누락 영구 해결

### DIFF
--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -237,7 +237,7 @@ export default async function InsightsPage({
         {act.dau.length > 0 ? (
           <div className="mt-s-4">
             <p className="text-caption-xs font-bold text-ink-3">일별 DAU (최근 {act.dau.length}일 · 데이터 있는 날)</p>
-            <div className="mt-s-2 flex h-28 items-end gap-0.5">
+            <div className="mt-s-2 flex items-end gap-0.5" style={{ height: "112px" }}>
               {act.dau.map((x) => (
                 <div key={x.date} className="flex h-full flex-1 flex-col items-center justify-end" title={`${x.date}: ${x.visitors}명`}>
                   <span className="mb-px text-[9px] font-bold leading-none text-ink-2">{x.visitors}</span>


### PR DESCRIPTION
## 문제
DAU 막대만 안 보임(NSM은 정상). DAU 트랙 높이가 **`h-28` 클래스(프로젝트 전체 유일 사용, page.tsx 1곳)**에 의존 → dev JIT/캐시에서 `.h-28` 미생성 시 행 높이 `auto` → `h-full` 열 불확정 → 막대 `height:%` **0 붕괴**. NSM은 트랙이 **인라인 120px**라 영향 없음 → NSM만 보이던 정확한 원인.

## 수정 (CSS 표현 1줄)
DAU 트랙 `h-28` → **`style={{ height: "112px" }}` 인라인** (NSM 패턴과 동일). 클래스/JIT 의존 제거 → **환경 무관(preview·prod·재배포) 항상 표시**.

## 검증 (dev 실측)
- DAU 트랙 인라인 112px ✓ · `h-28` 잔존 0 ✓
- DAU 막대 height% 28개 (h-full 열 아래) → 정상 해석 ✓
- DAU 숫자라벨 56 유지 ✓
- NSM 인라인 120px·막대 유지 ✓ · 퍼널·전환율·UTM intact ✓
- prod HTTP 200 ✓ · `tsc` ✅ / `eslint` ✅

## ★ 안전 (회귀 0)
- **CSS 표현만** — 막대 height%·숫자라벨·열 h-full·집계·데이터·모드/소스 토글 무변경.
- **DAU 트랙 높이 소스만** 클래스→인라인. NSM·퍼널·전환율·UTM 미수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)