### PR TITLE
feat(insights): 대시보드 로그인 방식(method) 분류 섹션 추가

### DIFF
--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -7,11 +7,13 @@ import {
   getInsights,
   getActivity,
   getNsmTrend,
+  getLoginMethods,
   FUNNEL_STEPS,
   OTHER_EVENTS,
   type InsightsData,
   type ActivityData,
   type NsmTrend,
+  type LoginMethods,
   type InsightsSource,
   type ModeFilter,
 } from "@/lib/playboard/insights";
@@ -39,6 +41,14 @@ const STAGE_BAR: Record<string, string> = {
 function fmtRate(r: number | null): string {
   return r === null ? "—" : `${r}%`;
 }
+
+// 로그인 방식 라벨·색 — reviewer 는 "채용담당자"로 한글 표기(이해 쉽게).
+// ★ 색은 STAGE_BAR 와 동일한 정적 토큰 클래스 → JIT 누락 없음.
+const LOGIN_METHODS = [
+  { key: "kakao", label: "카카오", color: "bg-warning" },
+  { key: "guest", label: "게스트", color: "bg-info" },
+  { key: "reviewer", label: "채용담당자", color: "bg-primary" },
+] as const;
 
 function Bar({ count, max, stage }: { count: number; max: number; stage: string }) {
   const width = max > 0 ? Math.max((count / max) * 100, count > 0 ? 4 : 0) : 0;
@@ -127,6 +137,7 @@ export default async function InsightsPage({
   const act: ActivityData = await getActivity(source, mode);
   const dauMax = Math.max(1, ...act.dau.map((x) => x.visitors));
   const nsm: NsmTrend = await getNsmTrend(source, mode);
+  const login: LoginMethods = await getLoginMethods(source, mode);
   const nsmMax = Math.max(1, nsm.target3mo, ...nsm.weeks.map((w) => w.completed));
   const funnelCounts = FUNNEL_STEPS.map((s) => d.counts[s.key] ?? 0);
   const otherCounts = OTHER_EVENTS.map((s) => d.counts[s.key] ?? 0);
@@ -355,6 +366,40 @@ export default async function InsightsPage({
             <FunnelRow key={s.key} label={s.label} stage={s.stage} count={otherCounts[i]} max={max} topCount={topCount} />
           ))}
         </div>
+      </section>
+
+      {/* 로그인 방식 분류 (login_entered.method) */}
+      <section aria-label="로그인 방식" className="mt-s-8 border-t border-card-border pt-s-6">
+        <h2 className="text-h3 font-extrabold text-ink">로그인 방식 분류</h2>
+        <p className="mt-s-1 text-caption-xs text-ink-3">
+          <code>login_entered</code> 의 <code>method</code> 기준 분포. 총 {login.total}건의 로그인 진입.
+        </p>
+        {login.total === 0 ? (
+          <p className="mt-s-3 text-caption text-ink-2">아직 로그인 진입 이벤트가 없습니다.</p>
+        ) : (
+          <div className="mt-s-4 grid gap-s-3 sm:grid-cols-3">
+            {LOGIN_METHODS.map(({ key, label, color }) => {
+              const count = login[key];
+              const ratio = login.total > 0 ? Math.round((count / login.total) * 1000) / 10 : 0;
+              return (
+                <div key={key} className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+                  <p className="text-caption-xs font-bold text-ink-3">{label}</p>
+                  <p className="mt-s-1 text-h2 font-extrabold text-ink">{count}</p>
+                  {/* ★ 막대 너비 = 인라인 style(JIT 누락 방지). 색만 정적 토큰 클래스 */}
+                  <div className="mt-s-2 h-2 w-full overflow-hidden rounded-sm bg-bg" aria-hidden>
+                    <div className={`h-full rounded-sm ${color}`} style={{ width: `${ratio}%` }} />
+                  </div>
+                  <p className="mt-s-1 text-caption-xs text-ink-3">{ratio}% (전체 로그인 대비)</p>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        {login.unknown > 0 ? (
+          <p className="mt-s-2 text-caption-xs text-warning">
+            ※ method 없는/기타 {login.unknown}건(과거 데이터·누락)은 분류에서 제외.
+          </p>
+        ) : null}
       </section>
 
       {/* 핵심 전환율 3종 */}

--- a/onday-app/src/lib/playboard/insights.ts
+++ b/onday-app/src/lib/playboard/insights.ts
@@ -138,6 +138,37 @@ export async function getInsights(source: InsightsSource = "prod", mode?: ModeFi
   };
 }
 
+// ── 로그인 방식 분류 (login_entered.method) — kakao/guest/reviewer 분포. 읽기 전용 SELECT. ──
+// ★ method 컬럼은 login_entered 에만 채워짐. null·과거데이터·예상밖 값은 unknown 으로 안전 처리.
+export interface LoginMethods {
+  total: number; // login_entered 총건(method 유무 무관)
+  kakao: number;
+  guest: number;
+  reviewer: number;
+  unknown: number; // method null·예상밖 값(과거/누락)
+}
+
+export async function getLoginMethods(source: InsightsSource = "prod", mode?: ModeFilter): Promise<LoginMethods> {
+  const model = delegate(source);
+  const modeWhere = mode ? { visitorId: { in: await modeVisitorIds(model, mode) } } : undefined;
+  const grouped = await model.groupBy({
+    by: ["method"],
+    where: { eventName: "login_entered", ...(modeWhere ?? {}) },
+    _count: { _all: true },
+  });
+
+  const result: LoginMethods = { total: 0, kakao: 0, guest: 0, reviewer: 0, unknown: 0 };
+  for (const g of grouped) {
+    const n = g._count._all;
+    result.total += n;
+    if (g.method === "kakao") result.kakao += n;
+    else if (g.method === "guest") result.guest += n;
+    else if (g.method === "reviewer") result.reviewer += n;
+    else result.unknown += n; // null·예상밖 값
+  }
+  return result;
+}
+
 // ── 활성 지표 (E1) — DAU/WAU/MAU. 익명 visitorId distinct 기준(PII 0), raw 직접(크론 0). ──
 const DAU_WINDOW_DAYS = 30;
 const DAY_MS = 86_400_000;


### PR DESCRIPTION
## 목표
insights 대시보드에 **로그인 방식(카카오/게스트/채용담당자)** 분류 섹션 추가.
`event_logs.method` 는 이미 적재되나(데이터 O) 화면 미노출(화면 X) 상태 → 읽어서 표시.

## 변경 (additive only — 76 insertions, 0 deletions)
- **`insights.ts`** — `getLoginMethods(source, mode)` 추가. `login_entered` 를 `method` 로 `groupBy`.
  `null`·과거데이터·예상밖 값은 `unknown` 버킷으로 안전 처리. 읽기 전용 SELECT.
- **`page.tsx`** — "로그인 방식 분류" 섹션. 카카오 / 게스트 / **채용담당자(reviewer 한글 표기)** 카드 + 비율 막대.
  - 막대 너비 = **인라인 `style`**(클래스 JIT 누락 방지, DAU 막대 패턴 계승), 색만 정적 토큰 클래스.
  - 소스(prod/preview)·모드(couple/single) 토글 기존 패턴 그대로 연동.
  - 빈 데이터 / `unknown>0` 안전 표기.

## 안전 (제출 임박)
- ✅ **기존 무변경** — 퍼널·전환율·DAU·NSM·UTM·모드 토글 코드 손대지 않음.
- ✅ **읽기 전용** — `groupBy`(SELECT)만. write·마이그레이션 0.
- ✅ **prod 차단 유지** — 페이지 `notFound()` 가드 그대로.

## 검증
- `tsc --noEmit` → 0 에러
- `next lint` (변경 2파일) → No ESLint warnings or errors
- UTF-8 인코딩 검사(`\xef\xbf\xbd`) → clean
- 라이브 **read-only** 쿼리(임시 스크립트, 실행 후 삭제):
  - prod: total 46 → kakao 16 / guest 3 / 채용담당자 27 / unknown 0
  - preview: total 56 → kakao 25 / guest 27 / 채용담당자 4 / unknown 0
  - `?source=preview` 더미로 3분류 정상 노출 확인

⚠️ 자동 머지/Close 금지 — 리뷰용 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)