### PR TITLE
feat(analytics): GA4 클라 gtag 마운트 + 11종 이벤트 fan-out (S2)

### DIFF
--- a/onday-app/src/app/layout.tsx
+++ b/onday-app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
+import { GoogleAnalytics } from "@/components/analytics/google-analytics";
 import { Toaster } from "@/components/layout/toaster";
 import { QueryProvider } from "@/providers/query-provider";
 import { SessionBridge } from "@/providers/session-bridge";
@@ -31,6 +32,7 @@ export default function RootLayout({
         <QueryProvider>{children}</QueryProvider>
         <Toaster />
         <SpeedInsights />
+        <GoogleAnalytics />
       </body>
     </html>
   );

--- a/onday-app/src/components/analytics/google-analytics.tsx
+++ b/onday-app/src/components/analytics/google-analytics.tsx
@@ -1,0 +1,23 @@
+import Script from "next/script";
+
+// GA4 gtag 마운트 (S2, T-APP-A) — 무의존 next/script(라이브러리 추가 0).
+// ★ env-guarded: NEXT_PUBLIC_GA_MEASUREMENT_ID 미설정 시 렌더 0(= gtag 미로딩 → gaEvent noop → 회귀 0).
+// ★ 가이드 §0 경고대로 — GA4 콘솔의 수동 설치 스니펫을 붙여넣지 않고 여기서 한 번만 로드(중복 로딩 0).
+// ★ dev(비-production)에선 debug_mode ON → GA4 DebugView 에 실시간 도착 확인 가능.
+// ★ 서버 컴포넌트(layout)에서 렌더 — map 의 useKakaoLoader 와 달리 dynamic ssr:false 가 아니라 next/script 정상 동작.
+
+export function GoogleAnalytics() {
+  const id = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  if (!id) return null; // 키 없으면 마운트 0 — 안전 기본값(GA4만 꺼짐)
+
+  const debug = process.env.NODE_ENV !== "production";
+
+  return (
+    <>
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${id}`} strategy="afterInteractive" />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${id}',{debug_mode:${debug}});`}
+      </Script>
+    </>
+  );
+}

--- a/onday-app/src/lib/analytics/ga-event.ts
+++ b/onday-app/src/lib/analytics/ga-event.ts
@@ -1,0 +1,24 @@
+// GA4 이벤트 전송 — gtag(클라) thin wrapper (S2, 로거 3번째 sink, additive).
+// ★ Mixpanel·자체DB 대체 아님 — 동일 11종 이벤트의 GA4(학습+BigQuery) 경로. 역할 분담: ga4-decision-log.md §0.
+// ★ env-guarded noop: gtag 미로딩(키 미설정 시 google-analytics.tsx 가 마운트 0) → window.gtag 부재 → 조용히 no-op.
+// ★ best-effort — 실패·미지원·서버 사이드 시 no-op(앱·Mixpanel·자체DB·진단 영향 0, throw 0).
+// ★ PII 0 — 호출부(mixpanel.ts)가 비식별 화이트리스트 속성만 전달(주소·좌표·토큰·이메일 없음).
+
+type GaParams = Record<string, string | number | boolean>;
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+/** GA4 로 이벤트 1건 전송. gtag 부재(키 미설정·미로딩) 시 no-op. 절대 throw 안 함. */
+export function gaEvent(name: string, params?: GaParams): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (typeof window.gtag !== "function") return; // 키 미설정·gtag 미로딩 → noop(회귀 0)
+    window.gtag("event", name, params ?? {});
+  } catch {
+    // best-effort — 절대 throw 안 함.
+  }
+}

--- a/onday-app/src/lib/analytics/mixpanel.ts
+++ b/onday-app/src/lib/analytics/mixpanel.ts
@@ -2,6 +2,9 @@ import mixpanel from "mixpanel-browser";
 // ★ DB raw 로거 fan-out (로거 1단계, additive). Mixpanel 전송과 독립 — ensureInit 가드 前 호출.
 //   best-effort no-op 이라 기존 track·퍼널 동작 회귀 0. 역할 분담: EVENT_LOGGER_UTM_PLAN.md §0.
 import { logEvent } from "@/lib/logging/log-event";
