### PR TITLE
test(playboard): 무결성 불변식 테스트 + 거버넌스 절 보강 (P0)

### DIFF
--- a/onday-app/CLAUDE.md
+++ b/onday-app/CLAUDE.md
@@ -133,6 +133,8 @@ lsof -ti:3000 | xargs kill -9 2>/dev/null; rm -rf .next && npm run dev
 
 OnDay는 화면·기능·기술기획의 **운영 현황을 Playboard**로 단일 관리한다.
 
+> **제1원칙 (불가침):** **표시되는 모든 것은 레지스트리에서 파생한다 — 두 곳을 손으로 맞추지 않는다.** 사실(fact)은 `registry.ts` 한 곳에만 적고, 모든 상황판 화면(`/playboard*`)은 그것을 계산해 보여준다. 화면에 하드코딩된 목록을 두지 않는다. 이 원칙이 깨지는 순간(보드와 실제가 따로 노는 순간) Playboard의 효용이 동시에 무너진다.
+
 - **SoT**: `src/lib/playboard/registry.ts` (화면 9 · 사용자 flow 5 · 기술기획 항목 · mission-critical 6영역 · `SCREEN_SPECS`[화면별 5종: 요구사항·게이트·데이터계약·예외·NFR] · `AREA_SPECS`[영역별 제어 스펙] · `CONVERGENCE`[갭 후속]).
 - **상황판**: `/playboard`(인덱스·커버리지 매트릭스·흐름) → `/playboard/[id]`(화면 상세) → `/playboard/flow/[type]`(흐름). 정적 렌더, registry만 참조(진단·DB import 0).
 
@@ -151,3 +153,16 @@ OnDay는 화면·기능·기술기획의 **운영 현황을 Playboard**로 단�
 - **unplanned** — SRS/PRD에도 없음(순수 미기획, 예: DB 자동 롤백). 현재 1건.
 
 > 모든 항목은 `evidence`(SRS/PRD/CON ID 또는 코드 `file:line`)를 둔다 — 추측·창작 금지. 근거 없으면 `unplanned`로 정직 표기.
+
+### ★ 양방향 싱크 (위성 기준 문서 ↔ 레지스트리)
+상세 기준 문서(`docs/05_SRS_*.md`·`docs/00_PRD_*.md`·`DB_SPEC_DEFINITION.md`·`docs/perf/*` 등)는 레지스트리의 **위성 문서**다.
+- 어느 쪽이 바뀌든 **같은 PR에서 양쪽을 함께 갱신**한다(문서만 고치고 registry 방치 금지, 반대도 금지).
+- 원천 기획서(PRD/SRS)는 **근거로 동결**하고, 충돌 시 Playboard registry가 우선임을 전제한다. 요구사항 변경은 원천이 아니라 **registry의 해당 `SCREEN_SPECS`/`AREA_SPECS`에 반영**하고 evidence로 원천을 가리킨다.
+
+### ★ 갭 승격 규칙 (갭은 줄어드는 방향이 정상)
+- `AREA_SPECS`의 `unimplemented`/`unplanned` 제어나 `CONVERGENCE`의 갭이 **해소되면**, 그 자리를 `implemented`(+ `evidence` `file:line`)로 **승격**하고 갭 목록(`CONVERGENCE`)에서 제거한다.
+- 빈 갭 ≠ 갭 없음. 미정은 정직하게 `gapNote`/`CONVERGENCE`에 남긴다(숨기고 "완료" 선언 금지).
+
+### ★ 무결성 테스트 green 게이트 (강제 메커니즘)
+- 위 규칙의 정합성은 `src/lib/playboard/registry.test.ts`(vitest)가 자동 강제한다 — 고아 참조 0·영역 키 집합 정합·`implemented`→`evidence` 필수·evidence 경로 실재·커버리지 매트릭스 이중정의 금지.
+- **이 테스트가 빨간 채로 머지하지 않는다.** 빨간 테스트 = 보드가 코드와 따로 놀고 있다는 직접 신호. registry 변경 PR은 `npm test`가 green이어야 머지.

