### PR TITLE
fix(security): public 스키마 11개 테이블 RLS deny-all (Supabase rls_disabled_in_public 대응)

### DIFF
--- a/onday-app/prisma/migrations/20260726000000_enable_rls_deny_all/migration.sql
+++ b/onday-app/prisma/migrations/20260726000000_enable_rls_deny_all/migration.sql
@@ -1,0 +1,60 @@
+-- Supabase "rls_disabled_in_public" 보안 경고 대응 — public 스키마 11개 테이블 전부
+-- deny-all 로 잠근다. PostgREST 자동 API(rest/v1/*) + 공개 anon key 로 외부인이 전 행을
+-- 읽을 수 있는 노출 경로를 차단한다.
+--
+-- ★ 정책(CREATE POLICY) 없음 = 의도적 deny-all. 앱은 Prisma 직결(DATABASE_URL = postgres 롤,
+--   테이블 owner + BYPASSRLS)로만 데이터를 읽/쓰므로 RLS 를 우회한다 → 진단·측정 등 기존 기능
+--   회귀 0. anon/authenticated(PostgREST)만 0행이 된다.
+-- ★ 벨트+멜빵: RLS 활성화에 더해 anon/authenticated 의 테이블 권한도 REVOKE(권한 자체 회수).
+--
+-- 참고: RLS 활성화는 롤 존재와 무관하므로 무조건 실행. REVOKE 만 롤 존재를 가드한다
+--   (로컬 검토·shadow DB 등 anon/authenticated 롤이 없는 환경에서도 안전하게).
+
+-- ── 1) RLS 활성화 (11개 전부) ──────────────────────────────────────────────
+ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."diagnoses" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."share_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."saved_searches" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."error_logs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."event_logs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."preview_event_logs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."metric_rollups" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."preview_metric_rollups" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."metric_aggregates" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."preview_metric_aggregates" ENABLE ROW LEVEL SECURITY;
+
+-- ── 2) anon 롤 권한 회수 (롤 존재 시에만) ──────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    REVOKE ALL ON "public"."users" FROM anon;
+    REVOKE ALL ON "public"."diagnoses" FROM anon;
+    REVOKE ALL ON "public"."share_links" FROM anon;
+    REVOKE ALL ON "public"."saved_searches" FROM anon;
+    REVOKE ALL ON "public"."error_logs" FROM anon;
+    REVOKE ALL ON "public"."event_logs" FROM anon;
+    REVOKE ALL ON "public"."preview_event_logs" FROM anon;
+    REVOKE ALL ON "public"."metric_rollups" FROM anon;
+    REVOKE ALL ON "public"."preview_metric_rollups" FROM anon;
+    REVOKE ALL ON "public"."metric_aggregates" FROM anon;
+    REVOKE ALL ON "public"."preview_metric_aggregates" FROM anon;
+  END IF;
+END $$;
+
+-- ── 3) authenticated 롤 권한 회수 (롤 존재 시에만) ─────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    REVOKE ALL ON "public"."users" FROM authenticated;
+    REVOKE ALL ON "public"."diagnoses" FROM authenticated;
+    REVOKE ALL ON "public"."share_links" FROM authenticated;
+    REVOKE ALL ON "public"."saved_searches" FROM authenticated;
+    REVOKE ALL ON "public"."error_logs" FROM authenticated;
+    REVOKE ALL ON "public"."event_logs" FROM authenticated;
+    REVOKE ALL ON "public"."preview_event_logs" FROM authenticated;
+    REVOKE ALL ON "public"."metric_rollups" FROM authenticated;
+    REVOKE ALL ON "public"."preview_metric_rollups" FROM authenticated;
+    REVOKE ALL ON "public"."metric_aggregates" FROM authenticated;
+    REVOKE ALL ON "public"."preview_metric_aggregates" FROM authenticated;
+  END IF;
+END $$;


### PR DESCRIPTION
## 배경
Supabase **"Table publicly accessible (rls_disabled_in_public)"** 보안 경고 대응.
public 스키마 11개 테이블이 RLS off 상태 → PostgREST 자동 API(`rest/v1/*`) + 공개 anon key로
외부인이 `diagnoses`(주소·좌표)·`users`(이메일) 등 전 행을 읽을 수 있던 노출 경로가 있었음.

## 변경
마이그레이션 `20260726000000_enable_rls_deny_all` 1개 (SQL only):
- **11개 테이블 전부 `ENABLE ROW LEVEL SECURITY`** (users·diagnoses·share_links·saved_searches·error_logs·event_logs·preview_event_logs·metric_rollups·preview_metric_rollups·metric_aggregates·preview_metric_aggregates)
- **`REVOKE ALL ... FROM anon, authenticated`** (벨트+멜빵) — `pg_roles` 존재 가드로 감쌈(롤 없는 환경 안전)
- **정책(CREATE POLICY) 0건 = 의도적 deny-all.** 앱은 Prisma 직결(`postgres` 롤, owner + BYPASSRLS)로만 접근 → RLS 우회 → 기존 기능 회귀 0

## 검증 (프로덕션 DB 적용 후 확인 완료)
- ✅ postgres 롤 read 정상 — `diagnoses` 411 / `event_logs` 612 / `users` 2 / `share_links` 13 (회귀 0)
- ✅ 11개 전부 `rls=true` / `policies=0` / `anon·authenticated SELECT 불가`
- ✅ 외부 anon key REST 조회 → **HTTP 401 permission denied** (실 노출 차단 확인)
- ✅ `tsc --noEmit` clean (SQL 변경이라 TS 영향 없음)

> ⚠️ 본 마이그레이션은 이미 프로덕션 DB(동일 Supabase 인스턴스)에 `migrate deploy`로 **적용된 상태**. 본 PR은 마이그레이션 이력을 코드베이스에 반영하는 것.

## 범위 밖 (별개 후속)
- `GET /api/diagnosis/[id]` 소유자 검증 부재 — 앱 계층 이슈로 RLS(외부 경로)와 **계층이 다름**(우리 라우트는 postgres 롤이라 RLS로 안 막힘). 별도 초안 문서 존재, 본 PR 미포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)