### PR TITLE
fix(diagnosis): Sentry named import 전환 — 클라 default 크래시 잠재 3파일

### DIFF
--- a/onday-app/src/lib/diagnosis/geocoding.ts
+++ b/onday-app/src/lib/diagnosis/geocoding.ts
@@ -10,8 +10,8 @@
 //   ★ CMD-DIAG-002~007 후행 ISSUE 시점 mapper.ts 분리 자연 도입 예상 (Wave 3 트랙 G 점진 진화 정신, ★ adaptive § Command 차원 첫 적용 정직 기록)
 // ──────────────────────────────────────────────
 
-// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
-import Sentry from "@sentry/nextjs";
+// ★ named import — 브라우저 번들엔 default export 없음(#259 login 크래시 동일 패턴). client·server 양쪽 안전.
+import { captureException } from "@sentry/nextjs";
 import type { Coordinate } from "@/lib/types";
 import type { GeocodeResult, GeocodedAddress } from "./geocoding-types";
 
@@ -42,7 +42,7 @@ export async function geocodeAddress(query: string, apiKey: string): Promise<Geo
 
     return documents.map(mapToGeocodedAddress);
   } catch (error) {
-    Sentry.captureException(error, { tags: { domain: "diagnosis", task: "CMD-DIAG-001" } });
+    captureException(error, { tags: { domain: "diagnosis", task: "CMD-DIAG-001" } });
     return [];
   }
 }

--- a/onday-app/src/lib/diagnosis/intersection.ts
+++ b/onday-app/src/lib/diagnosis/intersection.ts
@@ -8,8 +8,8 @@
 // ★ Coordinate ↔ KakaoCoord 변환은 toKakaoCoord 헬퍼로 transportClient 호출 직전만 (★ KakaoCoord ≠ Coordinate 분리 § 2번째 실전).
 // ──────────────────────────────────────────────
 
-// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
-import Sentry from "@sentry/nextjs";
+// ★ named import — 브라우저 번들엔 default export 없음(#259 login 크래시 동일 패턴). client·server 양쪽 안전.
+import { captureMessage } from "@sentry/nextjs";
 import type { IKakaoTransportClient, KakaoCoord } from "@/lib/external/kakao-transport";
 import { mapKakaoResponseToCommuteInfo } from "@/lib/external/kakao-transport";
 import type { Coordinate, DiagnosisFilters, CommuteSchedule, DayOfWeek } from "@/lib/types";
@@ -88,7 +88,7 @@ export async function calculateIntersection(
   const failureRate = pool.length === 0 ? 0 : (results.length - succeeded.length) / results.length;
 
   if (failureRate > FAILURE_THRESHOLD) {
-    Sentry.captureMessage(`Kakao API failure rate ${(failureRate * 100).toFixed(1)}%`, {
+    captureMessage(`Kakao API failure rate ${(failureRate * 100).toFixed(1)}%`, {
       level: "warning",
       tags: { domain: "diagnosis", task: "CMD-DIAG-002" },
     });

--- a/onday-app/src/lib/diagnosis/use-intersection.ts
+++ b/onday-app/src/lib/diagnosis/use-intersection.ts
@@ -9,8 +9,8 @@
 "use client";
 
 import { useCallback, useState } from "react";
-// ★ default import — namespace 는 ESM 빌드에서 capture* 미노출(sentry-error.ts 참조).
-import Sentry from "@sentry/nextjs";
+// ★ named import — 브라우저 번들엔 default export 없음(#259 login 크래시 동일 패턴). client·server 양쪽 안전.
+import { captureException, captureMessage } from "@sentry/nextjs";
 import type { IKakaoTransportClient } from "@/lib/external/kakao-transport";
 import type { Coordinate, DiagnosisFilters } from "@/lib/types";
 import { calculateIntersection, type IntersectionResult } from "./intersection";
@@ -31,12 +31,12 @@ export function useIntersection(transportClient: IKakaoTransportClient) {
         const res = await calculateIntersection(coordA, coordB, filters, transportClient);
         setResult(res);
       } catch (e) {
-        Sentry.captureException(e, { tags: { domain: "diagnosis", task: "CMD-DIAG-002" } });
+        captureException(e, { tags: { domain: "diagnosis", task: "CMD-DIAG-002" } });
         setError("진단 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
       } finally {
         const elapsed = performance.now() - startTime;
         if (elapsed > RESPONSE_TIME_THRESHOLD_MS) {
-          Sentry.captureMessage(`Intersection calculation exceeded ${RESPONSE_TIME_THRESHOLD_MS}ms: ${elapsed.toFixed(0)}ms`, {
+          captureMessage(`Intersection calculation exceeded ${RESPONSE_TIME_THRESHOLD_MS}ms: ${elapsed.toFixed(0)}ms`, {
             level: "warning",
             tags: { domain: "diagnosis", task: "CMD-DIAG-002" },
           });


### PR DESCRIPTION
## 배경
#259(login)와 **동일 버그 잠재**: `import Sentry from "@sentry/nextjs"`(default)는 브라우저 번들에 default export 가 없어 `Sentry.*` 접근 시 `undefined` 크래시. 진단 경로(클라 실행) 3파일이 같은 패턴 → named import 로 통일.

## 변경 (import·호출 표기만)
| 파일 | named import | 호출부 |
|---|---|---|
| `lib/diagnosis/use-intersection.ts` | `{ captureException, captureMessage }` | `Sentry.x` → `x` |
| `lib/diagnosis/intersection.ts` | `{ captureMessage }` | `Sentry.x` → `x` |
| `lib/diagnosis/geocoding.ts` | `{ captureException }` | `Sentry.x` → `x` |

## 검증
- 3파일 `Sentry.*`(undefined 접근) 잔존 **0**.
- 전수: **클라 도달 default import 0** (login #259 + 진단 3 전부 named).
- `import * as Sentry`(namespace) **0건**.
- `/diagnosis` 200 · `/login` 200 · `tsc` ✅ / `eslint` ✅.

## ★ 안전 (회귀 0)
- import/호출 표기만, 로직 무변경. named = client·server 양쪽 안전(Sentry 공식 패턴). DSN 미설정 시 no-op 동일.
- 진단·교차연산·geocoding 동작 무변경.

## 남은 default import 2개 (서버 전용 — 정직 표기)
`lib/helpers/sentry-error.ts`(reportErrorToSentry 헬퍼)·`app/api/sentry-test/route.ts` — **서버 컨텍스트 전용**(클라 미도달)이라 default 안전. 본 PR 범위 밖(원하면 named 통일 가능).

🤖 Generated with [Claude Code](https://claude.com/claude-code)