--- a/onday-app/src/lib/playboard/registry.test.ts
+++ b/onday-app/src/lib/playboard/registry.test.ts
@@ -1,0 +1,208 @@
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AREA_SPECS,
+  CONVERGENCE,
+  CRITICAL_AREAS,
+  type CriticalAreaId,
+  SCREEN_SPECS,
+  SCREENS,
+  TECH_ITEMS,
+  USER_FLOWS,
+  buildCoverageMatrix,
+} from "./registry";
+
+// Playboard SoT 무결성 불변식 — playboard-skill §10 / 재현 체크리스트 대응.
+//   ★ 이 테스트는 레지스트리(registry.ts)를 변경하지 않고 정합성만 강제한다.
+//   ★ green = "보드가 코드와 따로 놀지 않는다"의 자동 증거. 빨간데 머지하면 효용이 샌다.
+//   ★ 검사 항목: 고아 참조 0 · 영역 키 집합 정합 · implemented→근거 필수 · evidence 경로 실재.
+
+// CriticalAreaId 의 정본 집합(레지스트리가 다루는 6영역). 키 멤버십 검사의 기준.
+const AREA_IDS: CriticalAreaId[] = [
+  "auth-session",
+  "access-control",
+  "data-integrity",
+  "resilience",
+  "observability",
+  "performance",
+];
+
+const SCREEN_IDS = new Set(SCREENS.map((s) => s.id));
+const TECH_IDS = new Set(TECH_ITEMS.map((t) => t.id));
+const AREA_ID_SET = new Set<string>(AREA_IDS);
+
+// evidence/screenshot 경로 해석: docs/·design-input/ 은 프로젝트 루트, 나머지는 onday-app 루트 기준.
+const APP_ROOT = process.cwd();
+const PROJECT_ROOT = resolve(APP_ROOT, "..");
+function resolveRepoPath(p: string): string {
+  const rootRelative = p.startsWith("docs/") || p.startsWith("design-input/");
+  return join(rootRelative ? PROJECT_ROOT : APP_ROOT, p);
+}
+// "src/foo.ts:42" → "src/foo.ts" (라인 번호 분리).
+function pathPart(evidence: string): string {
+  return evidence.split(":")[0];
+}
+
+describe("Playboard 레지스트리 무결성 — 식별자 유일성", () => {
+  it("화면 id 중복 없음", () => {
+    expect(SCREEN_IDS.size).toBe(SCREENS.length);
+  });
+
+  it("기술항목 id 중복 없음", () => {
+    expect(TECH_IDS.size).toBe(TECH_ITEMS.length);
+  });
+
+  it("mission-critical 영역 id 중복 없음 + 정본 6영역과 일치", () => {
+    const ids = CRITICAL_AREAS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(ids)).toEqual(AREA_ID_SET);
+  });
+});
+
+describe("Playboard 레지스트리 무결성 — 고아 참조 금지", () => {
+  it("USER_FLOWS.screens 는 모두 실재 화면 id", () => {
+    for (const flow of USER_FLOWS) {
+      for (const screenId of flow.screens) {
+        expect(SCREEN_IDS, `flow ${flow.id} → ${screenId}`).toContain(screenId);
+      }
+    }
+  });
+
+  it("CRITICAL_AREAS.techItemIds 는 모두 실재 기술항목 id", () => {
+    for (const area of CRITICAL_AREAS) {
+      for (const techId of area.techItemIds) {
+        expect(TECH_IDS, `area ${area.id} → ${techId}`).toContain(techId);
+      }
+    }
+  });
+
+  it("CRITICAL_AREAS.exercisedOnScreens 는 모두 실재 화면 id", () => {
+    for (const area of CRITICAL_AREAS) {
+      for (const screenId of area.exercisedOnScreens) {
+        expect(SCREEN_IDS, `area ${area.id} → ${screenId}`).toContain(screenId);
+      }
+    }
+  });
+
+  it("TECH_ITEMS.area 는 모두 정의된 제어 영역", () => {
+    for (const tech of TECH_ITEMS) {
+      expect(AREA_ID_SET, `tech ${tech.id}`).toContain(tech.area);
+    }
+  });
+
+  it("SCREEN_SPECS 키는 모두 실재 화면 id", () => {
+    for (const screenId of Object.keys(SCREEN_SPECS)) {
+      expect(SCREEN_IDS, `spec ${screenId}`).toContain(screenId);
+    }
+  });
+
+  it("SCREEN_SPECS[*].nfr 는 모두 정의된 제어 영역", () => {
+    for (const [screenId, spec] of Object.entries(SCREEN_SPECS)) {
+      for (const area of spec.nfr) {
+        expect(AREA_ID_SET, `spec ${screenId} → nfr ${area}`).toContain(area);
+      }
+    }
+  });
+
+  it("CONVERGENCE.targetId 는 화면·기술항목·영역 중 실재 id", () => {
+    const known = new Set<string>([...SCREEN_IDS, ...TECH_IDS, ...AREA_ID_SET]);
+    for (const conv of CONVERGENCE) {
+      expect(known, `convergence "${conv.title}" → ${conv.targetId}`).toContain(conv.targetId);
+    }
+  });
+});
+
+describe("Playboard 레지스트리 무결성 — 영역 키 집합 정합", () => {
+  it("AREA_SPECS 키 집합 = 정본 6영역 (누락·잉여 0)", () => {
+    expect(new Set(Object.keys(AREA_SPECS))).toEqual(AREA_ID_SET);
+  });
+
+  it("모든 제어 영역은 최소 1개 화면에서 행사 (커버리지 갭 없음)", () => {
+    for (const area of CRITICAL_AREAS) {
+      expect(area.exercisedOnScreens.length, `area ${area.id}`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("Playboard 레지스트리 무결성 — implemented → 근거(evidence) 필수", () => {
+  it("status=implemented 기술항목은 evidence 보유", () => {
+    for (const tech of TECH_ITEMS) {
+      if (tech.status === "implemented") {
+        expect(tech.evidence.length, `tech ${tech.id}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("status=implemented 제어 항목(AREA_SPECS)은 evidence 보유", () => {
+    for (const [areaId, spec] of Object.entries(AREA_SPECS)) {
+      for (const control of spec.controls) {
+        if (control.status === "implemented") {
+          expect(control.evidence.length, `area ${areaId} → "${control.text}"`).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("status=implemented 화면 스펙 항목은 evidence 보유 (na/gap 제외)", () => {
+    for (const [screenId, spec] of Object.entries(SCREEN_SPECS)) {
+      const items = [...spec.requirements, ...spec.gates, ...spec.dataContracts, ...spec.exceptions];
+      for (const item of items) {
+        const status = item.status ?? "implemented"; // 기본 implemented
+        if (status === "implemented") {
+          expect(item.evidence.length, `spec ${screenId} → "${item.text}"`).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+});
+
+describe("Playboard 레지스트리 무결성 — evidence 경로 실재 (문서·코드)", () => {
+  // 모든 evidence 의 파일 경로가 실재하는지 — '거짓 근거' 방지. (skill §10 위성 문서 경로 실재)
+  function collectEvidence(): { ref: string; path: string }[] {
+    const out: { ref: string; path: string }[] = [];
+    for (const tech of TECH_ITEMS) {
+      tech.evidence.forEach((e) => out.push({ ref: `tech ${tech.id}`, path: e }));
+    }
+    for (const [areaId, spec] of Object.entries(AREA_SPECS)) {
+      spec.controls.forEach((c) => c.evidence.forEach((e) => out.push({ ref: `area ${areaId}`, path: e })));
+    }
+    for (const [screenId, spec] of Object.entries(SCREEN_SPECS)) {
+      const items = [...spec.requirements, ...spec.gates, ...spec.dataContracts, ...spec.exceptions];
+      items.forEach((i) => i.evidence.forEach((e) => out.push({ ref: `spec ${screenId}`, path: e })));
+    }
+    return out;
+  }
+
+  it("모든 evidence 파일 경로 실재", () => {
+    for (const { ref, path } of collectEvidence()) {
+      expect(existsSync(resolveRepoPath(pathPart(path))), `${ref} → ${path}`).toBe(true);
+    }
+  });
+
+  it("화면 스크린샷(있으면) 캡처 파일 실재", () => {
+    for (const screen of SCREENS) {
+      const shots = [screen.screenshot, ...(screen.altScreenshots ?? [])].filter(Boolean) as string[];
+      for (const shot of shots) {
+        expect(existsSync(resolveRepoPath(shot)), `screen ${screen.id} → ${shot}`).toBe(true);
+      }
+    }
+  });
+});
+
+describe("Playboard 파생 — 커버리지 매트릭스 정합", () => {
+  it("buildCoverageMatrix 셀 수 = 영역 × 화면", () => {
+    const cells = buildCoverageMatrix();
+    expect(cells.length).toBe(CRITICAL_AREAS.length * SCREENS.length);
+  });
+
+  it("매트릭스의 exercised 셀은 CRITICAL_AREAS.exercisedOnScreens 와 일치 (이중 정의 없음)", () => {
+    const cells = buildCoverageMatrix();
+    for (const cell of cells) {
+      const area = CRITICAL_AREAS.find((a) => a.id === cell.area)!;
+      expect(cell.exercised).toBe(area.exercisedOnScreens.includes(cell.screen));
+    }
+  });
+});


### PR DESCRIPTION
## 배경
`github.com/wild-mental/playboard-skill` 기준 내 Playboard 점검 결과, **P0 2건**(저비용·발표 신뢰도) 보충. P1·P2(WorkItem DAG·plan/schedule·5 위젯 등)는 발표 후.

★ **additive — 레지스트리(`registry.ts`)·기존 코드/문서 무변경.** 검사 로직 + 문서만 추가.

## P0-1 — 무결성 불변식 테스트
`onday-app/src/lib/playboard/registry.test.ts` (vitest, **19개 전부 green**)

playboard-skill §10 불변식을 현재 레지스트리에 매핑:
- **고아 참조 0** — `USER_FLOWS.screens` / `CRITICAL_AREAS.techItemIds`·`exercisedOnScreens` / `TECH_ITEMS.area` / `SCREEN_SPECS` 키·`nfr` / `CONVERGENCE.targetId` 전부 실재 식별자
- **영역 키 집합 정합** — `AREA_SPECS` 키 = 정본 6영역, 모든 영역 ≥1 화면 행사(커버리지 갭 없음)
- **implemented → evidence 필수** (na/gap 제외)
- **evidence 경로 실재** — 43개 file:line + 스크린샷 PNG 디스크 존재(거짓 근거 차단)
- **커버리지 매트릭스 이중 정의 금지**

> DAG 비순환·exceptionStates 불변식은 의도적 제외 — 해당 레지스트리(WorkItem DAG·system-state plane)가 아직 없음(P1). 현재 모델에 있는 것만 정직하게 검사.

## P0-2 — 거버넌스 절 보강
`onday-app/CLAUDE.md` — 기존 "Playboard 운영 SoT" 절 **보존**, 빠진 4개만 **+15줄 추가**:
1. **제1원칙** — 표시되는 모든 것은 레지스트리에서 파생, 두 곳을 손으로 안 맞춤
2. **양방향 싱크** — 위성 기준 문서(SRS/PRD/DB_SPEC) ↔ registry 같은 PR 갱신
3. **갭 승격 규칙** — 해소 시 `implemented` 승격 + `CONVERGENCE`에서 제거
4. **무결성 테스트 green 게이트** — `registry.test.ts` 빨간 채로 머지 금지

## 검증
- `npx vitest run src/lib/playboard/registry.test.ts` → **19/19 passed**
- `tsc --noEmit` → exit 0
- `eslint` (신규 파일) → exit 0
- 한글 인코딩 손상 검사 → clean
- 기존(insights·flow·screen·진단·측정) 무변경 (CLAUDE.md +15줄 삽입만, 코드 0줄 변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)