### PR TITLE
docs(ga4): GA4 연동 파이프라인 문서 3종 (계획·설정·BigQuery 분석)

### DIFF
--- a/docs/ga4/BIGQUERY_ANALYSIS.md
+++ b/docs/ga4/BIGQUERY_ANALYSIS.md
@@ -1,0 +1,260 @@
+# OnDay — GA4 → BigQuery 분석 가이드 + SQL (T3 / S5)
+
+> 단계: **S5 (마지막)** · 문서만 · 코드 0
+> 목적: GA4 raw 익스포트를 BigQuery SQL 로 분석 — **자체 `insights.ts` 대시보드를 GA4 표준으로 1:1 재현**(학습 핵심)
+> 관련: 설정 = `docs/ga4/SETUP_GUIDE.md` · 계획/결정 = `docs/loop/ga4-decision-log.md`
+
+---
+
+## 0. 왜 BigQuery 인가 (자체 DB ↔ GA4 역할, 정직)
+
+OnDay 는 같은 11종 이벤트를 **3곳**에 적재한다. 분석 관점 비교:
+
+| | 자체 DB (`event_logs`) | GA4 표준 보고서 | **GA4 → BigQuery** |
+|---|---|---|---|
+| 접근 | Prisma SELECT (`insights.ts`) | GA4 콘솔 UI | **표준 SQL(BigQuery)** |
+| raw 행 | ✅ 완전 소유 | ❌ 집계만 | ✅ **이벤트 raw 전체** |
+| 샘플링 | 없음 | 큰 데이터셋서 샘플링 가능 | **없음(raw)** |
+| 비용 | 인프라 내 | 무료 | 무료(샌드박스 한도) |
+| 가치 | 소유·통제 | 즉시 시각화 | **표준 SQL 역량·BI 연동·학습** |
+
+> ★ 결론: BigQuery 는 자체 DB 를 대체하지 않는다. **"내 DB SQL 역량을 업계 표준(GA4) 위에서도 쓴다"** 가 목적. 본 문서의 SQL 은 의도적으로 `insights.ts` 와 같은 지표를 계산해 **대조 학습**한다.
+
+---
+
+## 1. BigQuery 익스포트 설정 (선택)
+
+1. GA4 ⚙️ **관리 → 제품 링크 → BigQuery 링크 → 연결**. (상세: `SETUP_GUIDE.md §8`)
+2. GCP 프로젝트 선택(없으면 무료 생성) · 빈도 **매일(Daily)**(샌드박스 무료) 또는 스트리밍.
+3. 연결 **다음 날부터** 데이터셋 `analytics_<속성ID>` 에 테이블 생성:
+   - `events_YYYYMMDD` — 날짜별 확정 익스포트
+   - `events_intraday_YYYYMMDD` — 당일 실시간(스트리밍 시)
+4. 속성 ID 찾기: GA4 ⚙️ 관리 → 속성 설정 → "속성 ID"(숫자). 데이터셋명 = `analytics_<그 숫자>`.
+
+> 본 가이드 SQL 의 `` `PROJECT.analytics_PROPERTY.events_*` `` 를 본인 값으로 치환. `events_*` 와일드카드 + `_TABLE_SUFFIX` 로 날짜 범위 한정(스캔 비용↓).
+
+---
+
+## 2. GA4 익스포트 스키마 핵심
+
+| 컬럼 | 의미 | OnDay 매핑 |
+|---|---|---|
+| `event_name` | 이벤트명 | `diagnosis_completed` 등 11종 |
+| `event_timestamp` | 발생 micros(UTC) | `TIMESTAMP_MICROS(event_timestamp)` |
+| `event_date` | `'YYYYMMDD'` 문자열 | 일자 집계 키 |
+| `user_pseudo_id` | 익명 사용자 id | **gtag=GA 쿠키 id · MP 더미=`client_id`(우리 `visitorId`)** |
+| `event_params` | `ARRAY<STRUCT<key, value STRUCT<string_value,int_value,double_value,float_value>>>` | 아래 파라미터 |
+
+OnDay 가 보내는 파라미터(비식별, PII 0):
+
+| param | 타입 | 추출 |
+|---|---|---|
+| `method` (kakao/guest/reviewer) | string | `value.string_value` |
+| `mode` (couple/single) | string | `value.string_value` |
+| `count` (1/2) | int | `value.int_value` |
+| `days_left` | int | `value.int_value` |
+| `diagnosis_id` | string | `value.string_value` |
+
+**파라미터 추출 패턴** (모든 쿼리 공통):
+```sql
+(SELECT ep.value.string_value FROM UNNEST(event_params) ep WHERE ep.key = 'method')   -- 문자열
+(SELECT ep.value.int_value    FROM UNNEST(event_params) ep WHERE ep.key = 'count')    -- 정수
+```
+
+> 공통 날짜 변수(각 쿼리 상단에 둘 수 있음):
+> ```sql
+> DECLARE start_date STRING DEFAULT '20260601';
+> DECLARE end_date   STRING DEFAULT FORMAT_DATE('%Y%m%d', CURRENT_DATE());
+> ```
+
+---
+
+## 3. SQL 세트 — `insights.ts` 지표 재현
+
+아래 `PROJECT.analytics_PROPERTY` 는 본인 값으로 치환.
+
+### 3-1. 11종 전환 퍼널 (랜딩 대비 %) — ↔ `getInsights().counts`
+```sql
+WITH counts AS (
+  SELECT event_name, COUNT(*) AS cnt
+  FROM `PROJECT.analytics_PROPERTY.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN start_date AND end_date
+    AND event_name IN (
+      'landing_viewed','login_entered','diagnosis_input_viewed','address_verified',
+      'diagnosis_submit_clicked','diagnosis_started','diagnosis_completed',
+      'share_link_created','share_link_clicked','saved_search_loaded','deadline_mode_activated')
+  GROUP BY event_name
+)
+SELECT
+  event_name,
+  cnt,
+  ROUND(100 * cnt / NULLIF((SELECT cnt FROM counts WHERE event_name = 'landing_viewed'), 0), 1) AS pct_of_landing
+FROM counts
+ORDER BY cnt DESC;
+```
+
+### 3-2. NSM — 주간 진단 완료 수 — ↔ `getNsmTrend()`
+```sql
+SELECT
+  DATE_TRUNC(DATE(TIMESTAMP_MICROS(event_timestamp)), WEEK(MONDAY)) AS week_start,
+  -- insights 와 동일: diagnosis_id distinct + null 은 행 카운트 폴백
+  COUNT(DISTINCT (SELECT ep.value.string_value FROM UNNEST(event_params) ep WHERE ep.key = 'diagnosis_id'))
+    + COUNTIF((SELECT ep.value.string_value FROM UNNEST(event_params) ep WHERE ep.key = 'diagnosis_id') IS NULL) AS completed
+FROM `PROJECT.analytics_PROPERTY.events_*`
+WHERE _TABLE_SUFFIX BETWEEN start_date AND end_date
+  AND event_name = 'diagnosis_completed'
+GROUP BY week_start
+ORDER BY week_start;
+```
+> 목표선 50/주(3개월)·200/주(6개월) = REQ-NF-026 (콘솔/시트에서 오버레이).
+
+### 3-3. 핵심 전환율 3종 — ↔ `getInsights().rates`
+```sql
+WITH c AS (
+  SELECT
+    COUNTIF(event_name='diagnosis_input_viewed') AS input_viewed,
+    COUNTIF(event_name='address_verified'
+      AND (SELECT ep.value.int_value FROM UNNEST(event_params) ep WHERE ep.key='count') = 2) AS addr2,
+    COUNTIF(event_name='diagnosis_submit_clicked') AS submit_clicked,
+    COUNTIF(event_name='diagnosis_started') AS started,
+    COUNTIF(event_name='diagnosis_completed') AS completed,
+    COUNTIF(event_name='share_link_created') AS share_created
+  FROM `PROJECT.analytics_PROPERTY.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN start_date AND end_date
+)
+SELECT
+  ROUND(100*addr2/NULLIF(input_viewed,0),1)        AS input_completion_pct, -- 주소2건 입력완료율
+  ROUND(100*started/NULLIF(submit_clicked,0),1)    AS submit_success_pct,   -- 제출 성공률
+  ROUND(100*share_created/NULLIF(completed,0),1)   AS share_creation_pct    -- 공유 생성률
+FROM c;
+```
+
+### 3-4. 로그인 방식 분포 — ↔ `getLoginMethods()`
+```sql
+SELECT
+  COALESCE((SELECT ep.value.string_value FROM UNNEST(event_params) ep WHERE ep.key='method'), '(unknown)') AS method,
+  COUNT(*) AS cnt
+FROM `PROJECT.analytics_PROPERTY.events_*`
+WHERE _TABLE_SUFFIX BETWEEN start_date AND end_date
+  AND event_name = 'login_entered'
+GROUP BY method
+ORDER BY cnt DESC;
+```
+
+### 3-5. 세그먼트 — NSM 주간완료 × 로그인 방식 — ↔ `getSegmentAnalytics().nsmByMethod`
+```sql
+WITH ev AS (
+  SELECT * FROM `PROJECT.analytics_PROPERTY.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN start_date AND end_date
+),
+-- ★ insights 와 동일한 귀속: diagnosis_completed 엔 method 가 없어 visitor→method(최초 login) 로 추론
+visitor_method AS (
+  SELECT user_pseudo_id,
+    ANY_VALUE((SELECT ep.value.string_value FROM UNNEST(event_params) ep WHERE ep.key='method')) AS method
+  FROM ev WHERE event_name = 'login_entered'
+  GROUP BY user_pseudo_id
+)
+SELECT
+  DATE_TRUNC(DATE(TIMESTAMP_MICROS(c.event_timestamp)), WEEK(MONDAY)) AS week_start,
+  COALESCE(vm.method, '(unknown)') AS method,
+  COUNT(DISTINCT (SELECT ep.value.string_value FROM UNNEST(c.event_params) ep WHERE ep.key='diagnosis_id')) AS completed
+FROM ev c
+LEFT JOIN visitor_method vm USING (user_pseudo_id)
+WHERE c.event_name = 'diagnosis_completed'
+GROUP BY week_start, method
+ORDER BY week_start, method;
+```
+
+### 3-6. 세그먼트 — 퍼널 비교 × 모드 — ↔ `getSegmentAnalytics().funnelByMode`
+```sql
+WITH ev AS (
+  SELECT * FROM `PROJECT.analytics_PROPERTY.events_*`
+  WHERE _TABLE_SUFFIX BETWEEN start_date AND end_date
+),
+visitor_mode AS (
+  SELECT user_pseudo_id,
+    ANY_VALUE((SELECT ep.value.string_value FROM UNNEST(event_params) ep WHERE ep.key='mode')) AS mode
+  FROM ev
+  WHERE (SELECT ep.value.string_value FROM UNNEST(event_params) ep WHERE ep.key='mode') IS NOT NULL
+  GROUP BY user_pseudo_id
+)
+SELECT
+  COALESCE(vm.mode, '(unknown)') AS mode,
+  e.event_name,
+  COUNT(*) AS cnt
+FROM ev e
+LEFT JOIN visitor_mode vm USING (user_pseudo_id)
+WHERE e.event_name IN ('login_entered','diagnosis_input_viewed','diagnosis_submit_clicked','diagnosis_completed','share_link_created')
+GROUP BY mode, event_name
+ORDER BY mode, cnt DESC;
+```
+
+### 3-7. DAU / WAU / MAU — ↔ `getActivity()`
+```sql
+-- 일별 DAU
+SELECT event_date, COUNT(DISTINCT user_pseudo_id) AS dau
+FROM `PROJECT.analytics_PROPERTY.events_*`
+WHERE _TABLE_SUFFIX BETWEEN start_date AND end_date
+GROUP BY event_date ORDER BY event_date;
+
+-- WAU(최근 7일) / MAU(최근 30일) trailing
+SELECT
+  (SELECT COUNT(DISTINCT user_pseudo_id) FROM `PROJECT.analytics_PROPERTY.events_*`
+     WHERE PARSE_DATE('%Y%m%d', event_date) >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY))  AS wau,
+  (SELECT COUNT(DISTINCT user_pseudo_id) FROM `PROJECT.analytics_PROPERTY.events_*`
+     WHERE PARSE_DATE('%Y%m%d', event_date) >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)) AS mau;
+```
+
+### 3-8. UTM 채널별 전환율 — ↔ `getInsights().utm`
+> gtag 라이브 이벤트는 GA4 가 자체 `source`/`medium`/`campaign` 를 부여(traffic_source/collected). 자체 DB 의 `props` utm 과 의미가 비슷하나 출처가 다름 — 아래는 GA4 표준 채널 기준.
+```sql
+SELECT
+  collected_traffic_source.manual_source AS utm_source,
+  COUNTIF(event_name='landing_viewed')      AS landed,
+  COUNTIF(event_name='diagnosis_completed') AS completed,
+  ROUND(100*COUNTIF(event_name='diagnosis_completed')/NULLIF(COUNTIF(event_name='landing_viewed'),0),1) AS conv_pct
+FROM `PROJECT.analytics_PROPERTY.events_*`
+WHERE _TABLE_SUFFIX BETWEEN start_date AND end_date
+GROUP BY utm_source ORDER BY landed DESC;
+```
+> `collected_traffic_source` 는 GA4 최신 익스포트 컬럼. 속성에 없으면 `event_params` 의 자체 `utm_*`(우리가 보낸 경우)로 대체.
+
+---
+
+## 4. `insights.ts` ↔ GA4 BigQuery SQL 1:1 대조표
+
+| 지표 | `insights.ts` 함수 | GA4 SQL | 주의(차이) |
+|---|---|---|---|
+| 11종 퍼널 카운트 | `getInsights().counts` | §3-1 | 동일 |
+| NSM 주간완료 | `getNsmTrend()` | §3-2 | null diagnosis_id 폴백까지 동일 구현 |
+| 전환율 3종 | `getInsights().rates` | §3-3 | 동일 |
+| 로그인 방식 분포 | `getLoginMethods()` | §3-4 | unknown 버킷 동일 |
+| NSM×방식 (세그) | `getSegmentAnalytics().nsmByMethod` | §3-5 | visitor→method 귀속 동일 |
+| 퍼널×모드 (세그) | `getSegmentAnalytics().funnelByMode` | §3-6 | visitor→mode 귀속 동일 |
+| DAU/WAU/MAU | `getActivity()` | §3-7 | `visitorId` ↔ `user_pseudo_id` |
+| UTM 채널 | `getInsights().utm` | §3-8 | 출처 다름(자체 props ↔ GA4 traffic_source) |
+
+---
+
+## 5. 정직한 차이·한계 (자체 DB vs GA4)
+
+- **식별자 차이**: 자체 DB `visitorId`(우리 localStorage) ↔ GA4 `user_pseudo_id`. **gtag 라이브 사용자는 GA 쿠키 id**, **MP 더미(S4)는 `client_id`=우리 `visitorId`**. 둘이 섞이므로 distinct 수가 자체 DB 와 정확히 일치하지 않을 수 있음(정상).
+- **귀속 한계 동일**: `diagnosis_completed` 에 `method`/`mode` 가 없어 visitor 추론으로 귀속 — 자체 `getSegmentAnalytics` 와 같은 한계(매핑 없으면 `(unknown)`).
+- **샘플링**: GA4 표준 보고서엔 샘플링이 있을 수 있으나 **BigQuery raw 엔 없음**(BQ 가 더 정확).
+- **백필 72h**: S4 더미를 원본 시각으로 보냈다면 ~72h 초과분은 GA4 에 미적재될 수 있음(S4는 기본 now 전송으로 회피).
+- **이중집계 0**: 라이브는 gtag 만 → BQ 에 1회만. 더미는 별도 `seed_` 식별자라 라이브와 안 섞임.
+
+---
+
+## 6. GA4 전체 트랙 완료 요약 (S1~S5)
+
+| 단계 | 산출물 | 상태 | PR |
+|---|---|---|---|
+| S0 | 계획 + aztks EVALUATE + 결정 로그 | ✅ `docs/loop/ga4-decision-log.md` | — |
+| S1 | GA4 설정 교육 가이드 | ✅ `docs/ga4/SETUP_GUIDE.md` | — |
+| S2 | 클라 gtag 마운트 + 11종 fan-out | ✅ 코드 | #265 |
+| S3 | 서버 MP util (격리·미와이어) | ✅ 코드 | #266 |
+| S4 | 더미 백필 스크립트 + E2E 검증 | ✅ 코드(실전송 ok 20) | #267 |
+| S5 | BigQuery 분석 가이드 + SQL (본 문서) | ✅ `docs/ga4/BIGQUERY_ANALYSIS.md` | — |
+
+**불변 원칙 (전 단계 공통, 달성):** 기존 Mixpanel·자체DB·진단·로거·대시보드 **무변경(additive only)** · GA4 전 경로 **env-guarded noop(회귀 0)** · **이중집계 0**(라이브 gtag 단일) · **PII 0** · **3중 수집 중복 정직**.

--- a/docs/ga4/SETUP_GUIDE.md
+++ b/docs/ga4/SETUP_GUIDE.md
@@ -1,0 +1,176 @@
+# OnDay — GA4 설정 가이드 (T2)
+
+> 단계: **S1 (설정 가이드)** · 코드 0 · 사용자가 직접 GA4 콘솔에서 키 발급
+> 산출물 종류: 교육/운영 문서 · 최신 GA4 공식 UI 기준 (2025~2026)
+> 관련: 계획·결정 = `docs/loop/ga4-decision-log.md` · 다음 = S2(클라 gtag 마운트)
+
+---
+
+## 0. 먼저 — OnDay 에서 GA4 의 역할 (꼭 읽기)
+
+OnDay 는 **이미 측정 도구 2개**를 운영 중이다. GA4 는 **3번째**이고, 목적이 다르다.
+
+| 도구 | 이미 있음? | 역할 |
+|---|---|---|
+| **Mixpanel** | ✅ 운영 중 | 퍼널·리텐션·p50 (운영 분석 UI) |
+| **자체 DB** (`event_logs` + `/playboard/insights`) | ✅ 운영 중 | raw 원본 소유 + 자체 대시보드 |
+| **GA4** (지금 설정) | ⬜ 신규 | **학습 + 표준 분석(BigQuery 무료 익스포트)** |
+
+**즉 GA4 는 Mixpanel·자체DB 를 대체하지 않는다.** 같은 이벤트를 보되 "업계 표준 도구 숙련 + BigQuery SQL 확장" 목적의 **추가 sink** 다. (중복 정당화 상세: 결정 로그 §0)
+
+### ★★ 이 가이드에서 "하지 말 것" — 설치 스니펫 따라하기 금지
+GA4 콘솔/공식 문서는 데이터 스트림을 만들면 **"이 코드를 `<head>`에 붙여넣으세요"** 라며 gtag.js 스니펫을 준다.
+
+> ❌ **그 스니펫을 OnDay 코드에 붙여넣지 말 것.**
+> ✅ OnDay 는 **S2 단계에서 `next/script` 로 직접 마운트**한다(기존 map-canvas-kakao 패턴, 중복·이중로딩 방지).
+> **이 가이드(S1)에서 당신이 할 일은 오직 "키(Measurement ID) 발급"까지.** 코드는 우리가 S2에서 붙인다.
+
+(Mixpanel·Sentry 도입 때와 동일한 방식 — 콘솔에서 키만 받아 `.env` 에 넣고, 마운트는 우리 코드가 통제.)
+
+---
+
+## 1. GA4 계정·속성이 이미 있는지 확인
+
+1. <https://analytics.google.com> 접속 (OnDay 운영 구글 계정으로 로그인).
+2. 화면이 뜨는 형태로 판단:
+   - **대시보드(보고서)가 바로 보이면** → 이미 계정+속성 있음. → **2번은 건너뛰고 §1-1 로**.
+   - **"측정 시작"/"Start measuring" 환영 화면이면** → 계정 없음. → **§2 로**.
+3. 좌측 하단 **⚙️ 관리(Admin)** 클릭 → 상단에 **계정(Account)** / **속성(Property)** 2개 열이 보인다.
+
+### §1-1. 기존 속성이 OnDay 용인지 확인
+- **속성(Property)** 열의 드롭다운에서 속성 목록 확인.
+- OnDay 전용 속성이 없고 다른 프로젝트만 있으면 → **새 속성만 생성**(§2-2 부터, 계정 생성은 생략).
+- ⚠️ **GA4 속성인지 확인**: 속성 설정에 "데이터 스트림(Data Streams)" 메뉴가 있으면 GA4. (구 Universal Analytics 는 2023.7 종료 — 신규는 전부 GA4.)
+
+---
+
+## 2. (없으면) GA4 계정·속성 생성
+
+> GA4 콘솔 UI 는 자주 바뀐다. 아래는 2025~2026 기준 흐름. 버튼 명칭이 조금 달라도 순서는 동일.
+
+### §2-1. 계정 생성 (계정이 아예 없을 때만)
+1. ⚙️ **관리(Admin)** → 계정 열의 **+ 만들기(Create)** → **계정(Account)**.
+2. **계정 이름**: 예) `OnDay`.
+3. 데이터 공유 설정: 기본값 유지(원하면 해제) → **다음**.
+
+### §2-2. 속성 생성
+1. **속성 이름**: 예) `OnDay (온데이)`.
+2. **보고 시간대**: `대한민국 (GMT+09:00) 서울`.
+3. **통화**: `대한민국 원 (₩)`.
+4. **다음** → 비즈니스 정보(업종/규모) 적당히 선택 → 비즈니스 목표 선택(예: "사용자 행동 검토") → **만들기**.
+5. 약관 동의(국가=대한민국) → 동의.
+
+### §2-3. 플랫폼 선택 → 웹
+- 속성 생성 직후 "데이터 수집 시작 / 플랫폼 선택" 화면이 뜬다 → **웹(Web)** 선택. → 바로 §3(데이터 스트림)로 이어진다.
+
+---
+
+## 3. 웹 데이터 스트림 설정 (OnDay 도메인)
+
+> 데이터 스트림 = "이 웹사이트에서 들어오는 데이터 통로". 여기서 **Measurement ID 가 발급**된다.
+
+1. (자동으로 안 떴다면) ⚙️ **관리** → **데이터 스트림(Data streams)** → **스트림 추가 → 웹**.
+2. **웹사이트 URL**: `https://onday-design-project.vercel.app`
+   (Vercel 프로덕션 도메인. 커스텀 도메인 있으면 그걸로. preview 도메인은 등록 불필요 — 우리 코드가 env 로 제어.)
+3. **스트림 이름**: 예) `OnDay Web (prod)`.
+4. **향상된 측정(Enhanced measurement)**: 기본 ON 유지(페이지뷰·스크롤 등 자동). OnDay 핵심 11종 이벤트는 S2에서 우리가 직접 보낸다.
+5. **스트림 만들기(Create stream)**.
+
+> ⚠️ 스트림 생성 후 **"태그 설치 안내 / gtag.js 스니펫"** 화면이 나온다 → **§0의 경고대로 무시**. 스니펫 복사 ❌. **Measurement ID 만** 다음 단계에서 복사.
+
+---
+
+## 4. Measurement ID (G-XXXXXXXXXX) 찾기·복사
+
+1. ⚙️ **관리** → **데이터 스트림** → 방금 만든 **웹 스트림** 클릭.
+2. 스트림 상세 화면 **우측 상단**에 `측정 ID(Measurement ID)` = **`G-` 로 시작하는 10자리** (예: `G-ABCD123XYZ`).
+3. 옆의 **복사 아이콘** 클릭 → 복사.
+
+> 이 값이 우리가 필요한 **유일한 필수 키**다. (`G-...` = 공개값 — 클라 번들에 노출돼도 안전. Mixpanel `NEXT_PUBLIC_*` 토큰과 동일 성격.)
+
+---
+
+## 5. (선택·미리) Measurement Protocol API secret — S4 용
+
+S4(더미 로그 → GA4 서버 전송) 에서 필요하다. 지금 같이 받아두면 편하다.
+
+1. 같은 **웹 스트림 상세** 화면 → 아래로 스크롤 → **Measurement Protocol API secrets**.
+2. **만들기(Create)** → 별칭(예: `onday-server`) → 생성.
+3. 표시되는 **secret 값**을 복사(서버 전용 비밀 — 절대 클라/깃에 노출 금지).
+
+> S4 전까지는 안 써도 된다. 라이브 이벤트는 클라 gtag 만 보내고(결정 D1), 이 secret 은 **더미 백필/서버 예비** 용이다.
+
+---
+
+## 6. DebugView 위치 (나중 검증용)
+
+S2 마운트 후 "이벤트가 진짜 GA4 에 도착하나" 를 **실시간** 확인하는 화면.
+
+- ⚙️ **관리** → **DebugView**. (또는 좌측 보고서 영역 하단)
+- 지금은 **위치만 기억**하면 된다. 데이터는 아직 안 들어온다(코드 미마운트).
+- S2 에서 우리가 **개발 환경에 `debug_mode` 를 켜서** 보내므로, S2 검증 때 이 화면에 OnDay 이벤트(`diagnosis_completed` 등)가 흐르는 걸 보게 된다.
+- (참고) 실시간 전체 트래픽은 **보고서 → 실시간(Realtime)** 에서도 확인 가능.
+
+---
+
+## 7. env 설정 — Mixpanel·Sentry 와 동일 패턴
+
+발급한 Measurement ID 를 **2곳**에 넣는다. (Mixpanel `NEXT_PUBLIC_MIXPANEL_TOKEN`, Sentry DSN 넣던 방식 그대로.)
+
+### 7-1. 로컬 — `onday-app/.env.local`
+```bash
+# GA4 (학습 + BigQuery 목적 · S2에서 next/script로 마운트)
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-ABCD123XYZ
+
+# (선택, S4용 — 서버 Measurement Protocol)
+GA4_API_SECRET=여기에_secret_붙여넣기
+```
+
+### 7-2. 프로덕션 — Vercel
+- Vercel 프로젝트 → **Settings → Environment Variables**.
+- `NEXT_PUBLIC_GA_MEASUREMENT_ID` = `G-...` 추가 → 환경 **Production**(원하면 Preview 도 ) 체크.
+- (선택) `GA4_API_SECRET` 추가 — 환경에서 **Production** 만(서버 비밀).
+- ⚠️ **`NEXT_PUBLIC_*` 는 빌드타임 inline** → 추가/변경 후 **반드시 Redeploy** 해야 반영(기존 Mixpanel·Supabase 키 교훈과 동일).
+
+> ✅ **키 미설정 = 안전 기본값**: S2 코드는 `NEXT_PUBLIC_GA_MEASUREMENT_ID` 가 없으면 gtag 를 아예 마운트하지 않는다(noop). 즉 키를 안 넣으면 GA4 만 꺼질 뿐 **앱·Mixpanel·자체DB·진단 전부 그대로**. 회귀 0.
+
+---
+
+## 8. (선택) BigQuery 연결 — 분석은 S5
+
+GA4 의 가장 큰 가치(무료 raw 익스포트). 지금 연결만 해두면 데이터가 쌓이기 시작한다.
+
+1. ⚙️ **관리** → **제품 링크(Product links)** → **BigQuery 링크** → **연결(Link)**.
+2. 구글 클라우드 프로젝트 선택(없으면 무료 GCP 프로젝트 생성) → 위치 `대한민국`/`미국` → 빈도 **매일(Daily)**(샌드박스 무료) → 제출.
+3. **상세 스키마·SQL 분석은 S5(T3 가이드)** 에서 다룬다. 여기선 연결만.
+
+> 연결 직후엔 익스포트가 없고, 다음 날부터 `events_YYYYMMDD` 테이블이 생긴다. 그래서 **연결을 일찍** 해두는 게 좋다.
+
+---
+
+## 9. 완료 체크리스트
+
+- [ ] analytics.google.com 접속 가능(OnDay 운영 구글 계정)
+- [ ] GA4 **속성** 존재(OnDay 용) — 데이터 스트림 메뉴 확인
+- [ ] **웹 데이터 스트림** 생성(URL = Vercel 프로덕션 도메인)
+- [ ] **Measurement ID `G-...`** 복사함
+- [ ] (선택) **MP API secret** 복사함(S4용)
+- [ ] **DebugView** 위치 확인함
+- [ ] `.env.local` 에 `NEXT_PUBLIC_GA_MEASUREMENT_ID` 추가
+- [ ] Vercel 에 `NEXT_PUBLIC_GA_MEASUREMENT_ID` 추가(+ Redeploy 예정)
+- [ ] (선택) BigQuery 링크 연결
+- [ ] ⛔ gtag.js 설치 스니펫은 **붙여넣지 않음**(S2가 처리)
+
+---
+
+## 10. 다음 단계 — S2 예고 (클라 gtag 마운트)
+
+S1 에서 키만 발급했다. S2 에서 **코드로** 연결한다(전부 additive·env-guarded noop):
+
+- 신규 `src/components/analytics/google-analytics.tsx` — `next/script` 로 gtag.js 로드. `NEXT_PUBLIC_GA_MEASUREMENT_ID` 없으면 **렌더 0**.
+- 신규 `src/lib/analytics/ga-event.ts` — `gaEvent(name, params)` thin wrapper(best-effort no-op, PII 0).
+- `src/lib/analytics/mixpanel.ts` 중앙 트래커 11종에 `gaEvent(...)` **1줄씩 추가**(기존 라인 무수정).
+- `src/app/layout.tsx` 에 `<GoogleAnalytics />` 마운트.
+- 개발 환경 `debug_mode` → DebugView 로 도착 검증.
+
+→ **S2 는 별도 승인 후 시작.** (이 가이드 단계는 여기서 멈춤.)

