### PR TITLE
feat(insights): 세그먼트별 NSM 추세(선) + 퍼널 비교(막대) 차트 4개

### DIFF
--- a/onday-app/src/app/playboard/insights/page.tsx
+++ b/onday-app/src/app/playboard/insights/page.tsx
@@ -8,12 +8,16 @@ import {
   getActivity,
   getNsmTrend,
   getLoginMethods,
+  getSegmentAnalytics,
   FUNNEL_STEPS,
   OTHER_EVENTS,
   type InsightsData,
   type ActivityData,
   type NsmTrend,
   type LoginMethods,
+  type SegmentAnalytics,
+  type SegLineSeries,
+  type SegFunnelSeries,
   type InsightsSource,
   type ModeFilter,
 } from "@/lib/playboard/insights";
@@ -49,6 +53,102 @@ const LOGIN_METHODS = [
   { key: "guest", label: "게스트", color: "bg-info" },
   { key: "reviewer", label: "채용담당자", color: "bg-primary" },
 ] as const;
+
+// ── 세그먼트 차트 — 색/좌표/높이 전부 인라인(JIT 클래스 의존 0). ──
+// 범례(선·막대 공용) — color swatch 는 인라인 backgroundColor.
+function SegLegend({ series, unit }: { series: { key: string; label: string; color: string; total: number }[]; unit: string }) {
+  return (
+    <div className="mt-s-2 flex flex-wrap gap-s-3 text-caption-xs">
+      {series.map((s) => (
+        <span key={s.key} className="inline-flex items-center gap-s-1">
+          <span className="inline-block h-2.5 w-2.5 rounded-xs" style={{ backgroundColor: s.color }} aria-hidden />
+          <span className="text-ink-2">{s.label}</span>
+          <span className="text-ink-3">
+            ({s.total} {unit})
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// NSM 선차트 — viewBox 0~100 stretch + non-scaling-stroke(선폭 일정). 좌표 인라인(points).
+// ★ 단일 주차(weeks<2)면 선이 안 그려짐 → 부모가 범례+안내로 대체(스파게티·빈선 방지).
+function SegLineChart({ weeks, series }: { weeks: string[]; series: SegLineSeries[] }) {
+  const max = Math.max(1, ...series.flatMap((s) => s.values));
+  const n = weeks.length;
+  const x = (i: number) => (n <= 1 ? 50 : (i / (n - 1)) * 100);
+  const y = (v: number) => 96 - (v / max) * 92; // 4(상단)~96(하단) 패딩
+  return (
+    <div>
+      <div className="border-b border-card-border">
+        <svg
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          className="w-full"
+          style={{ height: "150px" }}
+          role="img"
+          aria-label="세그먼트별 주간 진단 완료 추세"
+        >
+          {series.map((s) => (
+            <polyline
+              key={s.key}
+              points={s.values.map((v, i) => `${x(i)},${y(v)}`).join(" ")}
+              fill="none"
+              stroke={s.color}
+              strokeWidth="2"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+        </svg>
+      </div>
+      <div className="mt-s-1 flex justify-between text-caption-xs text-ink-3">
+        {weeks.map((w) => (
+          <span key={w}>{w.slice(5)}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// 퍼널 비교 막대 — 단계 그룹 × 세그먼트 막대. 높이 인라인 %, 색 인라인 backgroundColor.
+function SegBarCompare({ steps, series }: { steps: { key: string; label: string }[]; series: SegFunnelSeries[] }) {
+  const max = Math.max(1, ...series.flatMap((s) => s.counts));
+  return (
+    <div>
+      <div className="flex items-end gap-s-3" style={{ height: "150px" }}>
+        {steps.map((st, si) => (
+          <div key={st.key} className="flex h-full flex-1 flex-col justify-end">
+            <div className="flex h-full items-end justify-center gap-1">
+              {series.map((s) => {
+                const v = s.counts[si];
+                const h = max > 0 ? Math.max((v / max) * 100, v > 0 ? 3 : 0) : 0;
+                return (
+                  <div
+                    key={s.key}
+                    className="w-3 rounded-t-xs"
+                    style={{ height: `${h}%`, backgroundColor: s.color }}
+                    title={`${s.label} · ${st.label}: ${v}`}
+                    aria-hidden
+                  />
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-s-1 flex gap-s-3">
+        {steps.map((st) => (
+          <span key={st.key} className="flex-1 text-center text-caption-xs text-ink-3">
+            {st.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function Bar({ count, max, stage }: { count: number; max: number; stage: string }) {
   const width = max > 0 ? Math.max((count / max) * 100, count > 0 ? 4 : 0) : 0;
@@ -138,6 +238,8 @@ export default async function InsightsPage({
   const dauMax = Math.max(1, ...act.dau.map((x) => x.visitors));
   const nsm: NsmTrend = await getNsmTrend(source, mode);
   const login: LoginMethods = await getLoginMethods(source, mode);
+  // ★ 세그먼트 차트 — 소스만 연동(모드 필터 미적용: 차트 자체가 모드/방식으로 분해하므로).
+  const seg: SegmentAnalytics = await getSegmentAnalytics(source);
   const nsmMax = Math.max(1, nsm.target3mo, ...nsm.weeks.map((w) => w.completed));
   const funnelCounts = FUNNEL_STEPS.map((s) => d.counts[s.key] ?? 0);
   const otherCounts = OTHER_EVENTS.map((s) => d.counts[s.key] ?? 0);
@@ -400,6 +502,73 @@ export default async function InsightsPage({
             ※ method 없는/기타 {login.unknown}건(과거 데이터·누락)은 분류에서 제외.
           </p>
         ) : null}
+      </section>
+
+      {/* 세그먼트 분석 — NSM 추세(선) 2 + 퍼널 비교(막대) 2. 목적별 분리(스파게티 방지). */}
+      <section aria-label="세그먼트 분석" className="mt-s-8 border-t border-card-border pt-s-6">
+        <h2 className="text-h3 font-extrabold text-ink">세그먼트 분석 — 로그인 방식 · 모드</h2>
+        <p className="mt-s-1 text-caption-xs leading-relaxed text-ink-3">
+          완료·단계 이벤트를 방문자의 로그인 방식·모드로 귀속(<code>diagnosis_completed</code> 엔 세그먼트 컬럼이 없어{" "}
+          <code>visitorId</code> 로 추론). 소스 토글만 연동(모드 필터 미적용 — 차트가 직접 분해). 추세는 27일치 데이터(preview)에서 의미.
+        </p>
+
+        <div className="mt-s-4 grid gap-s-4 lg:grid-cols-2">
+          {/* ① NSM 추세 — 로그인 방식별(선) */}
+          <div className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+            <p className="text-caption-xs font-bold text-ink-3">① NSM 추세 — 로그인 방식별 (주간 완료)</p>
+            {seg.weeks.length >= 2 ? (
+              <div className="mt-s-3">
+                <SegLineChart weeks={seg.weeks} series={seg.nsmByMethod} />
+              </div>
+            ) : (
+              <p className="mt-s-2 text-caption-xs text-ink-2">추세선은 2주 이상 데이터 필요(현재 {seg.weeks.length}주) — 누적 합계만 표시.</p>
+            )}
+            <SegLegend series={seg.nsmByMethod} unit="건" />
+            {seg.excluded.methodUnknown > 0 ? (
+              <p className="mt-s-2 text-caption-xs text-warning">※ 로그인 방식 미상 방문자 {seg.excluded.methodUnknown}명 제외.</p>
+            ) : null}
+          </div>
+
+          {/* ② NSM 추세 — 모드별(선) */}
+          <div className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+            <p className="text-caption-xs font-bold text-ink-3">② NSM 추세 — 모드별 (주간 완료)</p>
+            {seg.weeks.length >= 2 ? (
+              <div className="mt-s-3">
+                <SegLineChart weeks={seg.weeks} series={seg.nsmByMode} />
+              </div>
+            ) : (
+              <p className="mt-s-2 text-caption-xs text-ink-2">추세선은 2주 이상 데이터 필요(현재 {seg.weeks.length}주) — 누적 합계만 표시.</p>
+            )}
+            <SegLegend series={seg.nsmByMode} unit="건" />
+            {seg.excluded.modeUnknown > 0 ? (
+              <p className="mt-s-2 text-caption-xs text-warning">※ 모드 미상 방문자 {seg.excluded.modeUnknown}명 제외(모드 선택 전 이탈 등).</p>
+            ) : null}
+          </div>
+
+          {/* ③ 퍼널 비교 — 로그인 방식별(막대) */}
+          <div className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+            <p className="text-caption-xs font-bold text-ink-3">③ 퍼널 비교 — 로그인 방식별 (핵심 5단계)</p>
+            <div className="mt-s-3">
+              <SegBarCompare steps={seg.funnelSteps} series={seg.funnelByMethod} />
+            </div>
+            <SegLegend series={seg.funnelByMethod} unit="이벤트" />
+            {seg.excluded.methodUnknown > 0 ? (
+              <p className="mt-s-2 text-caption-xs text-warning">※ 로그인 방식 미상 방문자 {seg.excluded.methodUnknown}명 제외.</p>
+            ) : null}
+          </div>
+
+          {/* ④ 퍼널 비교 — 모드별(막대) */}
+          <div className="rounded-lg border border-card-border bg-surface p-s-4 shadow-card">
+            <p className="text-caption-xs font-bold text-ink-3">④ 퍼널 비교 — 모드별 (핵심 5단계)</p>
+            <div className="mt-s-3">
+              <SegBarCompare steps={seg.funnelSteps} series={seg.funnelByMode} />
+            </div>
+            <SegLegend series={seg.funnelByMode} unit="이벤트" />
+            {seg.excluded.modeUnknown > 0 ? (
+              <p className="mt-s-2 text-caption-xs text-warning">※ 모드 미상 방문자 {seg.excluded.modeUnknown}명 제외(모드 선택 전 이탈 등).</p>
+            ) : null}
+          </div>
+        </div>
       </section>
 
       {/* 핵심 전환율 3종 */}

--- a/onday-app/src/lib/playboard/insights.ts
+++ b/onday-app/src/lib/playboard/insights.ts
@@ -292,3 +292,166 @@ export async function getNsmTrend(source: InsightsSource = "prod", mode?: ModeFi
     target6mo: NSM_TARGET_6MO,
   };
 }
+
+// ── 세그먼트 분석 — 로그인방식/모드별 NSM 추세(선) + 퍼널 비교(막대). 읽기 전용 SELECT. ──
+// ★ diagnosis_completed 엔 method/mode 컬럼이 없음(login_entered=method, 5개 이벤트=mode).
+//   → visitorId → 세그먼트(최초값) 매핑으로 귀속. 매핑 없는 방문자 이벤트는 unknown=차트 제외.
+// ★ 색은 hsl(토큰 var) 문자열 — 페이지에서 선 stroke·막대 backgroundColor 인라인 사용(클래스 0).
+// ★ 좌표/높이는 페이지가 인라인 style 로 렌더(JIT 클래스 의존 0). 데이터 0/단일주차 안전.
+
+export interface SegLineSeries {
+  key: string;
+  label: string;
+  color: string;
+  values: number[]; // weeks 인덱스별 주간 완료수
+  total: number;
+}
+export interface SegFunnelSeries {
+  key: string;
+  label: string;
+  color: string;
+  counts: number[]; // funnelSteps 인덱스별 이벤트수
+  total: number;
+}
+export interface SegmentAnalytics {
+  weeks: string[]; // 양 NSM 선차트 공용 X축(월요일 시작, 최근 NSM_WEEKS)
+  nsmByMethod: SegLineSeries[];
+  nsmByMode: SegLineSeries[];
+  funnelSteps: { key: string; label: string }[];
+  funnelByMethod: SegFunnelSeries[];
+  funnelByMode: SegFunnelSeries[];
+  excluded: { methodUnknown: number; modeUnknown: number }; // 세그 미매핑 방문자수(정직 표기)
+  completions: number; // diagnosis_completed 총건(귀속 전, 참고)
+}
+
+// 퍼널 비교 핵심 단계(login→완료→공유) — 11종 전부는 막대 비교서 스파게티 → 핵심 5단계.
+const SEG_FUNNEL_STEPS = [
+  { key: "login_entered", label: "로그인" },
+  { key: "diagnosis_input_viewed", label: "입력" },
+  { key: "diagnosis_submit_clicked", label: "제출" },
+  { key: "diagnosis_completed", label: "완료" },
+  { key: "share_link_created", label: "공유" },
+] as const;
+
+// 세그먼트 색(hsl 토큰 var) — 선/막대/범례 공용. 톤 구분 우선(카카오 amber·게스트 blue·채용 red).
+const METHOD_COLORS: Record<string, string> = {
+  kakao: "hsl(var(--warning))",
+  guest: "hsl(var(--info))",
+  reviewer: "hsl(var(--danger))",
+};
+const MODE_COLORS: Record<string, string> = {
+  couple: "hsl(var(--primary))",
+  single: "hsl(var(--warning))",
+};
+const METHOD_LABEL: Record<string, string> = { kakao: "카카오", guest: "게스트", reviewer: "채용담당자" };
+const MODE_LABEL: Record<string, string> = { couple: "부부", single: "싱글" };
+const METHOD_SEGS = ["kakao", "guest", "reviewer"] as const;
+const MODE_SEGS = ["couple", "single"] as const;
+
+export async function getSegmentAnalytics(source: InsightsSource = "prod"): Promise<SegmentAnalytics> {
+  const model = delegate(source);
+  // 단일 SELECT — 필요한 컬럼만(preview 수백 행 수준, 충분). write 0.
+  const rows = await model.findMany({
+    select: { eventName: true, visitorId: true, method: true, mode: true, diagnosisId: true, timestamp: true },
+  });
+
+  // 방문자 → 세그먼트(최초 등장값). method=login_entered.method, mode=mode 보유 이벤트.
+  const vMethod = new Map<string, string>();
+  const vMode = new Map<string, string>();
+  for (const r of rows) {
+    if (!r.visitorId) continue;
+    if (r.eventName === "login_entered" && r.method && !vMethod.has(r.visitorId)) vMethod.set(r.visitorId, r.method);
+    if (r.mode && !vMode.has(r.visitorId)) vMode.set(r.visitorId, r.mode);
+  }
+
+  const now = Date.now();
+  // 공용 주차축 — 완료 이벤트 전체 기준(양 NSM 차트 동일 X축).
+  const completionWeeks = new Set<string>();
+  let completions = 0;
+  for (const r of rows) {
+    if (r.eventName === "diagnosis_completed" && r.visitorId && r.timestamp.getTime() <= now) {
+      completionWeeks.add(weekStartUTC(r.timestamp));
+      completions += 1;
+    }
+  }
+  const weeks = [...completionWeeks].sort((a, b) => a.localeCompare(b)).slice(-NSM_WEEKS);
+  const weekIdx = new Map(weeks.map((w, i) => [w, i]));
+
+  // NSM 선 — 세그먼트별 주간 완료(diagnosisId dedup, null=행 폴백).
+  const buildLines = (
+    vMap: Map<string, string>,
+    segs: readonly string[],
+    colors: Record<string, string>,
+    labels: Record<string, string>,
+  ): { series: SegLineSeries[]; unknown: number } => {
+    const buckets = segs.map((s) => ({ key: s, ids: weeks.map(() => new Set<string>()), nulls: weeks.map(() => 0) }));
+    const bySeg = new Map(buckets.map((b) => [b.key, b]));
+    const unknown = new Set<string>();
+    for (const r of rows) {
+      if (r.eventName !== "diagnosis_completed" || !r.visitorId || r.timestamp.getTime() > now) continue;
+      const wi = weekIdx.get(weekStartUTC(r.timestamp));
+      if (wi === undefined) continue;
+      const seg = vMap.get(r.visitorId);
+      const b = seg ? bySeg.get(seg) : undefined;
+      if (!b) {
+        unknown.add(r.visitorId);
+        continue;
+      }
+      if (r.diagnosisId) b.ids[wi].add(r.diagnosisId);
+      else b.nulls[wi] += 1;
+    }
+    const series = buckets.map((b) => {
+      const values = weeks.map((_, i) => b.ids[i].size + b.nulls[i]);
+      return { key: b.key, label: labels[b.key], color: colors[b.key], values, total: values.reduce((a, c) => a + c, 0) };
+    });
+    return { series, unknown: unknown.size };
+  };
+
+  // 퍼널 막대 — 세그먼트별 단계 이벤트수.
+  const buildFunnel = (
+    vMap: Map<string, string>,
+    segs: readonly string[],
+    colors: Record<string, string>,
+    labels: Record<string, string>,
+  ): { series: SegFunnelSeries[]; unknown: number } => {
+    const stepKeys = SEG_FUNNEL_STEPS.map((s) => s.key as string);
+    const buckets = segs.map((s) => ({ key: s, counts: stepKeys.map(() => 0) }));
+    const bySeg = new Map(buckets.map((b) => [b.key, b]));
+    const unknown = new Set<string>();
+    for (const r of rows) {
+      const si = stepKeys.indexOf(r.eventName);
+      if (si === -1 || !r.visitorId) continue;
+      const seg = vMap.get(r.visitorId);
+      const b = seg ? bySeg.get(seg) : undefined;
+      if (!b) {
+        unknown.add(r.visitorId);
+        continue;
+      }
+      b.counts[si] += 1;
+    }
+    const series = buckets.map((b) => ({
+      key: b.key,
+      label: labels[b.key],
+      color: colors[b.key],
+      counts: b.counts,
+      total: b.counts.reduce((a, c) => a + c, 0),
+    }));
+    return { series, unknown: unknown.size };
+  };
+
+  const nsmM = buildLines(vMethod, METHOD_SEGS, METHOD_COLORS, METHOD_LABEL);
+  const nsmMode = buildLines(vMode, MODE_SEGS, MODE_COLORS, MODE_LABEL);
+  const funM = buildFunnel(vMethod, METHOD_SEGS, METHOD_COLORS, METHOD_LABEL);
+  const funMode = buildFunnel(vMode, MODE_SEGS, MODE_COLORS, MODE_LABEL);
+
+  return {
+    weeks,
+    nsmByMethod: nsmM.series,
+    nsmByMode: nsmMode.series,
+    funnelSteps: SEG_FUNNEL_STEPS.map((s) => ({ key: s.key, label: s.label })),
+    funnelByMethod: funM.series,
+    funnelByMode: funMode.series,
+    excluded: { methodUnknown: funM.unknown, modeUnknown: funMode.unknown },
+    completions,
+  };
+}


### PR DESCRIPTION
## 목표
insights 대시보드에 **세그먼트별 분석 차트 4개** 추가. 목적별로 분리해 한눈에(스파게티 방지) — NSM=선차트(추세), 퍼널=막대(단계 비교).

| # | 차트 | 종류 | 세그먼트 |
|---|------|------|----------|
| ① | NSM 추세 — 로그인 방식별 | 선 | 카카오 / 게스트 / 채용담당자 |
| ② | NSM 추세 — 모드별 | 선 | 부부 / 싱글 |
| ③ | 퍼널 비교 — 로그인 방식별 | 막대 | 카카오 / 게스트 / 채용담당자 |
| ④ | 퍼널 비교 — 모드별 | 막대 | 부부 / 싱글 |

## 설계 핵심
- **`diagnosis_completed` 에는 method/mode 컬럼이 없음** (method=login_entered, mode=5개 이벤트). → 방문자 `visitorId → 세그먼트(최초값)` 매핑으로 귀속. 매핑 없는 방문자는 `unknown` = 차트 제외(`excluded` 정직 표기).
- **`getSegmentAnalytics(source)`** — 단일 `findMany` SELECT 후 JS 집계. 양 NSM 차트는 동일 주차축 공유.
- 퍼널 비교는 **핵심 5단계**(로그인→입력→제출→완료→공유)로 압축 — 11종 전부는 막대 비교서 스파게티.

## 인라인 좌표/색 (DAU JIT 교훈)
- 선차트 = SVG `polyline points`(좌표 인라인) + `non-scaling-stroke`(선폭 일정), `stroke`=인라인 색.
- 막대 = 높이 인라인 `style`, 색 인라인 `backgroundColor`. **JIT 클래스 의존 0.**
- 색 = `hsl(토큰 var)` 톤 구분(카카오 amber·게스트 blue·채용 red / 부부 blue·싱글 amber). 범례 제공.
- reviewer="**채용담당자**" 한글, kakao=카카오, guest=게스트.

## 안전 (제출 임박)
- ✅ **기존 무변경** — 퍼널·전환율·DAU·NSM·UTM·모드·로그인방식 코드 미수정. diff = **332 insertions, 0 deletions**.
- ✅ **읽기 전용** — `findMany`(SELECT)만. write·마이그레이션 0. prod `notFound()` 차단 유지.
- ✅ **데이터 적을 때 안전** — 단일 주차(<2주)면 추세선 대신 누적 합계+안내(빈선 방지). 빈/단일점 처리.
- ✅ 소스(prod/preview) 토글 연동. method/mode 미상 행 = unknown 제외 + 경고 문구.

## 검증
- `tsc --noEmit` → 0 / `next lint` → clean / UTF-8 인코딩 검사 → clean
- 라이브 렌더(dev):
  - `?source=preview`(27일치): 선 **5개**(method 3 + mode 2) 렌더, 막대 퍼널 정상(예: 카카오 25→20→14→13→3)
  - `?source=prod`(소량): 선차트 graceful fallback("추세선은 2주 이상" ×4), 막대는 실데이터 렌더 — 무크래시
- 4개 차트 + 범례 + excluded 안내 모두 표시 확인

⚠️ 자동 머지/Close 금지 — 리뷰용 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)