### PR TITLE
fix: 게스트 주소 잔류 + 게스트 새로고침 경로선 복원 (실사용 버그 2건)

### DIFF
--- a/onday-app/prisma/migrations/20260630000000_add_diagnosis_coordinates/migration.sql
+++ b/onday-app/prisma/migrations/20260630000000_add_diagnosis_coordinates/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: 입력 직장 좌표(JSON {lat,lng}) 보존 — 새로고침 시 경로선 서버 복원용.
+--   nullable + DEFAULT 없음 → 기존 row 는 NULL(기존 동작 유지), additive 안전 마이그레이션.
+ALTER TABLE "diagnoses" ADD COLUMN "coordinate_a" TEXT;
+ALTER TABLE "diagnoses" ADD COLUMN "coordinate_b" TEXT;

--- a/onday-app/prisma/schema.prisma
+++ b/onday-app/prisma/schema.prisma
@@ -26,6 +26,10 @@ model Diagnosis {
   userId       String   @map("user_id")
   addressA     String   @map("address_a")
   addressB     String?  @map("address_b") // nullable for single mode
+  // 입력 직장 좌표(JSON {lat,lng}). 새로고침 시 경로선 복원용 — 게스트/심사관은 localStorage 미저장이라
+  //   서버 GET 만이 복원 경로(프라이버시 유지). nullable — 본 컬럼 이전 진단 row 는 null(기존 동작 유지).
+  coordinateA  String?  @map("coordinate_a")
+  coordinateB  String?  @map("coordinate_b")
   filters      String   @default("{}") // JSON string — app-layer parse, JSONB는 차후 ISSUE
   candidates   String   @default("[]") // JSON string array of CandidateArea — app-layer parse, JSONB는 차후 ISSUE
   mode         String   @default("couple") // couple | single

--- a/onday-app/src/app/api/diagnosis/[id]/route.ts
+++ b/onday-app/src/app/api/diagnosis/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import type { CandidateArea, DiagnosisFilters } from "@/lib/types";
+import type { CandidateArea, Coordinate, DiagnosisFilters } from "@/lib/types";
 import { getServerUser } from "@/lib/auth/session";
 import { logError, type LogUserType } from "@/lib/logging/log-error";
 
@@ -20,12 +20,22 @@ export async function GET(
 
     const candidates: CandidateArea[] = JSON.parse(diagnosis.candidates);
     const filters: DiagnosisFilters = JSON.parse(diagnosis.filters);
+    // 입력 직장 좌표 — 새로고침 시 경로선 복원용(게스트/심사관은 localStorage 미저장이라 서버만이 복원 경로).
+    //   본 컬럼 이전 진단 row 는 null → 클라가 복원 skip(기존 동작 유지).
+    const coordinateA = diagnosis.coordinateA
+      ? (JSON.parse(diagnosis.coordinateA) as Coordinate)
+      : null;
+    const coordinateB = diagnosis.coordinateB
+      ? (JSON.parse(diagnosis.coordinateB) as Coordinate)
+      : null;
 
     return NextResponse.json({
       id: diagnosis.id,
       userId: diagnosis.userId,
       addressA: diagnosis.addressA,
       addressB: diagnosis.addressB,
+      coordinateA,
+      coordinateB,
       candidates,
       filters,
       mode: diagnosis.mode,

--- a/onday-app/src/app/api/diagnosis/route.ts
+++ b/onday-app/src/app/api/diagnosis/route.ts
@@ -41,6 +41,9 @@ export async function POST(request: Request) {
           userId,
           addressA: input.addressA,
           addressB: input.addressB ?? null,
+          // 입력 직장 좌표 보존 — 새로고침 시 경로선 서버 복원(게스트 localStorage 미저장).
+          coordinateA: JSON.stringify(input.coordinateA),
+          coordinateB: input.coordinateB ? JSON.stringify(input.coordinateB) : null,
           filters: JSON.stringify(input.filters),
           candidates: JSON.stringify(candidates),
           mode: input.mode,
@@ -75,6 +78,9 @@ export async function POST(request: Request) {
         userId,
         addressA: input.addressA,
         addressB: input.addressB ?? null,
+        // 입력 직장 좌표 보존 — 새로고침 시 경로선 서버 복원(게스트 localStorage 미저장).
+        coordinateA: JSON.stringify(input.coordinateA),
+        coordinateB: input.coordinateB ? JSON.stringify(input.coordinateB) : null,
         filters: JSON.stringify(input.filters),
         candidates: JSON.stringify(candidates),
         mode: input.mode,

--- a/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
+++ b/onday-app/src/app/diagnosis/result/[id]/result-view.tsx
@@ -43,6 +43,9 @@ export function ResultView({ id }: ResultViewProps) {
   const setResult = useDiagnosisStore((s) => s.setResult);
   // Issue #108 ㊙ — 시나리오 B (페이지 reload / 직접 URL 접속) filters store 박힘 (★ "사용자 입력 → 결과" 자연 흐름 양방향 정합).
   const setFilters = useDiagnosisStore((s) => s.setFilters);
+  // 새로고침 시 입력 좌표 서버 복원용 — 경로선 재생성(게스트/심사관 localStorage 미저장 유지).
+  const setAddressA = useDiagnosisStore((s) => s.setAddressA);
+  const setAddressB = useDiagnosisStore((s) => s.setAddressB);
   // Issue #125 — EmptyState SuggestionButton 클릭 시 runMockDiagnosis 재계산 (★ what-if 답습 #5).
   const coordinateA = useDiagnosisStore((s) => s.coordinateA);
   const coordinateB = useDiagnosisStore((s) => s.coordinateB);
@@ -61,8 +64,14 @@ export function ResultView({ id }: ResultViewProps) {
     if (!inSync && query.data) {
       setResult(query.data.id, query.data.candidates);
       setFilters(liftLegacyDealType(query.data.filters));
+      // 게스트/심사관 새로고침 — 입력 좌표를 서버에서 복원해 경로선 재생성. 좌표 없는 이전 진단은
+      //   skip(기존 동작). 비로그인은 persist 게이팅으로 localStorage 미기록(프라이버시 유지).
+      if (query.data.coordinateA)
+        setAddressA(query.data.addressA, query.data.coordinateA);
+      if (query.data.coordinateB)
+        setAddressB(query.data.addressB ?? "", query.data.coordinateB);
     }
-  }, [inSync, query.data, setResult, setFilters]);
+  }, [inSync, query.data, setResult, setFilters, setAddressA, setAddressB]);
 
   // MON-003 v1.4 부활 (Issue #127) — REQ-NF-008 funnel 완료점.
   //   ref 가드 = React Strict Mode 2회 실행 + 같은 id 재마운트 중복 방지.

--- a/onday-app/src/app/single/[id]/single-result-view.tsx
+++ b/onday-app/src/app/single/[id]/single-result-view.tsx
@@ -232,6 +232,8 @@ export function SingleResultView({ id }: SingleResultViewProps) {
   const storeAddressA = useDiagnosisStore((s) => s.addressA);
   const setResult = useDiagnosisStore((s) => s.setResult);
   const setFilters = useDiagnosisStore((s) => s.setFilters);
+  // 새로고침 시 입력 직장 좌표 서버 복원용 — 경로선 재생성(게스트/심사관 localStorage 미저장 유지).
+  const setAddressA = useDiagnosisStore((s) => s.setAddressA);
   // 지도 마커용 좌표 — 부부 모드와 동일하게 store 직접 참조(같은 세션에서만 표시).
   const coordinateA = useDiagnosisStore((s) => s.coordinateA);
   const leisureCoordA = useDiagnosisStore((s) => s.leisureCoordA);
@@ -256,8 +258,12 @@ export function SingleResultView({ id }: SingleResultViewProps) {
       setResult(query.data.id, query.data.candidates);
       // 재오픈 시 거래유형 복원(레거시 budget.dealType 승격 포함) — 시세 표시 dealType 보존.
       setFilters(liftLegacyDealType(query.data.filters));
+      // 게스트/심사관 새로고침 — 입력 직장 좌표를 서버에서 복원해 경로선 재생성. 좌표 없는 이전
+      //   진단은 skip(기존 동작). 비로그인은 persist 게이팅으로 localStorage 미기록(프라이버시 유지).
+      if (query.data.coordinateA)
+        setAddressA(query.data.addressA, query.data.coordinateA);
     }
-  }, [inSync, query.data, setResult, setFilters]);
+  }, [inSync, query.data, setResult, setFilters, setAddressA]);
 
   const candidates = React.useMemo<CandidateArea[]>(
     () => (inSync ? storeCandidates : query.data?.candidates ?? []),

--- a/onday-app/src/lib/types.ts
+++ b/onday-app/src/lib/types.ts
@@ -117,6 +117,9 @@ export interface DiagnosisResult {
   userId: string;
   addressA: string;
   addressB?: string;
+  // 입력 직장 좌표 — 새로고침 시 경로선 복원용. 본 필드 이전 진단은 null(복원 skip → 기존 동작).
+  coordinateA?: Coordinate | null;
+  coordinateB?: Coordinate | null;
   candidates: CandidateArea[];
   filters: DiagnosisFilters;
   mode: DiagnosisMode;


### PR DESCRIPTION
실사용 버그 2건 수정. **additive·기존 무변경·단계별 2커밋.** 자동 머지/Close 금지 — 리뷰용 Draft.

## 버그 2 — 게스트 전환 시 주소 잔류 (프라이버시, 먼저)
**증상:** 카카오 로그인 중 입력한 주소가 게스트/심사관 진입·로그아웃 후 입력폼에 잔류.

**원인:** `clearGuestPersisted()` 가 localStorage + 인메모리 찜만 비우고 **인메모리 진단 store(addressA/coordinateA 등)는 안 비움**. `router.push`(풀 리로드 아님)에서 zustand 상태가 살아남아 이전 사용자 주소 노출.

**수정:** `clearGuestPersisted` 에 `useDiagnosisStore.getState().reset()` 한 줄 추가(찜 `clear()` 옆). 세 호출처(게스트·심사관 진입·로그아웃) 모두 fresh 세션이라 안전. `reset()` 은 기존에 호출처 0인 액션 → 정상 흐름 영향 없음.

## 버그 1 — 게스트 새로고침 시 경로선 안 그려짐
**증상:** 게스트/심사관이 결과(/single·/diagnosis/result)를 새로고침하면 경로선(polyline) 사라짐.

**원인:** 경로선은 store `coordinateA/B` 에만 의존. `0e20531`(6/13) 프라이버시 게이팅으로 비로그인은 좌표를 localStorage 에 안 남김 → 새로고침 시 인메모리 유실 → `coordinateA=null` → `buildLine` 빈 배열 → 선 영구 누락. 서버 GET 응답엔 좌표가 없어 복원 경로도 없었음.
> ⚠️ 진단 시 "부부 정상·싱글 깨짐"은 **코드상 비대칭이 없음**(두 모드 동일하게 coordinateA 의존). 재현 조건(부부=로그인/싱글=게스트) 차이로 보이며, 본 수정은 **두 모드 모두** 게스트 새로고침 복원.

**수정 (프라이버시 유지 — 게스트 좌표 localStorage 미저장, 서버 복원만):**
- `Diagnosis` 에 `coordinate_a/b` 컬럼(JSON, nullable) 추가 — additive 마이그레이션. **이전 진단 row 는 null → 기존 동작 유지.**
- POST 생성 시 입력 좌표 저장(mock·production 양 경로), GET 응답에 `coordinateA/B` 반환.
- `result-view`·`single-result-view` 의 서버 복원 effect 에서 `setAddress*` 로 **인메모리만** 복원. 비로그인은 persist 게이팅으로 localStorage 미기록.

## 검증
- ✅ **버그2** — 게스트·심사관 진입 시 인메모리 진단 store reset → 주소 잔류 0
- ✅ **버그1** — 게스트 새로고침 후 서버 GET 으로 좌표 복원 → 경로선 재생성 (부부·싱글)
- ✅ **프라이버시** — 비로그인 persist `setItem` 게이팅(`diagnosis-store.ts:152`) 유지 → 게스트 좌표 localStorage 미기록
- ✅ **기존 무변경** — 로그인 사용자 persist·정상 진단·측정 무변경, 좌표 없는 이전 진단은 복원 skip, 좌표 null 가드로 크래시 0
- ✅ `tsc --noEmit` 0 에러 · `eslint` 0 · 한글 인코딩 손상 0

## ⚠️ 배포 시 주의
- DB 마이그레이션 1건(`20260630000000_add_diagnosis_coordinates`) 포함 — 배포 시 `migrate deploy` 로 `coordinate_a/b` nullable 컬럼 추가. additive 라 다운타임/기존 데이터 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)