+// ★ GA4 3번째 sink (S2, additive). logEvent 와 동일하게 ensureInit 가드 前 호출 → Mixpanel 토큰 유무와 독립.
+//   키 미설정 시 gtag 미로딩 → gaEvent no-op(회귀 0). 역할 분담: ga4-decision-log.md §0.
+import { gaEvent } from "@/lib/analytics/ga-event";
 
 // MON-003 v1.4 부활 (Issue #127) — REQ-NF-008 평균 탐색 완료 시간 p50 ≤ 10분 측정.
 //   diagnosis_started → diagnosis_completed funnel = Mixpanel Dashboard p50 자동 계산.
@@ -33,6 +36,7 @@ function ensureInit(): boolean {
 
 export function trackDiagnosisStarted(diagnosisId: string): void {
   logEvent("diagnosis_started", { diagnosisId });
+  gaEvent("diagnosis_started", { diagnosis_id: diagnosisId });
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_started", {
     diagnosis_id: diagnosisId,
@@ -42,6 +46,7 @@ export function trackDiagnosisStarted(diagnosisId: string): void {
 
 export function trackDiagnosisCompleted(diagnosisId: string): void {
   logEvent("diagnosis_completed", { diagnosisId });
+  gaEvent("diagnosis_completed", { diagnosis_id: diagnosisId });
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_completed", {
     diagnosis_id: diagnosisId,
@@ -55,18 +60,21 @@ export function trackDiagnosisCompleted(diagnosisId: string): void {
 
 export function trackLandingViewed(): void {
   logEvent("landing_viewed");
+  gaEvent("landing_viewed");
   if (!ensureInit()) return;
   mixpanel.track("landing_viewed", { timestamp: Date.now() });
 }
 
 export function trackLoginEntered(method: "kakao" | "guest" | "reviewer"): void {
   logEvent("login_entered", { method });
+  gaEvent("login_entered", { method });
   if (!ensureInit()) return;
   mixpanel.track("login_entered", { method, timestamp: Date.now() });
 }
 
 export function trackDiagnosisInputViewed(mode: "couple" | "single"): void {
   logEvent("diagnosis_input_viewed", { mode });
+  gaEvent("diagnosis_input_viewed", { mode });
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_input_viewed", { mode, timestamp: Date.now() });
 }
@@ -74,6 +82,7 @@ export function trackDiagnosisInputViewed(mode: "couple" | "single"): void {
 // ★ count = 확정된 주소 순번(1=A, 2=B). 주소 title·coordinate·역 이름은 절대 담지 않는다(재식별 차단).
 export function trackAddressVerified(count: 1 | 2): void {
   logEvent("address_verified", { count });
+  gaEvent("address_verified", { count });
   if (!ensureInit()) return;
   mixpanel.track("address_verified", { count, timestamp: Date.now() });
 }
@@ -82,6 +91,7 @@ export function trackAddressVerified(count: 1 | 2): void {
 //   설계의 has_deadline 은 deadline 발 제출 지점이 생기면 그때 추가(없는 값 만들지 않음).
 export function trackDiagnosisSubmitClicked(mode: "couple" | "single"): void {
   logEvent("diagnosis_submit_clicked", { mode });
+  gaEvent("diagnosis_submit_clicked", { mode });
   if (!ensureInit()) return;
   mixpanel.track("diagnosis_submit_clicked", { mode, timestamp: Date.now() });
 }
@@ -93,6 +103,7 @@ export function trackDiagnosisSubmitClicked(mode: "couple" | "single"): void {
 // ★ diagnosis_id = 내부 uuid(기존 diagnosis_started 패턴). 공유 토큰(uniqueUrl)은 담지 않는다.
 export function trackShareLinkCreated(diagnosisId: string, mode: "couple" | "single"): void {
   logEvent("share_link_created", { diagnosisId, mode });
+  gaEvent("share_link_created", { diagnosis_id: diagnosisId, mode });
   if (!ensureInit()) return;
   mixpanel.track("share_link_created", { diagnosis_id: diagnosisId, mode, timestamp: Date.now() });
 }
@@ -100,6 +111,7 @@ export function trackShareLinkCreated(diagnosisId: string, mode: "couple" | "sin
 // ★ mode 만 — share 페이지 data 의 uniqueUrl·addressA/B 는 절대 담지 않는다(재식별 차단).
 export function trackShareLinkClicked(mode: "couple" | "single"): void {
   logEvent("share_link_clicked", { mode });
+  gaEvent("share_link_clicked", { mode });
   if (!ensureInit()) return;
   mixpanel.track("share_link_clicked", { mode, timestamp: Date.now() });
 }
@@ -107,6 +119,7 @@ export function trackShareLinkClicked(mode: "couple" | "single"): void {
 // ★ mode 만 — 불러온 config 의 주소는 절대 담지 않는다.
 export function trackSavedSearchLoaded(mode: "couple" | "single"): void {
   logEvent("saved_search_loaded", { mode });
+  gaEvent("saved_search_loaded", { mode });
   if (!ensureInit()) return;
   mixpanel.track("saved_search_loaded", { mode, timestamp: Date.now() });
 }
@@ -114,6 +127,7 @@ export function trackSavedSearchLoaded(mode: "couple" | "single"): void {
 // ★ days_left(숫자)만 — ISO 날짜 대신 D-day 로 환원(식별성 0).
 export function trackDeadlineModeActivated(daysLeft: number): void {
   logEvent("deadline_mode_activated", { daysLeft });
+  gaEvent("deadline_mode_activated", { days_left: daysLeft });
   if (!ensureInit()) return;
   mixpanel.track("deadline_mode_activated", { days_left: daysLeft, timestamp: Date.now() });
 }


### PR DESCRIPTION
> **Draft** · 머지는 작성자가 직접. GA4 파이프라인 S2 (T-APP-A) 단계.
> 계획·결정: `docs/loop/ga4-decision-log.md` · 설정 가이드: `docs/ga4/SETUP_GUIDE.md` (별도)

## 목표
클라이언트 gtag 마운트 + GA4 이벤트 전송. **측정 3번째 sink**(Mixpanel·자체DB 대체 아님 — 학습 + BigQuery 목적). 전부 **additive · env-guarded noop**.

## 변경 (4파일, 기존 라인 무수정)
| 파일 | 변경 |
|---|---|
| `src/lib/analytics/ga-event.ts` | **신규** — `gaEvent()` best-effort no-op 헬퍼 |
| `src/components/analytics/google-analytics.tsx` | **신규** — 무의존 `next/script` gtag 마운트(env-guarded) |
| `src/app/layout.tsx` | import 1 + `<GoogleAnalytics/>` 1줄 |
| `src/lib/analytics/mixpanel.ts` | import 1블록 + `gaEvent()` **11줄**(각 `logEvent` 옆) |

## 설계 핵심
- **중앙 fan-out**: `mixpanel.ts` 가 이미 `logEvent`(DB)→`mixpanel.track` 구조 → GA4 는 **N+1 sink** 로 끼움(호출부 11곳 zero-touch).
- **독립성**: `gaEvent` 를 `if (!ensureInit()) return;` **앞**(logEvent 옆)에 배치 → Mixpanel 토큰 유무와 무관하게 GA4 동작.
- **env-guarded noop**: `NEXT_PUBLIC_GA_MEASUREMENT_ID` 미설정 시 마운트 0 → `window.gtag` 부재 → `gaEvent` no-op. **키 빼면 GA4만 꺼지고 앱·Mixpanel·자체DB·진단 그대로(회귀 0).**
- **중복 로딩 0**: `next/script` 단일 로드(GA4 콘솔 수동 스니펫 미사용 — 가이드 §0 준수).
- **이중집계 0**: 라이브는 gtag(클라)만. 서버 MP util 은 S3(격리·미와이어).
- **PII 0**: 비식별 화이트리스트 속성만(`method`/`mode`/`count`/`diagnosis_id`/`days_left`).

## 검증
- `tsc --noEmit` 0 / `next lint` clean / UTF-8 인코딩 OK
- 라이브(dev, 키 설정됨): gtag 마운트 · `gtag('config')` **1회** · `debug_mode:true`(dev) · `gaEvent` 호출 **11개** · `<link rel=preload>` 1개(중복 로딩 0) · 앱 정상 렌더(/login 200)
- DebugView 검증법: 진단 흐름 클릭 → GA4 관리→DebugView 에서 이벤트·파라미터 실시간 확인

## 범위 밖 (후속)
- S3: 서버 MP util(격리) · S4: 더미 백필 + DebugView E2E · S5: BigQuery 분석 SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)