### PR TITLE
fix(address): 한글 IME 끝글자 중복 — 주소 자동완성 선택

### DIFF
--- a/onday-app/src/components/form/address-input.tsx
+++ b/onday-app/src/components/form/address-input.tsx
@@ -53,12 +53,23 @@ export function AddressInput({
   const listId = `${id ?? inputId}-list`;
   const [highlightedId, setHighlightedId] = React.useState<string>();
   const [isFocus, setIsFocus] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const composingRef = React.useRef(false); // 한글 IME 조합 중 여부
   const showList = isFocus && suggestions.length > 0;
   // derived: 사용자가 highlight한 항목이 현재 suggestions에 없으면 첫 번째로 폴백
   const effectiveHighlightedId =
     highlightedId && suggestions.some((s) => s.id === highlightedId)
       ? highlightedId
       : suggestions[0]?.id;
+
+  // ★ 선택 확정 — 한글 IME 조합 중이면 blur 로 조합을 옛 값에 먼저 커밋(compositionend) 후 교체.
+  //   조합 미커밋 시 마지막 글자가 교체값 뒤에 잔류("강남 2호선역남")하는 버그 방지. Enter·클릭 공통.
+  const commitSelection = (item: AddressSuggestion) => {
+    onSelect?.(item);
+    if (composingRef.current) inputRef.current?.blur();
+    onChange(item.title); // 완전 교체(replace) — 잔류 0.
+    setIsFocus(false);
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!showList) return;
@@ -75,11 +86,7 @@ export function AddressInput({
     } else if (e.key === "Enter") {
       e.preventDefault();
       const sel = suggestions[idx];
-      if (sel) {
-        onSelect?.(sel);
-        onChange(sel.title);
-        setIsFocus(false);
-      }
+      if (sel) commitSelection(sel);
     } else if (e.key === "Escape") {
       setIsFocus(false);
     }
@@ -109,6 +116,7 @@ export function AddressInput({
             {tag}
           </span>
           <input
+            ref={inputRef}
             id={inputId}
             role="combobox"
             aria-expanded={showList}
@@ -120,6 +128,12 @@ export function AddressInput({
             value={value}
             placeholder={placeholder}
             onChange={(e) => onChange(e.target.value)}
+            onCompositionStart={() => {
+              composingRef.current = true;
+            }}
+            onCompositionEnd={() => {
+              composingRef.current = false;
+            }}
             onFocus={() => setIsFocus(true)}
             onBlur={() => setTimeout(() => setIsFocus(false), 150)}
             onKeyDown={handleKeyDown}
@@ -141,11 +155,7 @@ export function AddressInput({
           items={suggestions}
           highlightedId={effectiveHighlightedId}
           onHighlight={setHighlightedId}
-          onSelect={(item) => {
-            onSelect?.(item);
-            onChange(item.title);
-            setIsFocus(false);
-          }}
+          onSelect={commitSelection}
         />
       )}
     </div>

--- a/onday-app/src/components/form/suggest-list.tsx
+++ b/onday-app/src/components/form/suggest-list.tsx
@@ -54,7 +54,12 @@ export function SuggestList({
               type="button"
               role="option"
               aria-selected={isActive}
-              onClick={() => onSelect(item)}
+              // ★ onMouseDown + preventDefault — 입력 blur 차단(포커스 유지)으로
+              //   한글 IME compositionend 경합 제거(끝글자 잔류 방지). 선택은 mousedown 에서 확정.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(item);
+              }}
               onMouseEnter={() => onHighlight?.(item.id)}
               className={cn(
                 "flex w-full items-center gap-s-3 px-s-4 py-s-3 text-left transition-colors",


### PR DESCRIPTION
## 증상
진단 입력 주소창에서 **"강남"(마지막 글자 조합 중) → 드롭다운 클릭 → "강남 2호선역남"**(끝글자 잔류).

## 원인
- `address-input.tsx` 제어 input 에 **IME 조합 가드 없음**.
- `suggest-list.tsx` 옵션이 **`onClick`** → 클릭 시 입력 blur → **지연된 `compositionend`** 가 교체값("강남 2호선역") 뒤에 조합 중이던 "남"을 commit → 중복. (append 버그 아님 — 선택은 원래 replace)

## 수정 (진단 ①+② 병행)
| 파일 | 변경 |
|---|---|
| `suggest-list.tsx` | `onClick` → **`onMouseDown` + `e.preventDefault()`** — 입력 blur 차단(포커스 유지)으로 compositionend 경합 제거 |
| `address-input.tsx` | `onCompositionStart/End` 로 `isComposing` 추적 + **`commitSelection` 공통화**(Enter·클릭): 조합 중이면 `blur` 로 조합을 **옛 값에 먼저 커밋** 후 `onChange(title)` **완전 교체** |

## 검증
- `/diagnosis` 200 · suggest-list `onClick` 0 / `onMouseDown` 적용 · `tsc` ✅ / `eslint` ✅.
- **조합 완료 후 선택**: `composingRef=false` → blur 미발생 → `onChange(title)` 그대로 = **기존 동작(회귀 0)**.
- **Enter 선택**: 동일 `commitSelection` 적용 — 일관 처리.
- ⚠️ **한글 IME 실제 재현(조합 중 클릭)은 이 환경에서 브라우저 IME 테스트 불가** → Chrome 한글로 최종 확인 권장(표준 패턴 적용).

## ★ 안전 (회귀 0)
- 주소 입력/선택 동작만 수정. 다른 폼·진단 로직 무변경. 키보드(↑↓·Enter) 경로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)