--- a/docs/loop/ga4-decision-log.md
+++ b/docs/loop/ga4-decision-log.md
@@ -1,0 +1,142 @@
+# GA4 연동 파이프라인 — 결정 로그 + 구현 계획
+
+> 상태: **1단계(계획 수립) 완료 · 구현 대기(사용자 승인 후 단계별)**
+> 작성: 2026-06-25 · 통제 모드: 발표/제출 임박 → 단계별 멈춤·사용자 승인·additive·회귀 0
+> SSoT 정합: `docs/EVENT_LOGGER_UTM_PLAN.md §0`(측정 도구 역할 분담), `docs/LOG_IMPLEMENTATION_OUTLINE.md`
+
+---
+
+## 0. 목적 · 3중 수집 정당화 (정직)
+
+OnDay 는 이미 **2개 측정 경로**를 운영 중이다. GA4 는 **3번째**다. 중복을 숨기지 않고 역할로 분리한다.
+
+| 경로 | 수집 위치 | 역할 | 강점 | 한계 |
+|---|---|---|---|---|
+| **Mixpanel** | `mixpanel.ts` 클라 track | 운영 퍼널·리텐션·p50(REQ-NF-008) | 퍼널/코호트 UI 즉시 | 무료 한도·로우데이터 접근 제한 |
+| **자체 DB** (`event_logs`) | `/api/events` → Prisma | raw 원본 보관 + `/playboard/insights` 대시보드 | 완전 소유·SQL 자유·PII 0 통제 | 운영자 도구 한정·BI 미연동 |
+| **GA4** (신규) | gtag(클라) + MP(서버) | **학습 + 표준 분석(BigQuery)** | 업계 표준·**BigQuery 무료 익스포트**·DebugView | 샘플링·스키마 학습곡선 |
+
+**3중 정당화:** ① GA4 는 **부트캠프 학습 목표**(표준 도구 숙련). ② **BigQuery 네이티브 익스포트**로 자체 DB SQL 역량을 GA4 데이터에도 확장(T3). ③ Mixpanel·자체 DB 는 **그대로 유지** — GA4 는 **추가 sink** 일 뿐 대체 아님. 셋 다 **동일 11종 이벤트**를 보되 목적이 다르다(운영/소유/학습+표준).
+
+> ⚠️ 중복 비용 인지: 같은 이벤트가 3곳에 적재된다. GA4 는 무료 한도(월 1천만 이벤트 + BigQuery 샌드박스) 내라 추가 비용 0 예상. 정당화 안 되면 GA4 도입 자체를 보류하는 게 정직한 선택지임도 명시.
+
+---
+
+## 1. 코드베이스 앵커 (현재, 무변경 대상)
+
+| 앵커 | 경로 | 역할 | GA4 가 닿는 방식 |
+|---|---|---|---|
+| **중앙 트래커 (fan-out)** | `src/lib/analytics/mixpanel.ts` | 11종 `trackXxx()` = `logEvent()`(DB) → `mixpanel.track()` | ★ **여기에 3번째 sink `gaEvent()` 추가**(additive) |
+| 클라 emitter | `src/lib/logging/log-event.ts` | `/api/events` sendBeacon | 무변경 |
+| 서버 insert | `src/lib/logging/log-event-server.ts` | `event_logs`/`preview_event_logs` | 무변경 |
+| 수집기 | `src/app/api/events/route.ts` | enum-gate + PII-0 sanitize → **현재 DB insert 전용(미러 없음)** | ★ (신규·선택) 서버 MP 미러 분기 추가 지점 — 현재 없음 |
+| 대시보드 | `src/lib/playboard/insights.ts` · `.../insights/page.tsx` | 자체 DB 집계 | 무변경 (T3 SQL 이 GA4 측 동등물) |
+| 루트 레이아웃 | `src/app/layout.tsx` | 현재 analytics 마운트 0 | ★ gtag `<Script>` 마운트 지점 |
+| env 검증 | `src/lib/env.ts` | NEXT_PUBLIC 분리 | ★ GA4 키 (선택) 추가 |
+
+**핵심 설계 원칙:** 중앙 트래커(`mixpanel.ts`)가 이미 "1 호출 → N sink" 구조다. GA4 는 **N+1 sink** 로 끼우면 호출부(컴포넌트) 전부 무변경. 회귀 표면 최소.
+
+---
+
+## 2. 4종 산출물 — 풀버전 스펙
+
+### T-APP (코드, critical path) — gtag 마운트 + 서버 미러링
+2단계로 분할.
+
+- **T-APP-A · 클라 gtag (실시간 클라 이벤트)**
+  - 신규 `src/components/analytics/google-analytics.tsx` — `next/script`(map-canvas-kakao 패턴 계승)로 gtag.js 로드. `NEXT_PUBLIC_GA_MEASUREMENT_ID` 미설정 시 **렌더 0 = noop**(Mixpanel `ensureInit` 철학 동일).
+  - 신규 `src/lib/analytics/ga-event.ts` — `gaEvent(name, params)` thin wrapper. `window.gtag` 부재·키 부재 시 best-effort no-op. PII 0(기존 화이트리스트 속성만 전달).
+  - `mixpanel.ts` 각 `trackXxx()` 에 `gaEvent(...)` **1줄 추가**(logEvent·mixpanel.track 다음, additive). 기존 라인 무수정.
+  - `src/app/layout.tsx` 에 `<GoogleAnalytics />` 마운트(1줄).
+  - 대안: `@next/third-parties/google` 의 `<GoogleAnalytics>` — 공식이나 신규 의존성. **기본은 무의존 next/script 권장**(1인 MVP·완전 통제).
+
+- **T-APP-B · 서버 미러링 (Measurement Protocol)**
+  - 신규 `src/lib/analytics/ga-measurement-protocol.ts` — `sendGa4Event(clientId, name, params)` → `POST https://www.google-analytics.com/mp/collect?measurement_id=...&api_secret=...`. `GA4_API_SECRET`·`NEXT_PUBLIC_GA_MEASUREMENT_ID` 미설정 시 no-op. best-effort(throw 0). `client_id` = 익명 `visitorId` 재사용(PII 0).
+  - ★ **이중 수집(double-count) 결정 필요** — 라이브 이벤트를 클라 gtag + 서버 MP **둘 다** 보내면 GA4 가 2배 집계(기본 dedup 없음). → **권장: 라이브는 gtag(클라)만, MP util 은 (1) T1 더미 백필 (2) 향후 진짜 서버 전용 이벤트 용으로 보유.** `/api/events` 에 라이브 미러 와이어링은 **기본 보류**(이중집계 회피). 전체 서버 미러를 원하면 gtag 이벤트 전송을 끄고 MP 단일화하는 별도 결정으로.
+  - → **§5 미결 결정 D1** 에서 사용자 선택.
+
+### T1 (스크립트) — 더미 로그 GA4 전송 (preview 더미 활용)
+- 신규 `scripts/send-preview-events-to-ga4.ts` — `preview_event_logs` 의 `seed_` 행을 읽어 **MP util 로 GA4 전송**(읽기 전용 SELECT, DB write 0). `seed-preview-events.ts` 격리 패턴 계승.
+- 목적: **실 트래픽 전에 파이프라인 E2E 검증** — GA4 DebugView/Realtime 에서 이벤트·파라미터(method/mode/count…) 도착 확인.
+- 안전: prod `event_logs` 미접근. 키 미설정 시 안내 후 종료.
+
+### T2 (문서) — GA4 설정 교육 가이드
+- 신규 `docs/ga4/SETUP_GUIDE.md` — ① GA4 속성·데이터 스트림 생성 ② `Measurement ID(G-XXXX)` + `Measurement Protocol API secret` 발급 ③ env 등록(`NEXT_PUBLIC_GA_MEASUREMENT_ID`, `GA4_API_SECRET` — **사용자가 설정**, Mixpanel·Sentry 동일) ④ DebugView 검증 ⑤ BigQuery 링크(무료 익스포트) 설정. 스크린샷 자리표시 + 단계별 체크리스트.
+
+### T3 (문서) — GA4→BigQuery 분석 가이드 + SQL
+- 신규 `docs/ga4/BIGQUERY_ANALYSIS.md` — GA4 BigQuery 익스포트 스키마(`events_YYYYMMDD`, `event_params` nested) 설명 + **SQL 세트**:
+  - NSM: 주간 `diagnosis_completed` 수(자체 insights NSM 동등물)
+  - 퍼널: 11종 단계별 카운트 + 전환율
+  - 세그먼트: `method`(kakao/guest/reviewer)·`mode`(couple/single)별 분해 — `UNNEST(event_params)` 패턴
+  - DAU/WAU/MAU: `user_pseudo_id` distinct
+- 자체 `insights.ts` 로직을 GA4 SQL 로 옮긴 **1:1 대조표**(소유 DB ↔ GA4 표준) — 학습 가치 핵심.
+
+---
+
+## 3. 구현 로드맵 (안전 순서 · 단계별 멈춤)
+
+> 각 단계: 구현 → tsc/lint → **멈춤·사용자 보고** → aztks EVALUATE(검토) → 사용자 승인 → 다음.
+> 커밋·푸시·이슈·머지 = **사용자 직접**. 나는 working-tree 변경 + (승인 시) Draft PR 준비까지.
+
+| 단계 | 산출물 | 코드 위험 | 이유(순서) |
+|---|---|---|---|
+| **S0 (현재)** | 본 계획 + aztks EVALUATE + 결정 로그 | 0 (문서) | 방향 확정 먼저 |
+| **S1** | T2 설정 가이드 문서 | 0 (문서) | 키 발급이 모든 코드의 선행 조건. 가장 안전 |
+| **S2** | T-APP-A 클라 gtag | 낮음 (env unset=noop) | 단일 sink 추가, 회귀 표면 최소. 라이브 검증 가능 |
+| **S3** | T-APP-B 서버 MP util | 낮음 (util만, 미와이어) | 능력만 추가, 라이브 미러 보류(이중집계 회피) |
+| **S4** | T1 더미 전송 스크립트 | 낮음 (읽기전용 스크립트) | MP util 검증 + DebugView E2E |
+| **S5** | T3 BigQuery 분석 가이드+SQL | 0 (문서) | 데이터 도착 후 분석. 마지막 |
+
+**안전 근거:** 문서(S1)→noop 가능한 클라 코드(S2)→격리 util(S3)→읽기전용 스크립트(S4)→문서(S5). **위험 오름차순이 아니라 의존성 순**이며, 코드 변경은 전부 env-guarded noop/additive 라 키 미설정 prod 에 **회귀 0**.
+
+---
+
+## 4. 환경 변수 (사용자가 설정 — Mixpanel·Sentry 동일)
+
+| 키 | 용도 | 공개 | 미설정 시 |
+|---|---|---|---|
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | gtag + MP measurement_id (G-XXXX) | 클라(inline) | gtag 미마운트·MP no-op |
+| `GA4_API_SECRET` | Measurement Protocol 인증 | 서버 전용 | MP no-op |
+
+> 키 미설정이 **기본 안전 상태**: 모든 GA4 경로 noop → 기존 동작 완전 보존. env.ts 검증 추가는 **optional**(필수화하면 키 없는 환경 깨짐 → required 금지, optional 만).
+
+---
+
+## 5. 결정 확정 (2026-06-25, 사용자 승인 완료)
+
+- **D4 — GA4 도입: ✅ 진행** (학습 + BigQuery 목적, 3중 중복 정당화 수용).
+- **D1 — 서버 미러링: ✅ (a) gtag(클라) 라이브 + MP 는 T1 더미/향후 서버전용 예비.** 라이브 이중집계 0. `/api/events` 라이브 미러 와이어링은 안 함.
+- **D2 — gtag 마운트: ✅ (a) 무의존 `next/script` 래퍼** (map-canvas-kakao 패턴 계승, 신규 의존성 0).
+- **D3 — env.ts: ✅ optional 추가만** (required 금지 — 키 없는 환경 무회귀).
+
+→ S2(T-APP-A): `next/script` 래퍼 + `ga-event.ts` + `mixpanel.ts` fan-out. S3(T-APP-B): MP util 격리(미와이어). 확정 반영.
+
+---
+
+## 6. 안전·정직 체크리스트 (전 단계 공통)
+
+- [ ] 기존 Mixpanel·자체DB·진단·로거·대시보드 **코드 무변경**(additive only, 라인 무수정)
+- [ ] GA4 전 경로 **env-guarded noop** — 키 미설정 시 회귀 0
+- [ ] PII 0 — 기존 화이트리스트 속성만(주소·좌표·토큰·이메일 0). `client_id`=익명 visitorId
+- [ ] best-effort — GA4 실패가 앱/기존 track 영향 0 (throw 0)
+- [ ] 단계별 멈춤·사용자 승인 · 병렬 자동 EXECUTE 금지 · TURN 자동 재개 금지
+- [ ] 커밋·푸시·이슈·머지 = 사용자 직접
+- [ ] 3중 수집 중복 정직 명시(본 문서 §0)
+
+---
+
+## 7. aztks EVALUATE 결과 (S0, 2026-06-25)
+
+**판정: GO** — 단계별 구현 진행 가능. FAIL 축 0.
+
+| 축 | 점수 | 요지 |
+|---|---|---|
+| A 알아서 | 5 | 4종 산출물 + 단계(S0~S5) + env + 위험 + 미결결정(D1~D4) + 보류옵션 전부 커버 |
+| Z 잘 | 5 | N+1 sink fan-out 정확, 이중집계 위험 명시 + 건전한 기본값, noop/best-effort 가드가 기존 패턴 계승 |
+| T 딱 | 4 | 앵커가 실제 코드와 일치. 1건 drift(아래 fix) 교정함 |
+| K 깔끔 | 5 | 섹션별 표·위험순 로드맵·★마커로 skimmable |
+| S 센스 | 5 | 3중 중복 정직(보류가 정직 포함)·단계별 멈춤·키 사용자설정·PII0 체크리스트 = 즉시 실행가능 |
+
+**적용한 단일 최고레버리지 fix:** §1 `/api/events` 행이 서버 MP 미러가 이미 "분기"하는 것처럼 읽힘 → 현재 DB insert 전용(미러 없음)임을 명시(무회귀 baseline 정확화, S3 "미와이어"와 정합). ✅ 반영 완료.
+
+검증 근거: fan-out `mixpanel.ts:34-41`, 수집기 DB-only `api/events/route.ts:53-63`, layout analytics 0, env.ts GA4 키 0, `seed-preview-events.ts` 존재 — 전부 확인됨.


