### PR TITLE
fix(login): 심사관 버튼 Sentry 크래시 — named import 로 교체

### DIFF
--- a/onday-app/src/components/auth/login-form.tsx
+++ b/onday-app/src/components/auth/login-form.tsx
@@ -2,8 +2,9 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
-import Sentry from "@sentry/nextjs";
+// ★ named import — "use client" 브라우저 번들엔 default export 가 없어(import Sentry → undefined),
+//   #247 의 default import 가 클라에서 captureMessage 크래시 유발. named import 는 client·server 양쪽 안전.
+import { captureMessage } from "@sentry/nextjs";
 
 import { Button } from "@/components/ui/button";
 import { OAuthButton } from "@/components/ui/oauth-button";
@@ -94,7 +95,7 @@ export function LoginForm() {
     // 심사관도 회원 정보 미저장 — 이전 로그인 사용자가 남긴 좌표·이전조건·찜 제거.
     clearGuestPersisted();
     // CMD-AUTH-004 — 진입 이벤트 기록(Sentry 미초기화 시 silent no-op).
-    Sentry.captureMessage("reviewer_mode_entered", "info");
+    captureMessage("reviewer_mode_entered", "info");
     pushToast({
       variant: "default",
       message:


### PR DESCRIPTION
## 증상
`/login` "채용담당자(심사관)" 버튼 클릭 → `TypeError: undefined is not an object (evaluating 'r.default.captureMessage')` → `handleReviewer` 중단 → **접속 안 됨**.

## 원인 (★ 전제와 반대 — 정직)
- `login-form.tsx` 는 **`"use client"`(브라우저)**, 이미 **default import**(`import Sentry from "@sentry/nextjs"`, #247이 적용).
- `@sentry/nextjs` 는 **브라우저 번들에 default export 가 없음** → `Sentry`(=module.default)=`undefined` → `Sentry.captureMessage`(line 97) 크래시.
- 즉 **남은 namespace import 문제가 아니라**, #247의 namespace→default 전환(서버 ESM 빌드용)이 **클라이언트(login)에선 역으로 깨뜨림**.

## 수정 (최소, login-form만)
named import 으로 교체 — **client·server 양쪽 안전**(Sentry 공식 패턴). default/namespace 모호성 제거.
```diff
- import Sentry from "@sentry/nextjs";
- Sentry.captureMessage("reviewer_mode_entered", "info");
+ import { captureMessage } from "@sentry/nextjs";
+ captureMessage("reviewer_mode_entered", "info");
```

## 검증
- `/login` HTTP 200 · login-form 내 `Sentry.*` undefined 접근 **0** · named `captureMessage()` 호출 1.
- `import * as Sentry`(namespace) 잔존 **0건**(전수 grep) — 사용자 우려 항목 확인.
- `tsc` ✅ / `eslint` ✅. DSN 미설정 시 no-op 동일.

## ★ 안전 (회귀 0)
- import/호출 표기만, 로직 무변경. 다른 로그인(카카오/게스트)·Sentry·대시보드 무변경.

## ⚠️ 같은 패턴 잠재 리스크 (이 PR 범위 밖 — 정직 표기)
`src/lib/diagnosis/{use-intersection,intersection,geocoding}.ts` 도 **default import + 클라 실행 경로**라 동일 크래시 가능(단, Kakao API 실패율·교차연산 임계 등 **조건부 드문 분기**에서만 `Sentry.captureMessage` 호출 → login처럼 매번은 아님). 동일 named import 전환 권장 — 별도 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)