### PR TITLE
fix(landing): 추정·목표 문구 정직성 라벨 보강 (①③④)

### DIFF
--- a/onday-app/src/app/landing/landing-client.tsx
+++ b/onday-app/src/app/landing/landing-client.tsx
@@ -341,12 +341,12 @@ function BeforeAfterSection() {
           <motion.div variants={baItem} className="flex items-center justify-center gap-s-4 rounded-2xl bg-primary-soft/60 p-s-5">
             <div className="text-center">
               <p className="text-display-2 font-extrabold text-primary tabular">12~18배</p>
-              <p className="text-caption text-ink-3">시간 단축</p>
+              <p className="text-caption text-ink-3">시간 단축 (목표)</p>
             </div>
             <div aria-hidden className="h-10 w-px bg-line" />
             <p className="text-body-sm md:text-base leading-relaxed text-ink-2">
               수작업 비교 <strong className="text-ink">2~3시간</strong> →{" "}
-              <strong className="text-primary">10분 탐색 완료</strong>
+              <strong className="text-primary">10분 탐색 완료 (목표)</strong>
               <br />진단 응답은 단 몇 초
             </p>
           </motion.div>
@@ -500,7 +500,7 @@ function MarketSection() {
         </div>
         <div className="grid grid-cols-2 gap-s-3">
           {[
-            { end: 4.2, prefix: "", suffix: "개월", duration: 0, label: "평균 동네 탐색 기간", sub: "인터뷰 14건 실측" },
+            { end: 4.2, prefix: "", suffix: "개월", duration: 0, label: "평균 동네 탐색 기간", sub: "인터뷰 14건 기반" },
             { end: 470, prefix: "$", suffix: "억", duration: 2, label: "글로벌 프롭테크", sub: "CAGR 16%" },
             { end: 0, prefix: "", suffix: "개", duration: 0, label: "두 동선 동시 계산 도구", sub: "블루오션" },
             { end: 10, prefix: "", suffix: "분", duration: 1.5, label: "탐색 완료 목표", sub: "기존 2~3시간" },
@@ -659,7 +659,7 @@ function PricingSection() {
         >
           <div className="space-y-s-2 text-center">
             <span className="inline-block rounded-chip bg-primary/10 px-s-3 py-1 text-caption-xs font-bold text-primary">
-              비용 ROI
+              대안 비용 참고
             </span>
             <h3 className="text-title font-bold text-ink">
               1주 살아보기 vs 10분 진단
@@ -673,18 +673,21 @@ function PricingSection() {
               </p>
             </div>
             <div className="rounded-xl bg-bg p-s-4 text-center">
-              <p className="text-caption-xs text-primary">온데이 1회</p>
+              <p className="text-caption-xs text-primary">온데이 1회 (예상)</p>
               <p className="mt-s-1 text-h3 font-extrabold text-primary tabular">
                 3~5<span className="ml-0.5 text-body-sm font-bold text-ink-3">만원</span>
               </p>
             </div>
           </div>
           <p className="text-center text-body-sm font-bold text-primary">
-            93~96% 절감
+            예상 절감 93~96%
           </p>
           <div className="space-y-s-2 text-center text-caption-xs text-ink-2 leading-relaxed">
             <p>
-              ※ 비용 출처: 단기체류 플랫폼 1주 요금 기준
+              ※ 비용 출처: 단기체류 플랫폼 1주 요금 기준 — 성격이 다른 대안, 비용 참고용 비교
+            </p>
+            <p>
+              ※ 온데이 가격은 베타 WTP 설문으로 확정 예정 — 위 3~5만원·절감률은 WTP 가정 기준 예상치
             </p>
             <p>
               목표: 임장 12회→3회 (75%↓) · 부부 합의 4.2개월→2주


### PR DESCRIPTION
랜딩 정직성 점검 결과 중 **①③④만** 근거 범위 내 수정. ②(임장/합의 목표 라벨)는 이미 정직 → 무변경. 다른 정직 영역(가격 미정·인터뷰 시점·게스트 삭제·출처 배지) 무변경.

자동 머지 금지 — Draft. 머지는 작성자가.

## 변경 (landing-client.tsx, 단일 파일)
| 위치 | 현재 | 변경 | 근거 |
|---|---|---|---|
| ① MARKET INSIGHT (:503) | `인터뷰 14건 실측` | `인터뷰 14건 기반` | 포폴은 "실측"을 7일 베타 텔레메트리에만 사용, 인터뷰값은 "기반". Hero 뱃지(`자체 인터뷰 14건`)와 통일 |
| ③ BEFORE&AFTER (:343–350) | `12~18배 시간 단축` / `10분 탐색 완료` | `시간 단축 (목표)` / `10분 탐색 완료 (목표)` | PRD `≤10분`=목표(출시후 측정), 포폴 KPI=TO-BE. 같은 랜딩 :506 `탐색 완료 목표`와 통일. **"진단 응답 단 몇 초"(6초, 실제 동작)는 유지** |
| ④ 비용 ROI (:665–691) | `비용 ROI` / `온데이 1회` / `93~96% 절감` | `대안 비용 참고` / `온데이 1회 (예상)` / `예상 절감 93~96%` + 주석 2줄 | 3~5만원=미검증 WTP 가정(PRD A3/ASM-03), 같은 페이지 가격카드 `미정`과 정합. 비교는 톤다운(삭제 안 함) |

④ 추가 주석:
- `※ 비용 출처: 단기체류 플랫폼 1주 요금 기준 — 성격이 다른 대안, 비용 참고용 비교`
- `※ 온데이 가격은 베타 WTP 설문으로 확정 예정 — 위 3~5만원·절감률은 WTP 가정 기준 예상치`

## 무변경 (의도)
- ② `목표: 임장 12회→3회(75%↓)·합의 4.2개월→2주` — 이미 "목표:" 라벨, 정직
- ⑥ Hero `주말 6시간` — 감성 카피로 유지 (참고: PRD·인터뷰 근거 없음, 원본 pain은 `2~3시간/회`)
- 가격카드 `가격 미정·WTP 설문` / Persona `2026.03 출시 전 조사` / 게스트 데이터 자동 삭제 / 데이터 출처 배지 / AOS·시장규모(근거 있음)

## 검증
- `tsc --noEmit` 0 에러 · eslint 0 에러(기존 미사용 import 경고 5건만, 본 수정 무관) · 한글 인코딩 손상 0
- DB·로직 변경 없음, 카피만 (단일 파일 10+/7-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)