### PR DESCRIPTION
> **Draft** · 머지는 작성자가 직접. **문서만 — 코드 0.**

GA4 연동 파이프라인(S1~S5)의 문서 산출물 모음. 코드 PR(#265 S2 · #266 S3 · #267 S4)과 분리.

## 추가 문서 (3종)
| 파일 | 내용 |
|---|---|
| `docs/loop/ga4-decision-log.md` | 계획 + 3중 수집 정당화 + aztks EVALUATE(GO) + 확정 결정(D1~D4) |
| `docs/ga4/SETUP_GUIDE.md` | GA4 계정·속성·웹스트림·Measurement ID·DebugView·env 설정 (★ 설치 스니펫 금지) |
| `docs/ga4/BIGQUERY_ANALYSIS.md` | BigQuery 스키마 + SQL 8종 + `insights.ts` ↔ GA4 1:1 대조표 |

## 안전
- **코드 변경 0** (docs/ 만). 기존 무변경.
- GA4 무관 기존 untracked 문서(EVENT_LOGGER_UTM_PLAN·LOG_IMPLEMENTATION_OUTLINE·DB_SPEC_DEFINITION·reviews)는 **미포함**.

## 관련 PR
- #265 (S2 클라 gtag) · #266 (S3 서버 MP util) · #267 (S4 더미 백필)

🤖 Generated with [Claude Code](https://claude.com/claude-code)