### PR TITLE
fix(guest): 게스트/심사관 전환 시 주소 잔류 수정 (프라이버시, DB 변경 없음)

### DIFF
--- a/onday-app/src/lib/auth/clear-guest-persisted.ts
+++ b/onday-app/src/lib/auth/clear-guest-persisted.ts
@@ -1,4 +1,8 @@
-import { DIAGNOSIS_PERSIST_KEY, LAST_CONFIG_KEY } from "@/stores/diagnosis-store";
+import {
+  DIAGNOSIS_PERSIST_KEY,
+  LAST_CONFIG_KEY,
+  useDiagnosisStore,
+} from "@/stores/diagnosis-store";
 import { FAVORITES_PERSIST_KEY, useFavoritesStore } from "@/stores/favorites";
 
 // 게스트/심사관 진입·로그아웃 시 — 로그인 사용자만 남기는 localStorage 흔적을 전부 제거.
@@ -12,4 +16,8 @@ export function clearGuestPersisted(): void {
   // ★ in-memory 찜도 비움 — 이전 로그인 사용자의 찜이 reload 전까지 화면에 남는 것 방지.
   //   clear() 의 persist 쓰기는 비로그인이라 storage 게이팅에서 skip → localStorage 잔존 0.
   useFavoritesStore.getState().clear();
+  // ★ in-memory 진단 입력(주소·좌표 등)도 비움 — 카카오 로그인 중 입력한 주소가
+  //   게스트/심사관 진입·로그아웃 후 client 내비게이션(풀 리로드 아님)에서 잔존하는 것 방지.
+  //   reset() 의 persist 쓰기도 비로그인이라 게이팅에서 skip → localStorage 잔존 0(프라이버시 유지).
+  useDiagnosisStore.getState().reset();
 }


### PR DESCRIPTION
#277 에서 **버그2(게스트 주소 잔류)만 분리**한 PR. DB 마이그레이션이 없어 **바로 머지 안전**.
버그1(좌표 복원·마이그레이션)은 #277 에 그대로 두고 나중에 처리.

자동 머지/Close 금지 — 리뷰용 Draft. 머지는 작성자가.

## 버그 2 — 게스트 전환 시 주소 잔류 (프라이버시)
**증상:** 카카오 로그인 중 입력한 주소가 게스트/심사관 진입·로그아웃 후 입력폼에 잔류.

**원인:** `clearGuestPersisted()` 가 localStorage + 인메모리 찜만 비우고 **인메모리 진단 store(addressA/coordinateA 등)는 안 비움**. `router.push`(풀 리로드 아님)에서 zustand 상태가 살아남아 이전 사용자 주소 노출.

**수정:** `clear-guest-persisted.ts` 에 `useDiagnosisStore.getState().reset()` 한 줄 추가(찜 `clear()` 옆). 세 호출처(게스트·심사관 진입·로그아웃) 모두 fresh 세션이라 안전. `reset()` 은 기존 호출처 0인 액션 → 정상 진단 흐름 영향 없음. 비로그인은 persist 게이팅으로 localStorage 미기록(프라이버시 유지).

## 검증
- ✅ 게스트·심사관 진입 시 인메모리 진단 store reset → 주소 잔류 0
- ✅ **DB 마이그레이션 없음** — 파일 1개(`clear-guest-persisted.ts`)만 변경, 스키마 무변경 → 바로 머지 안전
- ✅ 기존 무변경 — 정상 진단 흐름 영향 0 (reset 은 dead→첫 사용)
- ✅ `tsc --noEmit` 0 · `eslint` 0

## 분리 맥락
- 본 PR = 버그2만 (DB 변경 없음 → 즉시 머지 가능)
- #277 = 버그1(좌표 서버 복원 + nullable 컬럼 마이그레이션) — 마이그레이션 선적용 필요로 별도 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)