### PR TITLE
feat(insight): 동네 미리보기 로컬 템플릿 폴백 — Gemini 과부하시 항상 작동

### DIFF
--- a/onday-app/src/components/insight/day-preview.tsx
+++ b/onday-app/src/components/insight/day-preview.tsx
@@ -6,6 +6,7 @@ import { RotateCw, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { extractDayData } from "@/lib/insight/extract-day-data";
+import { buildFallbackStory } from "@/lib/insight/fallback-story";
 import type { DayStory, StorySlot } from "@/lib/insight/story";
 import { useDiagnosisStore } from "@/stores/diagnosis-store";
 import type { CandidateArea, DiagnosisMode } from "@/lib/types";
@@ -83,12 +84,17 @@ interface DayPreviewProps {
 
 export function DayPreview({ candidate, mode }: DayPreviewProps) {
   const [status, setStatus] = React.useState<Status>("idle");
+  // ★ AI 실패 시 로컬 템플릿 폴백(외부 호출 0) — store 캐시 미오염, 이 카드 내에서만 표시.
+  const [fallback, setFallback] = React.useState<DayStory | null>(null);
   // ★ 세션 캐시 — 캐시된 story 가 있으면 재호출 없이 바로 렌더(시트 close/reopen 비용 0).
   const story = useDiagnosisStore((s) => s.stories[candidate.id]) ?? null;
   const setStory = useDiagnosisStore((s) => s.setStory);
+  // 표시 우선순위: AI story(캐시) > 폴백.
+  const shown = story ?? fallback;
 
   const generate = React.useCallback(async () => {
     setStatus("loading");
+    setFallback(null);
     try {
       const data = extractDayData(candidate, mode);
       const res = await fetch("/api/insight", {
@@ -102,7 +108,13 @@ export function DayPreview({ candidate, mode }: DayPreviewProps) {
       setStory(candidate.id, json.story); // store 보관 → 캐시 hit 시 idle 스킵.
       setStatus("idle"); // story 존재가 done 표시를 주도(아래 렌더 우선순위).
     } catch {
-      setStatus("error"); // 503/502/400/네트워크 모두 graceful (크래시·빈 화면 금지).
+      // ★ AI 실패(503/502/429/네트워크) → 로컬 템플릿 폴백으로 "언제 봐도 작동". 에러 카드 X.
+      try {
+        setFallback(buildFallbackStory(extractDayData(candidate, mode)));
+        setStatus("idle");
+      } catch {
+        setStatus("error"); // 폴백 생성마저 실패 시에만 에러 카드(극히 드묾).
+      }
     }
   }, [candidate, mode, setStory]);
 
@@ -113,7 +125,7 @@ export function DayPreview({ candidate, mode }: DayPreviewProps) {
         <p className="text-caption font-bold text-ink-2">동네 하루 미리보기</p>
       </div>
 
-      {!story && status === "idle" && (
+      {!shown && status === "idle" && (
         <Button variant="outline" fullWidth onClick={generate}>
           AI로 이 동네 하루 미리보기 ✨
         </Button>
@@ -121,7 +133,7 @@ export function DayPreview({ candidate, mode }: DayPreviewProps) {
 
       {status === "loading" && <DayPreviewSkeleton />}
 
-      {!story && status === "error" && (
+      {!shown && status === "error" && (
         <div className="space-y-s-2 rounded-lg border border-card-border bg-surface px-s-4 py-s-3 text-center">
           <p className="text-body-sm text-ink-3">
             지금은 미리보기를 불러올 수 없어요
@@ -133,10 +145,10 @@ export function DayPreview({ candidate, mode }: DayPreviewProps) {
         </div>
       )}
 
-      {story && (
+      {shown && (
         <ol className="space-y-s-3">
           {SLOTS.map(({ key, emoji, label }) => {
-            const slot = story[key] as StorySlot | null;
+            const slot = shown[key] as StorySlot | null;
             if (!slot) return null; // evening null(부부·여가 없음) → 저녁 카드 생략.
             return (
               <li

--- a/onday-app/src/lib/insight/fallback-story.ts
+++ b/onday-app/src/lib/insight/fallback-story.ts
@@ -1,0 +1,64 @@
+import type { SafetyGrade } from "@/lib/types";
+import type { DayCommuteSlot, DayPreviewData } from "./extract-day-data";
+import type { DayStory, StorySlot } from "./story";
+
+// 동네 하루 미리보기 — AI(Gemini) 실패·과부하 시 로컬 폴백 스토리.
+// ★ 외부 호출 0(Gemini 무관) → "언제 봐도 작동". ★ DayPreviewData 에 실제 있는 값만 사실 묘사 —
+//   없는 정보(역 이름·미입력 여가·등급 등)는 줄 자체를 빼고 창작 0. AI story 와 동일 UI(DayStory).
+//   ★ 등급은 사실 라벨만(미화 금지). keywords ⊆ text(하이라이트 동일 동작).
+
+const GRADE_LABEL: Record<SafetyGrade, string> = { A: "안심", B: "양호", C: "보통", D: "주의" };
+
+// 통근 표현 — 있는 값만(시간 필수, 환승·출발역 선택).
+function commutePhrase(s: DayCommuteSlot): string {
+  const parts = [`약 ${s.time}분`];
+  if (s.transfers != null) parts.push(s.transfers === 0 ? "환승 없이" : `환승 ${s.transfers}회로`);
+  if (s.departureStation) parts.push(`${s.departureStation}에서`);
+  return parts.join(" ");
+}
+
+function uniqInText(keywords: string[], text: string): string[] {
+  return [...new Set(keywords)].filter((k) => k.length > 0 && text.includes(k));
+}
+
+function morningSlot(data: DayPreviewData): StorySlot {
+  const { dong, morning } = data;
+  let text = `${dong}에서 아침 출근은 ${commutePhrase(morning.a)} 닿는 거리예요.`;
+  const kw = [dong, `${morning.a.time}분`];
+  if (morning.b) {
+    text += ` 배우자는 ${commutePhrase(morning.b)} 출근할 수 있어요.`;
+    kw.push(`${morning.b.time}분`);
+  }
+  return { text, keywords: uniqInText(kw, text) };
+}
+
+// 여가 데이터(싱글 여가거점) 없으면 null — 부부·미입력은 저녁 슬롯 생략(거짓값 금지).
+function eveningSlot(data: DayPreviewData): StorySlot | null {
+  const { dong, leisure } = data;
+  if (!leisure) return null;
+  const text = `퇴근 후엔 자주 가는 곳까지 ${commutePhrase(leisure)} 이동해 ${dong}에서의 저녁을 보낼 수 있어요.`;
+  return { text, keywords: uniqInText([dong, `${leisure.time}분`], text) };
+}
+
+function nightSlot(data: DayPreviewData): StorySlot {
+  const { dong, night } = data;
+  const kw = [dong];
+  const bits: string[] = [];
+  if (night.grade) {
+    bits.push(`야간 치안은 ${GRADE_LABEL[night.grade]} 수준`);
+    kw.push(GRADE_LABEL[night.grade]);
+  }
+  if (night.convenience != null) bits.push("편의점이 가까이 분포해 있어요");
+  if (night.cafes != null) bits.push("주변에 카페도 자리해 있어요");
+  const text = bits.length ? `${dong}의 밤은 ${bits.join(", ")}.` : `${dong}에서의 밤 시간대예요.`;
+  return { text, keywords: uniqInText(kw, text) };
+}
+
+/** DayPreviewData → 로컬 템플릿 DayStory. AI 실패 시 graceful 대체(외부 호출 0, 실데이터만). */
+export function buildFallbackStory(data: DayPreviewData): DayStory {
+  return {
+    morning: morningSlot(data),
+    evening: eveningSlot(data),
+    night: nightSlot(data),
+  };
+}


### PR DESCRIPTION
## 배경
Gemini 모델 일시 과부하("high demand", 3회 재시도 후 실패 → 502)로 "동네 하루 미리보기"가 **간헐적으로 에러 카드**. 이력서 제출용이라 **"언제 봐도 작동"** 필요.

## 구현 (조사 1순위 — 로컬 템플릿 폴백)
AI 실패 시 `DayPreviewData` 기반 **로컬 템플릿 story** 렌더(외부 호출 0). AI 성공 시는 기존대로.

| 파일 | 내용 |
|---|---|
| `lib/insight/fallback-story.ts` (신규) | `buildFallbackStory(DayPreviewData)→DayStory`. 실데이터 있는 값만 사실 묘사(역·여가·등급 없으면 줄 생략, 창작 0), `keywords ⊆ text` |
| `components/insight/day-preview.tsx` | catch 에서 `setFallback(buildFallbackStory(...))` → **에러 카드 대신 동일 `<ol>` UI 렌더**. `shown = story ?? fallback` |

## 검증
- **폴백 단위테스트**: 부부(여가 없음→evening null)·싱글(leisure 있음→evening) / 야간 등급 라벨(B="양호")·편의·카페 / `keywords ⊆ text` true / 통근분 사실 포함 true.
  - COUPLE: "공덕동에서 아침 출근은 약 22분 환승 1회로 공덕역에서 닿는 거리예요. 배우자는 약 35분 환승 없이…"
  - SINGLE 야간(no_data): 등급 줄 생략(거짓값 0).
- `/diagnosis` 200 · `/dev` 200 · `tsc` ✅ / `eslint` ✅.
- ⚠️ AI-다운 상태에서의 **버튼 클릭 end-to-end는 브라우저 필요**(이 환경 미수행) — 헬퍼 단위테스트 + catch 배선 + 렌더 `shown` 분기로 검증. Chrome에서 1회 확인 권장.

## ★ 안전 (회귀 0)
- additive: catch 분기 + 신규 헬퍼만. **AI 성공 경로·store 캐시 무변경**(폴백은 로컬 state, 캐시 미오염).
- **외부 호출 0** → Gemini 상태와 무관하게 항상 작동.
- 정직: 템플릿=실데이터 사실 묘사(미화·허위 0, 없는 정보 생략).

🤖 Generated with [Claude Code](https://claude.com/claude-code)